### PR TITLE
Fix: Correct Static Web App deployment path for Docker container

### DIFF
--- a/.ado/templates/deploy-swa.yml
+++ b/.ado/templates/deploy-swa.yml
@@ -115,9 +115,10 @@ steps:
     displayName: "Deploy to Static Web App"
     inputs:
       azure_static_web_apps_api_token: $(DEPLOYMENT_TOKEN)
-      app_location: "$(Pipeline.Workspace)/drop/swa"
+      app_location: "swa"
       output_location: ""
       skip_app_build: true
+      working_directory: "$(Pipeline.Workspace)/drop"
 
   # Wait for deployment propagation
   - script: |

--- a/apim/specs/pcpc-api.openapi.yaml
+++ b/apim/specs/pcpc-api.openapi.yaml
@@ -1,0 +1,105 @@
+openapi: 3.0.1
+info:
+  title: Pokedata API
+  description: ''
+  version: '1.0'
+servers:
+  - url: https://maber-apim-test.azure-api.net/pokedata-api
+paths:
+  /sets:
+    get:
+      summary: Get Set List
+      description: Returns a list of all Pokémon card sets
+      operationId: get-set-list
+      parameters:
+        - name: forceRefresh
+          in: query
+          schema:
+            enum:
+              - true
+            type: boolean
+            default: true
+        - name: groupByExpansion
+          in: query
+          schema:
+            enum:
+              - true
+            type: boolean
+            default: true
+        - name: all
+          in: query
+          schema:
+            enum:
+              - true
+            type: boolean
+            default: true
+      responses:
+        '200':
+          description: ''
+  '/sets/{setCode}/cards':
+    get:
+      summary: Get Cards By Set
+      description: Returns cards for a specific set
+      operationId: get-cards-by-set
+      parameters:
+        - name: setCode
+          in: path
+          required: true
+          schema:
+            type: String
+        - name: forceRefresh
+          in: query
+          schema:
+            type: boolean
+        - name: page
+          in: query
+          schema:
+            type: integer
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ''
+  '/sets/{setId}/cards/{cardId}':
+    get:
+      summary: Get Card Info
+      description: "Returns detailed information for a specific card\n"
+      operationId: get-card-info
+      parameters:
+        - name: setId
+          in: path
+          required: true
+          schema:
+            type: ''
+        - name: cardId
+          in: path
+          required: true
+          schema:
+            type: ''
+        - name: forceRefresh
+          in: query
+          schema:
+            type: boolean
+        - name: setId
+          in: query
+          required: true
+          schema:
+            type: ''
+      responses:
+        '200':
+          description: ''
+components:
+  securitySchemes:
+    apiKeyHeader:
+      type: apiKey
+      name: Ocp-Apim-Subscription-Key
+      in: header
+    apiKeyQuery:
+      type: apiKey
+      name: subscription-key
+      in: query
+security:
+  - apiKeyHeader: [ ]
+  - apiKeyQuery: [ ]

--- a/app/backend/src/functions/HealthCheck/index.ts
+++ b/app/backend/src/functions/HealthCheck/index.ts
@@ -1,5 +1,4 @@
 import {
-  app,
   HttpRequest,
   HttpResponseInit,
   InvocationContext,
@@ -322,11 +321,3 @@ function determineOverallStatus(
   // All components are healthy
   return "healthy";
 }
-
-// Register the function with Azure Functions runtime
-app.http("healthCheck", {
-  methods: ["GET"],
-  authLevel: "anonymous",
-  route: "health",
-  handler: healthCheck,
-});

--- a/app/backend/src/index.ts
+++ b/app/backend/src/index.ts
@@ -95,6 +95,7 @@ console.log("✅ [STARTUP] All services initialized successfully!");
 import { getCardInfo } from "./functions/GetCardInfo";
 import { getCardsBySet } from "./functions/GetCardsBySet";
 import { getSetList } from "./functions/GetSetList";
+import { healthCheck } from "./functions/HealthCheck";
 import { monitorCredits } from "./functions/MonitorCredits";
 import { refreshData } from "./functions/RefreshData";
 
@@ -118,6 +119,13 @@ app.http("getCardsBySet", {
   authLevel: "function",
   route: "sets/{setId}/cards",
   handler: getCardsBySet,
+});
+
+app.http("healthCheck", {
+  methods: ["GET"],
+  authLevel: "anonymous",
+  route: "health",
+  handler: healthCheck,
 });
 
 // Register timer-triggered functions


### PR DESCRIPTION
The deployment was failing because the Azure Static Web Apps task runs inside a Docker container and was looking for an absolute path that doesn't exist inside the container:

- Error: `App Directory Location: '/home/vsts/work/1/drop/swa' is invalid`

Solution Applied ✅

Updated `.ado/templates/deploy-swa.yml`:

- Changed `app_location` from `"$(Pipeline.Workspace)/drop/swa"` to `"swa"` (relative path)
- Added `working_directory: "$(Pipeline.Workspace)/drop"` to specify the base directory
