### PR TITLE
fix(ado): update CD pipeline trigger paths after Phase 0 path moves

### DIFF
--- a/pipelines/ado/azure-pipelines.yml
+++ b/pipelines/ado/azure-pipelines.yml
@@ -9,9 +9,10 @@ trigger:
   paths:
     include:
       - "app/**"
+      - "backend/**"
       - "infra/**"
       - "apim/**"
-      - ".ado/**"
+      - "pipelines/ado/**"
     exclude:
       - "**/*.md"
       - "docs/**"


### PR DESCRIPTION
Tiny follow-up to #127 — fixes a Phase 0 oversight that's keeping the post-merge multi-stage CD pipeline from queueing.

## What's wrong on main

`pipelines/ado/azure-pipelines.yml`'s `trigger.paths.include` still lists:

\`\`\`yaml
- "app/**"
- "infra/**"
- "apim/**"
- ".ado/**"
\`\`\`

But Phase 0 moved \`.ado/\` → \`pipelines/ado/\` and \`app/backend/\` → \`backend/functions/\`. So the merge of #127 to main:
- Touched \`pipelines/ado/**\` and \`backend/**\` — neither in the include list.
- Did *not* touch any path under the OLD names.

Result: ADO didn't see any included paths change → CD pipeline never queued.

## Fix

\`\`\`diff
   paths:
     include:
       - "app/**"
+      - "backend/**"
       - "infra/**"
       - "apim/**"
-      - ".ado/**"
+      - "pipelines/ado/**"
\`\`\`

- \`app/**\` stays (still covers the legacy \`app/frontend/\` SPA that's deployed to SWA).
- \`backend/**\` added — covers the moved \`backend/functions/\` and the new \`backend/shared/\` workspace.
- \`pipelines/ado/**\` replaces the obsolete \`.ado/**\`.

The PR validation pipeline (\`azure-pipelines-pr.yml\`) only has path **excludes**, not includes, so this issue doesn't affect it.

## Why #127 missed this

That PR's path-reference sweep caught template \`workingDirectory\` and \`source\` paths inside templates, but the top-level pipeline's \`trigger.paths.include\` block didn't show up in the grep because nothing in it lexically matched \`app/backend\` or \`.ado/\` as a substring of a longer path — the grep was for the full strings used inside templates, not the trigger glob fragments. Lesson logged.

## Verification after merge

The push of this PR (touching \`pipelines/ado/**\`) is itself in the new include list, so the merge to main will be the first run that queues the CD pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)