### PR TITLE
Add debug outputs for Function App settings troubleshooting

### DIFF
--- a/infra/envs/dev/outputs.tf
+++ b/infra/envs/dev/outputs.tf
@@ -193,6 +193,35 @@ output "project_name" {
   value       = var.project_name
 }
 
+# Debug Output - App Settings Keys
+output "debug_function_app_settings_keys" {
+  description = "DEBUG: List of app setting keys being passed to Function App (for troubleshooting)"
+  value       = keys(merge(
+    var.function_app_secrets,
+    var.function_app_config,
+    {
+      "COSMOS_DB_CONNECTION_STRING"           = "(set)"
+      "COSMOS_DB_ENDPOINT"                    = "(set)"
+      "COSMOS_DB_KEY"                         = "(set)"
+      "WEBSITE_NODE_DEFAULT_VERSION"          = "(set)"
+      "FUNCTIONS_WORKER_RUNTIME"              = "(set)"
+      "FUNCTIONS_EXTENSION_VERSION"           = "(set)"
+      "APPINSIGHTS_INSTRUMENTATIONKEY"        = "(set)"
+      "APPLICATIONINSIGHTS_CONNECTION_STRING" = "(set)"
+    }
+  ))
+}
+
+output "debug_secrets_keys_received" {
+  description = "DEBUG: Keys from function_app_secrets variable (should have 4 keys with hyphens)"
+  value       = keys(var.function_app_secrets)
+}
+
+output "debug_config_keys_received" {
+  description = "DEBUG: Keys from function_app_config variable"
+  value       = keys(var.function_app_config)
+}
+
 # Deployment Summary
 output "deployment_summary" {
   description = "Summary of deployed resources"


### PR DESCRIPTION
Add Terraform outputs to diagnose app_settings flow from secrets to Function App.

DEBUG OUTPUTS ADDED:
1. debug_function_app_settings_keys - Shows all keys being merged into app_settings
2. debug_secrets_keys_received - Shows keys from function_app_secrets variable (should be 4 with hyphens)
3. debug_config_keys_received - Shows keys from function_app_config variable

EXPECTED OUTPUT:
- debug_secrets_keys_received should show: ["POKEDATA-API-KEY", "POKEMON-TCG-API-KEY", "ARM-CLIENT-ID", "ARM-CLIENT-SECRET"]
- debug_function_app_settings_keys should show all keys including secrets + config + system variables

PURPOSE:
- Verify secrets.auto.tfvars is being loaded by Terraform
- Confirm function_app_secrets variable receives the 4 secrets with hyphenated names
- Validate merge operation includes all expected keys before transformation
- Help identify where keys are being lost in the flow

TROUBLESHOOTING:
- If debug_secrets_keys_received is empty: secrets.auto.tfvars not loaded or empty default used
- If keys present but not in Function App: transformation or deployment issue in function-app module

FILES MODIFIED:
- infra/envs/dev/outputs.tf (Added 3 debug outputs)