### PR TITLE
fix(ado): stage SWA artifact under sources so AzureStaticWebApp@0 can find it

### DIFF
--- a/pipelines/ado/templates/deploy-swa.yml
+++ b/pipelines/ado/templates/deploy-swa.yml
@@ -284,14 +284,33 @@ steps:
         echo "✓ Deployment token retrieved successfully"
         echo "##vso[task.setvariable variable=DEPLOYMENT_TOKEN;issecret=true]$DEPLOYMENT_TOKEN"
 
+  # Stage the SWA artifact under $(Build.SourcesDirectory) so AzureStaticWebApp@0
+  # can resolve it. The task runs inside its own Oryx Docker container which
+  # mounts the source dir as /working_dir and treats `app_location` as a path
+  # *relative* to that mount. Passing an absolute artifact path (e.g.
+  # $(Pipeline.Workspace)/drop/swa) gets re-rooted as /working_dir/__w/1/...
+  # and fails with "App Directory Location ... is invalid". Staging under
+  # the source tree and passing a relative path is the MS-recommended
+  # pattern when skip_app_build is true.
+  - script: |
+      set -euo pipefail
+      DEST="$(Build.SourcesDirectory)/_swa_artifact"
+      rm -rf "$DEST"
+      mkdir -p "$DEST"
+      cp -R "$(Pipeline.Workspace)/drop/swa/." "$DEST/"
+      echo "✓ Staged SWA artifact at $DEST"
+      ls -lh "$DEST" | head -20
+    displayName: "Stage SWA artifact under sources"
+    condition: and(succeeded(), eq(variables['ShouldDeploySWA'], 'true'))
+
   # Deploy to Azure Static Web Apps
   - task: AzureStaticWebApp@0
     displayName: "Deploy to Static Web App"
     condition: and(succeeded(), eq(variables['ShouldDeploySWA'], 'true'))
     inputs:
       azure_static_web_apps_api_token: $(DEPLOYMENT_TOKEN)
-      # Point directly to the downloaded artifact location
-      app_location: "$(Pipeline.Workspace)/drop/swa"
+      # Path is relative to $(Build.SourcesDirectory) — see staging step above
+      app_location: "_swa_artifact"
       output_location: ""
       skip_app_build: true
 


### PR DESCRIPTION
Follow-up to the Phase 0 CD-pipeline trigger fix (#128). The first post-merge CD run surfaced an existing latent bug in the SWA deploy step.

## Symptom

\`\`\`
Try to validate location at: '/working_dir/__w/1/drop/swa'.
App Directory Location: '/__w/1/drop/swa' is invalid.
Could not detect this directory.
##[error]Error: The process '/usr/bin/bash' failed with exit code 1
\`\`\`

## Root cause

\`AzureStaticWebApp@0\` runs inside its own Oryx Docker container, which mounts the agent's source dir as \`/working_dir\` and resolves \`app_location\` **relative to that mount**. Passing an absolute path like \`\$(Pipeline.Workspace)/drop/swa\` (= \`/__w/1/drop/swa\`) gets re-rooted to \`/working_dir/__w/1/drop/swa\` — which doesn't exist.

This is **not** a Phase 0 regression. Commit \`75e733c\` (Nov 2025) had already broken this by switching from a working relative \`app_location: \"swa\"\` + \`cwd: $(Pipeline.Workspace)/drop\` pattern to an absolute path. That commit's title \"now deploys from the actual artifact path\" is misleading — the absolute path the docs don't support fails inside the task's container. The CD pipeline simply hadn't run since then because of separate trigger filter issues (#128) and other path moves.

## Fix

Add a small \"stage under sources\" step before the deploy:

\`\`\`yaml
- script: |
    DEST=\"\$(Build.SourcesDirectory)/_swa_artifact\"
    rm -rf \"\$DEST\"
    mkdir -p \"\$DEST\"
    cp -R \"\$(Pipeline.Workspace)/drop/swa/.\" \"\$DEST/\"
  displayName: \"Stage SWA artifact under sources\"
  condition: and(succeeded(), eq(variables['ShouldDeploySWA'], 'true'))

- task: AzureStaticWebApp@0
  inputs:
    azure_static_web_apps_api_token: \$(DEPLOYMENT_TOKEN)
    app_location: \"_swa_artifact\"      # relative — was \$(Pipeline.Workspace)/drop/swa
    output_location: \"\"
    skip_app_build: true
\`\`\`

The runtime \`env-config.js\` generated by the previous \"Generate Runtime Configuration\" step writes into \`\$(Pipeline.Workspace)/drop/swa/\`, which the staging step then copies into \`_swa_artifact/\` before deploy — so runtime config still ships.

## Bigger-picture note

\`docs/PORTFOLIO_PLAN.md\` Open Question #5 asks whether to retire the legacy \`app/frontend/\` Svelte 4 SPA. The new \`frontend/\` is now live on Vercel from this repo's \`frontend/\` directory; this Static Web App is on the path to becoming dead weight. This PR fixes the deploy mechanically; the retire-vs-keep call is a separate decision.

## Verification

After merge, the CD trigger now fires on \`pipelines/ado/**\` (per #128), so this PR's merge to main will itself queue the next CD run — same self-test pattern as #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)