### PR TITLE
Phase 1A — backend abstraction, BackendToggle UI, ADR-007/008, comparison doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A single product (Pokémon card pricing) deployed three ways from one repo to demonstrate architectural range across modern-edge, enterprise-cloud, and managed-container patterns. **One frontend, three interchangeable backends, one shared schema.**
 
-> **Status:** Phase 0 of 3 (consolidation in progress) — see [`docs/PORTFOLIO_PLAN.md`](docs/PORTFOLIO_PLAN.md).
-> **Live demo:** `pcpc.maber.io` (wired in Phase 1)
-> **Architecture comparison:** [`docs/architecture-comparison.md`](docs/architecture-comparison.md) *(in progress)*
+> **Status:** Phase 1 in progress — see [`docs/PORTFOLIO_PLAN.md`](docs/PORTFOLIO_PLAN.md).
+> **Live demo:** [pcpc.maber.io](https://pcpc.maber.io) — toggle backends via the corner badge or `?backend=vercel|azure`
+> **Architecture comparison:** [`docs/architecture-comparison.md`](docs/architecture-comparison.md) *(Path A & B; Path C lands in Phase 2)*
 
 ---
 
@@ -46,16 +46,24 @@ All three paths share the same Cosmos DB account and the same TypeScript types v
 
 **Architecture / Practice** · ADR-driven design · Repository consolidation via `git filter-repo` · Multi-runtime type sharing · Architectural decision documentation
 
-## Live demo (planned, Phase 1+)
+## Live demo
 
-A single URL, one frontend, three switchable backends, healthcheck-driven graceful degradation if any path is unhealthy. The toggle defaults to Path A so a recruiter who just opens the URL gets a normal app experience.
+[pcpc.maber.io](https://pcpc.maber.io) — one URL, one frontend, two switchable backends today (three after Phase 2). A corner badge surfaces the active path with its latency; click to switch, or pin via `?backend=vercel|azure` in the URL. Healthcheck-driven graceful degradation hides any path whose `/health` does not respond within 2s, so partial outages never break the demo. The toggle defaults to Path A — a recruiter who never engages it gets a normal app experience.
+
+| URL | What it hits |
+|---|---|
+| `pcpc.maber.io` | Path A (default) |
+| `pcpc.maber.io/?backend=vercel` | Path A explicitly |
+| `pcpc.maber.io/?backend=azure` | Path B (APIM + Functions, dev environment) |
+
+> **Phase 1 caveat (resolved in Phase 2):** Path B's Functions still serve the legacy PokeData schema. The frontend bridges shapes via a temporary adapter; per-variant pricing renders as "no data" on Path B until the Phase 2 schema migration. Full context: [`docs/architecture-comparison.md`](docs/architecture-comparison.md).
 
 ## Architecture decision records
 
-Decisions live in [`docs/adr/`](docs/adr/). The existing ADRs (001–006) cover earlier infrastructure choices (package manager, runtime, caching, devcontainer, schema, API integration). The three-path portfolio story will add four more:
+Decisions live in [`docs/adr/`](docs/adr/). The existing ADRs (001–006) cover earlier infrastructure choices (package manager, runtime, caching, devcontainer, schema, API integration). The three-path portfolio story adds:
 
-- **ADR-007** — API architecture spectrum (why three paths exist) *(Phase 1)*
-- **ADR-008** — APIM vs SvelteKit BFF as gateway *(Phase 1)*
+- **[ADR-007](docs/adr/ADR-007-api-architecture-spectrum.md)** — API architecture spectrum (why three paths exist) *(Accepted, Phase 1)*
+- **[ADR-008](docs/adr/ADR-008-apim-vs-bff-gateway.md)** — APIM vs SvelteKit BFF as gateway *(Accepted, Phase 1)*
 - **ADR-009** — Functions Consumption vs Container Apps *(Phase 2)*
 - **ADR-010** *(optional)* — Path to AKS *(Phase 3)*
 
@@ -99,10 +107,10 @@ Backend (Path B) and infrastructure are run via `pipelines/ado/` and Terraform m
 
 | Phase | Goal | Status |
 |---|---|---|
-| **0** | Consolidate maber-web/apps/pcpc into this repo, set up workspace, add portfolio surface | in progress |
-| **1** | Live two-path toggle (Vercel BFF + APIM/Functions), ADRs 0001 & 0003 | next |
-| **2** | Containerize Functions, ship ACA path, Scrydex schema migration, ADR 0002 | after Phase 1 |
-| **3** | Polish: portfolio site, LinkedIn distribution, ADR 0004 | final |
+| **0** | Consolidate maber-web/apps/pcpc into this repo, set up workspace, add portfolio surface | done |
+| **1** | Live two-path toggle (Vercel BFF + APIM/Functions), ADR-007 & ADR-008, comparison doc | in progress |
+| **2** | Containerize Functions, ship ACA path, Scrydex schema migration, ADR-009 | after Phase 1 |
+| **3** | Polish: portfolio site, LinkedIn distribution, ADR-010 | final |
 
 Full plan with risks, success metrics, and open questions: [`docs/PORTFOLIO_PLAN.md`](docs/PORTFOLIO_PLAN.md).
 

--- a/docs/adr/ADR-007-api-architecture-spectrum.md
+++ b/docs/adr/ADR-007-api-architecture-spectrum.md
@@ -1,0 +1,215 @@
+# ADR-007: API Architecture Spectrum (Three Paths)
+
+## Status
+
+Accepted
+
+Date: 2026-05-06
+
+## Context
+
+PCPC is a single product (Pokémon card pricing) but is being deployed three
+ways from one repository to demonstrate architectural range across modern-edge,
+enterprise-cloud, and managed-container patterns. The motivation is documented
+in [`docs/PORTFOLIO_PLAN.md`](../PORTFOLIO_PLAN.md): the project is a portfolio
+artifact, and recruiters evaluate fit across audiences (defense/regulated,
+enterprise mid-market, modern startup) whose architectural vocabulary differs.
+A single deployed shape forces the reader to imagine the others. Three live
+shapes let the reader compare directly.
+
+The product itself is not the artifact. The architectural reasoning behind
+deploying it three ways is the artifact, and this ADR is the front door to
+that reasoning.
+
+The three paths are:
+
+- **Path A — Vercel BFF.** SvelteKit `+server.ts` routes co-deployed with the
+  frontend on Vercel. This is the canonical product experience.
+- **Path B — APIM + Functions.** Azure API Management (Consumption) routing
+  to Azure Functions v4. This is the enterprise/regulated shape.
+- **Path C — ACA Container.** Same Functions code as Path B, packaged as a
+  container, deployed to Azure Container Apps with KEDA autoscaling. This is
+  the managed-container shape. Ships in Phase 2.
+
+A single SvelteKit frontend at `pcpc.maber.io` serves all three. A
+`?backend=vercel|azure|aca` query parameter selects which path is called for
+data fetching. A small corner badge surfaces the current selection and lets
+visitors switch with one click. Each path's own healthcheck determines whether
+its toggle option is enabled, so a broken or undeployed path degrades
+gracefully out of the UI rather than producing user-visible errors.
+
+All three paths share a single Cosmos DB account using the Scrydex schema, and
+all three share TypeScript types via `@pcpc/shared`. There is no per-path data
+divergence by design; the comparison is purely about the *runtime* and
+*operational surface* in front of the same data.
+
+## Decision
+
+**Ship the same product three ways from one repository, with a runtime
+backend toggle on the frontend, and document the architectural tradeoffs as
+the primary deliverable.**
+
+The decision has four components:
+
+### 1. Three deployment paths, not two
+
+Two paths (Vercel BFF vs APIM + Functions) is enough to make a comparison
+*statement* — modern edge vs enterprise cloud — but it is not enough to make
+a comparison *spectrum*. The third path (ACA container) is the inflection
+point that turns "two endpoints" into "three positions on a continuum" — the
+container path lets us argue about portability, image immutability, KEDA
+autoscaling, and the FedRAMP-friendly deployment model in the same breath as
+the other two.
+
+The marginal engineering cost of Path C is small (the Functions code is reused
+verbatim; only packaging and IaC change). The marginal narrative value is
+large.
+
+### 2. Single user-facing URL, runtime path selection
+
+There is exactly one URL to know: `pcpc.maber.io`. Recruiters do not need to
+follow a different link for each architecture. The `?backend=` query parameter
+plus the corner badge let a visitor switch paths in place and observe the
+*same UI* responding from a *different runtime*. This is more legible than
+three separate deployments at three URLs.
+
+The toggle defaults to Path A, so a recruiter who never engages the toggle
+gets a normal, fast, unbroken app experience. The toggle is opt-in.
+
+### 3. Frontend abstraction over the path differences
+
+Each backend path is represented by a `BackendDefinition` (see
+`frontend/src/lib/backends/`). Each definition exposes a `fetcher` that
+accepts the canonical Scrydex-shape path the frontend produces and is
+responsible for translating to its own backend's URL and reshaping responses
+back to the canonical envelope.
+
+Consequence: every consumer in the frontend (stores, services, components)
+calls `api.getSets()` etc. without knowing which backend will handle the
+request. Adding Path C in Phase 2 is a single new `BackendDefinition`
+registration; nothing else changes.
+
+### 4. Healthcheck-driven graceful degradation
+
+Each path exposes `/health` (Path A through SvelteKit, Path B through APIM →
+Functions, Path C through ACA ingress). The frontend probes each path on
+mount and on a 60-second poll. A path whose healthcheck does not return
+healthy or degraded within 2 seconds is dimmed in the toggle and cannot be
+selected. If the active path goes unhealthy mid-session, the frontend
+automatically reverts to the default (Path A).
+
+This means partial deployments are non-breaking. Path B can be down for
+maintenance, Path C can be undeployed entirely, and the recruiter still gets
+a working product — the toggle just shows fewer options.
+
+## Consequences
+
+### Positive
+
+- **Architectural legibility.** A recruiter can demonstrate the toggle in a
+  60-second screen share and *see* the comparison rather than read about it.
+  The artifact is operational, not just documented.
+- **Audience flexibility.** Defense/regulated recruiters see APIM, Terraform,
+  ADO pipelines, container immutability. Modern startup recruiters see edge
+  SSR, serverless functions, monorepo type sharing. Both audiences see the
+  *same code* deployed differently — the implication is that the engineer
+  understands *when* to use *which*.
+- **Atomic schema evolution.** Because all three paths share `@pcpc/shared`,
+  a schema change is one commit across one repo. There is no
+  out-of-band coordination between projects.
+- **Resilient demo.** Healthcheck-driven degradation means a partial outage
+  on any path never breaks the user-facing demo. The toggle shrinks; the
+  product keeps working.
+- **Cheap to maintain.** All paths share the same Cosmos data layer, so there
+  is no data divergence to manage. Total monthly cost across all three paths
+  at full deployment is projected at ~$10–25.
+
+### Negative
+
+- **Three deployments to monitor.** Each path is real infrastructure with
+  real failure modes. Path A is monitored through Vercel; Paths B and C
+  through Application Insights. This is more operational surface than a
+  single-deployment architecture.
+- **Schema parity is a soft constraint.** During Phase 1, Path B serves
+  PokeData-shape data (the legacy schema) while the frontend expects
+  Scrydex-shape data. A temporary translation adapter in
+  `$lib/backends/adapters/pokedata-to-scrydex.ts` bridges the gap. The
+  adapter is removed in Phase 2 when Functions migrate to Scrydex. Until
+  then, Path B's card pricing renders as "no pricing available" — an
+  acknowledged Phase 1 limitation, surfaced through the toggle UX.
+- **Cognitive overhead for casual readers.** Three architectures requires
+  more attention than one. The default-to-Path-A behavior protects against
+  this — a casual visitor never has to know about the toggle — but anyone
+  evaluating the portfolio depth has to engage with three boxes instead of
+  one.
+- **Phase coupling.** Path C requires the Functions schema migration to land
+  first (Phase 2), which is the largest single piece of work in the plan.
+  Phasing risk is real and explicitly tracked in
+  [`docs/PORTFOLIO_PLAN.md`](../PORTFOLIO_PLAN.md).
+
+## Alternatives Considered
+
+### Option 1: Single-path deployment (status quo, pre-Phase-1)
+
+- **Pros**: Lower operational surface; lower cost; simpler README.
+- **Cons**: The architectural comparison can only be *described*, not
+  *demonstrated*. The recruiter has to take the engineer's word that they
+  understand multiple deployment patterns.
+- **Reason for rejection**: The product is a portfolio artifact. A
+  description-only comparison loses the demonstration value that a runtime
+  toggle provides. The marginal engineering cost of adding Path B and Path C
+  is small relative to the narrative value gained.
+
+### Option 2: Three separate deployments at three URLs
+
+- **Pros**: Clean separation; no toggle UX to design; each deployment can
+  evolve independently.
+- **Cons**: Forces the visitor to context-switch between URLs; loses the
+  "same UI, different runtime" observability that makes the comparison
+  visceral; requires three distinct frontend deployments instead of one.
+- **Reason for rejection**: The point of the comparison is the *runtime
+  swap*. Three URLs hide that. One URL with a toggle makes it the headline
+  feature.
+
+### Option 3: Two paths only (Path A and Path B), defer Path C indefinitely
+
+- **Pros**: Smaller scope; ships faster; no Functions schema migration on
+  the critical path.
+- **Cons**: Two paths is a *binary*, not a *spectrum*. The container path is
+  what makes the story about *positions* (modern edge → managed
+  container → enterprise cloud) rather than just two opposing endpoints.
+- **Reason for rejection**: Phase 1 ships exactly this (two paths) as an
+  intentional first-mile state, but Phase 2 adding Path C is the artifact's
+  thesis and is not deferrable in the plan.
+
+### Option 4: Server-side path selection (different paths for different visitors)
+
+- **Pros**: Allows A/B-style segmentation; could route some traffic to Path B
+  to demonstrate it under load.
+- **Cons**: Hides the architectural choice from the visitor; defeats the
+  purpose of *demonstrating* the comparison; adds complexity for zero
+  portfolio benefit.
+- **Reason for rejection**: The portfolio goal is for the visitor to *see*
+  the choice. Hiding it server-side reverts the artifact to a single-path
+  deployment from the visitor's perspective.
+
+## Implementation Notes
+
+- The active path lives in
+  [`frontend/src/lib/backends/store.svelte.ts`](../../frontend/src/lib/backends/store.svelte.ts).
+  URL state, localStorage state, and the in-memory rune are kept in sync.
+- The fetcher seam is documented in ADR-008. ADR-008 covers the narrower
+  question of *gateway choice* (APIM vs SvelteKit BFF); this ADR covers the
+  *spectrum decision*.
+- ADR-009 (Phase 2) covers the Functions Consumption vs ACA decision in
+  detail.
+- ADR-010 (Phase 3, optional) speculates on a fourth path to AKS without
+  building it.
+
+## Related Decisions
+
+- [ADR-008: APIM vs SvelteKit BFF as Gateway](./ADR-008-apim-vs-bff-gateway.md)
+- ADR-009: Functions Consumption vs Container Apps *(planned, Phase 2)*
+- ADR-010: Path to AKS *(planned, Phase 3, optional)*
+- [ADR-005: Database Schema Design](./ADR-005-database-schema-design.md)
+- [ADR-006: API Integration Strategy](./ADR-006-api-integration-strategy.md)

--- a/docs/adr/ADR-008-apim-vs-bff-gateway.md
+++ b/docs/adr/ADR-008-apim-vs-bff-gateway.md
@@ -1,0 +1,180 @@
+# ADR-008: APIM vs SvelteKit BFF as Gateway
+
+## Status
+
+Accepted
+
+Date: 2026-05-06
+
+## Context
+
+PCPC's three-path architecture (see
+[ADR-007](./ADR-007-api-architecture-spectrum.md)) places two different kinds
+of API gateway in front of the same Cosmos data layer:
+
+- **Path A (Vercel BFF)** uses SvelteKit `+server.ts` routes co-deployed
+  with the frontend on Vercel. The "gateway" is just the SvelteKit app — no
+  separate gateway product, no separate runtime, no separate IaC.
+- **Path B (APIM + Functions)** uses Azure API Management (Consumption tier)
+  in front of Azure Functions v4 on a Consumption plan. APIM is a dedicated
+  API gateway product with its own policy engine, subscription model, and
+  developer portal.
+
+The decision is not "which gateway is better" — both are correct in their
+respective contexts. The decision is **why both exist in the same project,
+and when each pattern is the right call.** The portfolio narrative needs an
+explicit answer to that question because recruiters from different
+backgrounds will reach for different defaults.
+
+This ADR is intentionally narrower than ADR-007. ADR-007 explains why three
+deployment paths exist at all. This ADR explains the gateway-shaped tradeoff
+between two of them.
+
+## Decision
+
+**Keep both gateway patterns. Use APIM when the policy/governance/discovery
+surface earns its operational weight; use the BFF pattern when it does not.
+The PCPC frontend treats them as interchangeable through the
+`BackendDefinition` abstraction, so the gateway choice never leaks into
+application code.**
+
+The decision rule, written for future selves and for portfolio readers:
+
+| Choose APIM when… | Choose SvelteKit BFF when… |
+|---|---|
+| Multiple consumers (other apps, partner integrations, mobile clients) need stable contracts | Single frontend is the only consumer |
+| Rate limiting, quota, or subscription billing is a real requirement | Rate limiting can live at the CDN edge or in app code |
+| API discovery via developer portal has business value (FedRAMP/GovCloud, partner ecosystems) | No external API consumers |
+| Policy-engine concerns (request transformation, JWT validation, IP filtering) are best expressed declaratively at the gateway | Authn/authz is straightforward and lives near the app code |
+| Backend services are heterogeneous (multiple Functions apps, AKS services, external APIs) and benefit from a single front door | Backend is a single unit deployed alongside the frontend |
+| Operations team owns the gateway as a separate concern from the application teams | Application team owns the entire stack |
+
+## Consequences
+
+### Positive
+
+- **Honest about the tradeoff.** The codebase shows both patterns working,
+  not just claims they exist. A reader can run both, observe the latency
+  difference, and form their own opinion.
+- **Architectural fluency demonstrated.** Senior+ engineers are expected to
+  know that APIM is correct in some contexts and overkill in others. Showing
+  both shipped patterns in one repo is the strongest possible
+  demonstration of that fluency.
+- **No gateway lock-in for the application code.** The
+  `BackendDefinition` abstraction in `frontend/src/lib/backends/` makes the
+  gateway choice a runtime concern. The frontend has no `if (apim) ... else`
+  branches; it calls `backendStore.active.fetcher.fetch(canonicalPath)` and
+  the active definition handles the rest. This is the same shape of
+  abstraction that real-world teams build when they need to swap gateways
+  during a migration.
+- **Realistic latency cost is visible.** APIM Consumption adds ~80–150ms of
+  cold-start overhead on the gateway hop (Functions cold starts add more on
+  top). The BFF path has none of that overhead because the "gateway" is the
+  same process serving the page. The toggle's latency badge surfaces the
+  cost in real numbers, which is more useful than abstract claims.
+- **Failure isolation is explicit.** A bug in the BFF brings the page down.
+  A bug in APIM brings the gateway down for all consumers. The pattern
+  choice is a failure-domain choice, and demonstrating both makes that
+  visible.
+
+### Negative
+
+- **Two operational surfaces.** APIM requires its own Terraform module,
+  policy authoring (XML), named values, backends, and product/subscription
+  configuration. The BFF path requires none of that. Maintaining both means
+  paying both bills (operational and cognitive).
+- **APIM Consumption tier limits.** Consumption tier does not support
+  caching policies, virtual networks, or some advanced policies. For PCPC
+  (a portfolio), Consumption is right because Standard/Premium would cost
+  10–100× more for zero portfolio benefit. But the limitation is real and
+  is part of the honest comparison.
+- **Latency penalty for the demonstration path.** Path B is, on every
+  request, slower than Path A by at least one extra network hop (frontend →
+  APIM → Functions). For a real product where Path B is the only path, that
+  hop is justified by what APIM provides; for a portfolio where Path A is
+  the canonical experience, the hop is purely demonstrative.
+- **Default-path bias.** Because Path A is the default, casual visitors
+  never engage with Path B unless they discover the toggle. The "live
+  demonstration" benefit only materializes if visitors interact. Mitigated
+  by the visible corner badge and the architecture-comparison doc that
+  invites the toggle explicitly.
+
+## Alternatives Considered
+
+### Option 1: APIM in front of everything (including Path A)
+
+- **Pros**: Single gateway model; consistent rate-limiting/policy story;
+  could legitimately argue "this is how the enterprise version of the
+  product would look."
+- **Cons**: Adds ~100ms+ to every Path A request for no application benefit;
+  defeats the *contrast* between the two patterns; makes Path A's "edge
+  runtime, no separate gateway" story untellable.
+- **Reason for rejection**: The contrast is the point. APIM-everywhere
+  collapses the comparison into a single shape and loses the architectural
+  spectrum.
+
+### Option 2: BFF only, drop APIM entirely
+
+- **Pros**: Simpler operational surface; lower cost; the BFF pattern is
+  fashionable and well-understood.
+- **Cons**: Removes the entire enterprise/regulated-industry story from the
+  portfolio; fails the audience-flexibility goal in
+  [`docs/PORTFOLIO_PLAN.md`](../PORTFOLIO_PLAN.md); APIM is exactly the
+  kind of artifact defense and regulated-industry recruiters look for.
+- **Reason for rejection**: Audience flexibility is a stated goal. Dropping
+  APIM optimizes for the modern-startup audience at the cost of every other
+  audience.
+
+### Option 3: API Gateway product other than APIM (e.g. AWS API Gateway, Kong, Tyk)
+
+- **Pros**: Could argue cross-cloud fluency; Kong/Tyk are popular in
+  modern stacks.
+- **Cons**: Splits the Azure story; introduces a non-Azure dependency for
+  reasons unrelated to the comparison being made; the rest of the
+  enterprise stack (Cosmos, Functions, ACA, App Insights) is Azure.
+- **Reason for rejection**: Cross-cloud comparison is not what this project
+  is about. The comparison is *patterns within one cloud*, not *across
+  clouds*. Adding a non-Azure gateway would be noise.
+
+### Option 4: A custom gateway service (e.g. an Express/Fastify proxy)
+
+- **Pros**: Full control; cheap to run; could implement exactly the
+  policies needed.
+- **Cons**: Reinvents what APIM/Kong/Tyk already do; loses the
+  "off-the-shelf gateway product" demonstration that recruiters look for;
+  adds another runtime to operate.
+- **Reason for rejection**: The portfolio value of APIM is precisely that
+  it is the off-the-shelf option an enterprise team would actually choose.
+  A custom proxy would be cheaper to build but less legible as a portfolio
+  artifact.
+
+## Implementation Notes
+
+- The frontend abstraction lives at
+  [`frontend/src/lib/backends/`](../../frontend/src/lib/backends/). Each
+  path is a `BackendDefinition` with a `fetcher` that hides the gateway
+  shape from the rest of the app.
+- The APIM configuration lives at [`apim/`](../../apim/) and is deployed
+  via Terraform from [`apim/terraform/`](../../apim/terraform/).
+- The BFF routes live at
+  [`frontend/src/routes/api/`](../../frontend/src/routes/api/) and deploy
+  to Vercel automatically on push to `main`.
+- During Phase 1, Path B's responses are reshaped on the frontend by the
+  `pokedata-to-scrydex` adapter because the Functions code is still on the
+  legacy schema. This adapter is removed in Phase 2 along with the Functions
+  schema migration. The adapter is intentionally narrow — it bridges
+  request/response shape only; it does not paper over functional gaps
+  (e.g. PokeData has no per-variant pricing, so Path B card detail returns
+  empty variants and the UI degrades to "no pricing available"). The
+  toggle UX surfaces this honestly rather than hiding it.
+- Custom domains for Path B are provisioned separately in Phase 1B,
+  per-environment: `dev-api.pcpc.maber.io`, `staging-api.pcpc.maber.io`,
+  and `api.pcpc.maber.io` (prod). DNS records (validation + CNAME) are
+  added manually in Cloudflare; APIM's hostname binding + Azure-managed
+  cert are managed via Terraform.
+
+## Related Decisions
+
+- [ADR-007: API Architecture Spectrum](./ADR-007-api-architecture-spectrum.md)
+- ADR-009: Functions Consumption vs Container Apps *(planned, Phase 2)*
+- [ADR-006: API Integration Strategy](./ADR-006-api-integration-strategy.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,8 @@ Each ADR follows a standardized format:
 | [ADR-004](./ADR-004-devcontainer-acr-optimization.md) | DevContainer ACR Optimization | Accepted | 2025-09-28 |
 | [ADR-005](./ADR-005-database-schema-design.md) | Database Schema Design | Accepted | 2025-09-28 |
 | [ADR-006](./ADR-006-api-integration-strategy.md) | API Integration Strategy | Accepted | 2025-09-22 |
+| [ADR-007](./ADR-007-api-architecture-spectrum.md) | API Architecture Spectrum (three paths) | Accepted | 2026-05-06 |
+| [ADR-008](./ADR-008-apim-vs-bff-gateway.md) | APIM vs SvelteKit BFF as Gateway | Accepted | 2026-05-06 |
 
 ### Planned (three-path portfolio story)
 
@@ -35,8 +37,6 @@ These ADRs document the architectural reasoning behind PCPC's three-path deploym
 
 | ADR | Title | Phase | Status |
 |-----|-------|-------|--------|
-| [ADR-007](./ADR-007-api-architecture-spectrum.md) | API Architecture Spectrum (three paths) | 1 | Planned |
-| [ADR-008](./ADR-008-apim-vs-bff-gateway.md) | APIM vs SvelteKit BFF as Gateway | 1 | Planned |
 | [ADR-009](./ADR-009-functions-vs-container-apps.md) | Functions Consumption vs Container Apps | 2 | Planned |
 | [ADR-010](./ADR-010-path-to-aks.md) | Path to AKS (speculative) | 3 (optional) | Planned |
 

--- a/docs/architecture-comparison.md
+++ b/docs/architecture-comparison.md
@@ -1,0 +1,217 @@
+# Architecture Comparison
+
+> **Phase 1 (current).** Two of three paths are live: Path A (Vercel BFF)
+> and Path B (APIM + Functions). Path C (ACA Container) ships in Phase 2;
+> a third column will be added to every table here when it lands.
+
+This document is the marquee artifact of the PCPC portfolio. The plan
+(see [`PORTFOLIO_PLAN.md`](./PORTFOLIO_PLAN.md)) is to ship one product
+multiple ways from one repo so the architectural comparison is
+*operational*, not just *described*. This doc is where the tradeoffs are
+written down.
+
+The decision narrative behind the comparison lives in the ADRs:
+
+- [ADR-007 — API Architecture Spectrum](./adr/ADR-007-api-architecture-spectrum.md):
+  why three paths exist at all
+- [ADR-008 — APIM vs SvelteKit BFF as Gateway](./adr/ADR-008-apim-vs-bff-gateway.md):
+  the gateway-shaped tradeoff between Path A and Path B
+- ADR-009 *(Phase 2)*: Functions Consumption vs Container Apps
+
+---
+
+## Headline architecture
+
+```
+                          pcpc.maber.io
+                       (Vercel · SvelteKit)
+                                │
+                  ┌─────────────┴─────────────┐
+          ?backend=vercel              ?backend=azure          (?backend=aca, Phase 2)
+                  │                            │                            │
+        SvelteKit BFF                  APIM (Consumption)          ACA + KEDA (planned)
+        (+server.ts on                         │                            │
+         Vercel serverless)            Azure Functions v4         Azure Functions v4
+                  │                    (Node.js 22)               (containerized)
+                  │                            │                            │
+                  └────────────────────────────┴────────────────────────────┘
+                                               │
+                                  Cosmos DB (Scrydex schema)
+                                  Redis (optional)
+```
+
+A single SvelteKit frontend serves all three paths. The active path is
+selected by the `?backend=` URL parameter and surfaced in the corner badge.
+All paths share the same Cosmos DB account and the same TypeScript types
+via `@pcpc/shared`.
+
+## Data flow (Path A and Path B; Phase 2 adds Path C as a parallel branch)
+
+```
+Browser ──▶ pcpc.maber.io (Vercel)
+                │
+                ├── ?backend=vercel ──▶ SvelteKit +server.ts
+                │                              │
+                │                              ▼
+                │                        Cosmos DB (Scrydex schema)
+                │                              ▲
+                │                              │ (cache miss)
+                │                              ▼
+                │                        Scrydex API
+                │
+                └── ?backend=azure  ──▶ APIM (api.pcpc.maber.io, Consumption)
+                                               │
+                                               ▼
+                                       Azure Functions v4 (Node 22)
+                                               │
+                                               ▼
+                                       Cosmos DB (Scrydex schema)
+                                               ▲
+                                               │ (cache miss)
+                                               ▼
+                                       Scrydex API
+```
+
+The Scrydex upstream is the same for both paths — when neither Cosmos nor
+Redis has the data, both paths fetch from `api.scrydex.com` and write back
+through the same cache hierarchy. That hierarchy (Redis → Cosmos → upstream)
+is described in [ADR-003](./adr/ADR-003-caching-architecture-design.md).
+
+---
+
+## Side-by-side comparison
+
+### Request flow
+
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
+|---|---|---|
+| User-facing URL | `pcpc.maber.io` | `pcpc.maber.io` (toggle to `?backend=azure`) |
+| Frontend → API hop | Same Vercel deployment, no separate gateway | Browser → APIM → Functions → Cosmos |
+| Network hops added by the gateway | 0 | 1 (APIM → Functions) |
+| Cold-start surface | Vercel serverless (~50–150ms) | APIM cold (~80–150ms) + Functions cold (~500–1500ms on Consumption) |
+| Where business logic runs | SvelteKit `+server.ts` in same process as page rendering | Azure Functions v4 (separate process, separate runtime) |
+| Direct backend access without the gateway | N/A — same process | Functions HTTP trigger is `function`-auth (key required); APIM holds the key |
+
+### Operational characteristics
+
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
+|---|---|---|
+| IaC scope | None (Vercel project settings only) | 9 Terraform modules (`infra/modules/`) + APIM-as-code (`apim/`) |
+| CI/CD | Vercel auto-deploy on push to `main`; PR previews | Azure DevOps multi-stage pipeline; ACR-backed CI containers |
+| Deployment time | ~30–90s | ~3–8min (Terraform plan/apply + Functions deploy + APIM sync) |
+| Observability | Vercel logs + browser dev tools | Application Insights + Log Analytics + APIM Analytics |
+| Secret management | Vercel env vars | Azure Key Vault → Function App app-settings |
+| Identity model | Vercel deployment owner | Azure managed identity |
+| Custom domain (Phase 1) | `pcpc.maber.io` (Vercel + Cloudflare) | Per-env: `dev-api.pcpc.maber.io`, `staging-api.pcpc.maber.io`, `api.pcpc.maber.io` (APIM hostname binding + Azure-managed cert; CNAMEs in Cloudflare) |
+| TLS cert | Vercel-managed | Azure-managed (free) |
+
+### Scaling and cost
+
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
+|---|---|---|
+| Scaling model | Per-request serverless (Vercel) | APIM Consumption: per-call, no min instances; Functions Consumption: per-execution |
+| Scale-to-zero | Yes | Yes |
+| Concurrency limit per instance | Vercel default (high) | Functions Consumption: 200 concurrent per instance |
+| Estimated monthly cost (recruiter-traffic levels) | $0 (Vercel free tier) | ~$2–8 (APIM Consumption + Functions Consumption + Cosmos serverless) |
+
+### Security posture
+
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
+|---|---|---|
+| TLS termination | Vercel edge | APIM gateway |
+| Authn/authz | App-level (none required for read endpoints) | APIM subscription model available; currently `subscription_required = false` for the demo |
+| Secret access | Vercel env vars at build/runtime | Key Vault references in app-settings; Functions read at runtime |
+| Rate limiting | None (Vercel edge limits only) | Available via APIM policy; not currently configured |
+| CORS | SvelteKit handles same-origin natively | Configured at APIM to accept `pcpc.maber.io` (Phase 1B) |
+| Audit | Vercel deployment log | App Insights request log + APIM Analytics |
+
+### Schema and data
+
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
+|---|---|---|
+| Backend schema (Phase 1) | Scrydex | PokeData *(legacy; migrates to Scrydex in Phase 2)* |
+| Frontend-facing shape | Scrydex (canonical) | Scrydex via `pokedata-to-scrydex` adapter |
+| Type sharing | `@pcpc/shared` (Scrydex types) | `@pcpc/shared` (Scrydex types) |
+| Per-variant pricing supported | Yes | No *(empty `variants[]` until Phase 2)* |
+| Cosmos DB | Same account, same Scrydex containers | Same account; will use Scrydex containers post-migration |
+
+---
+
+## What each path is best for demonstrating
+
+### Path A — Vercel BFF (modern edge / startup vocabulary)
+
+- SvelteKit 2 + Svelte 5 runes, Tailwind CSS v4
+- `+server.ts` BFF pattern with no separate gateway
+- Vercel adapter, edge runtime familiarity
+- "One process, one deploy, one bill" simplicity
+- Lightweight personal-app architecture done well
+
+### Path B — APIM + Functions (enterprise / regulated vocabulary)
+
+- Azure API Management with declarative policies and a developer portal
+- Azure Functions v4 on Node.js 22 with idiomatic separation of concerns
+- 9-module Terraform composition (resource group, key vault, cosmos, function app, storage, app insights, log analytics, APIM, static web app legacy module)
+- Azure DevOps multi-stage pipelines with ACR-backed CI containers
+- Application Insights + Log Analytics for end-to-end observability
+- Managed identity, Key Vault references, audit log integration
+- Defense/regulated-industry-friendly deployment patterns
+
+---
+
+## Phase 1 known limitations (resolved in Phase 2)
+
+These are surfaced explicitly because the portfolio rewards honesty about
+in-progress work more than it rewards hiding it.
+
+- **Path B serves PokeData-shape data.** The Functions code has not yet
+  been migrated to the Scrydex schema. A frontend adapter
+  (`frontend/src/lib/backends/adapters/pokedata-to-scrydex.ts`) bridges
+  the request/response shape so the toggle works end-to-end, but the
+  adapter cannot synthesize per-variant pricing that PokeData never had.
+  Path B card detail therefore renders as "no pricing available" until
+  Phase 2 migrates the Functions to Scrydex.
+- **Set metadata on Path B is sparse.** Series, total, printedTotal,
+  isOnlineOnly, logo, and symbol come back undefined on Path B because
+  PokeData does not expose them. Path A returns full metadata.
+- **Custom domains land in Phase 1B.** Phase 1A ships the toggle pointed
+  at the dev APIM's `*.azure-api.net` hostname. Phase 1B provisions the
+  per-environment custom domains (`dev-api`, `staging-api`, `api`) with
+  Azure-managed certs and adds the validation + CNAME records in
+  Cloudflare manually.
+
+The toggle's healthcheck-driven graceful degradation guarantees the user
+experience never regresses below "Path A works." A reader who never
+engages the toggle gets a normal Scrydex-backed experience identical to
+the pre-Phase-1 deployment.
+
+---
+
+## How to try it
+
+1. Open [pcpc.maber.io](https://pcpc.maber.io) *(wired in Phase 1B)*.
+2. Notice the badge in the bottom-right corner. It shows the active backend
+   and the latency of its last healthcheck.
+3. Click the badge. Pick a different path from the popover. The page
+   reloads and the same UI is now talking to the other backend.
+4. The latency badge updates with the new backend's response time.
+5. To pin a path via URL, append `?backend=vercel` or `?backend=azure`.
+6. To return to default behavior, remove the parameter (or pick Vercel).
+
+The toggle is opt-in. A visitor who never opens the popover sees Path A
+behavior throughout — fast, normal, unbroken.
+
+---
+
+## What changes in Phase 2
+
+This document gets a third column (Path C — ACA Container) and ADR-009
+gets published. The headline diagram gains a third descending arrow, the
+data-flow diagram gains a third parallel branch, and the comparison tables
+above gain rows for KEDA scaling characteristics, container image
+provenance, and the cold-start delta between Functions Consumption and
+ACA min-replicas-1 deployments.
+
+Once Path C is live, the Phase 1 known-limitations section above
+collapses to a single line: "schema migrated; Path B and Path C now serve
+canonical Scrydex data."

--- a/frontend/src/lib/backends/adapters/pokedata-to-scrydex.ts
+++ b/frontend/src/lib/backends/adapters/pokedata-to-scrydex.ts
@@ -1,0 +1,131 @@
+/**
+ * PokeData → Scrydex response shape adapter.
+ *
+ * TEMPORARY (Phase 1 only). Path B's Azure Functions still return PokeData-
+ * shaped data, but the frontend was migrated to Scrydex shapes when it left
+ * maber-web. This adapter is the bridge so the live toggle can return real
+ * data from both paths in Phase 1 without blocking on the Functions
+ * migration.
+ *
+ * Phase 2 migrates the Functions code to Scrydex schema, after which the
+ * adapter is unnecessary and is deleted along with this file.
+ *
+ * Limitations (acknowledged for the portfolio demo):
+ *   - PokeData has no per-variant pricing model, so Path B card responses
+ *     will show empty `variants[]` and the UI will render "no pricing
+ *     available". This is the expected Phase 1 behavior.
+ *   - PokeData lacks several Scrydex metadata fields (series, total,
+ *     printedTotal, isOnlineOnly, logo, symbol). They surface as undefined.
+ */
+
+import type { PokemonSet, PokemonCard, ApiResponse } from '$lib/types';
+
+interface PokeDataSetListPayload {
+  sets?: Array<Record<string, unknown>>;
+  pagination?: unknown;
+}
+
+interface PokeDataCardListPayload {
+  cards?: Array<Record<string, unknown>>;
+  pagination?: unknown;
+}
+
+/** Convert PokeData language string ("ENGLISH"/"JAPANESE") to Scrydex code ("EN"/"JP"). */
+function pokeDataLanguageToCode(language: unknown): string | undefined {
+  if (typeof language !== 'string') return undefined;
+  if (language === 'JAPANESE') return 'JP';
+  if (language === 'ENGLISH') return 'EN';
+  return undefined;
+}
+
+/** Reshape one PokeData set into a frontend `PokemonSet`. */
+function adaptSet(raw: Record<string, unknown>): PokemonSet {
+  return {
+    id: raw.id !== undefined ? String(raw.id) : '',
+    code: typeof raw.code === 'string' ? raw.code : '',
+    name: typeof raw.name === 'string' ? raw.name : '',
+    series: '',
+    releaseDate:
+      typeof raw.release_date === 'string'
+        ? raw.release_date
+        : typeof raw.releaseDate === 'string'
+          ? raw.releaseDate
+          : undefined,
+    language: typeof raw.language === 'string' ? raw.language : undefined,
+    languageCode: pokeDataLanguageToCode(raw.language),
+    isOnlineOnly: false,
+  };
+}
+
+/** Reshape one PokeData card into a frontend `PokemonCard` (no pricing). */
+function adaptCard(raw: Record<string, unknown>): PokemonCard {
+  const id = raw.id !== undefined ? String(raw.id) : '';
+  const number =
+    typeof raw.cardNumber === 'string'
+      ? raw.cardNumber
+      : typeof raw.number === 'string'
+        ? raw.number
+        : undefined;
+
+  return {
+    id,
+    name: typeof raw.name === 'string' ? raw.name : '',
+    number,
+    cardNumber: number,
+    rarity: typeof raw.rarity === 'string' ? raw.rarity : undefined,
+    artist: typeof raw.artist === 'string' ? raw.artist : undefined,
+    images: [],
+    variants: [],
+  };
+}
+
+/**
+ * Adapt a Path B response envelope. Returns the same `ApiResponse<T>` shape
+ * the frontend already consumes; only `data` is reshaped.
+ *
+ * `endpointHint` selects which adapter to apply. We use a hint rather than
+ * URL parsing because the canonical path includes query strings and the
+ * mapping is endpoint-driven, not URL-driven.
+ */
+export function adaptPathBEnvelope<T>(
+  envelope: ApiResponse<unknown>,
+  endpointHint: 'sets' | 'cards-by-set' | 'card-info' | 'health' | 'passthrough'
+): ApiResponse<T> {
+  if (envelope.error || envelope.data === undefined) {
+    return envelope as ApiResponse<T>;
+  }
+
+  switch (endpointHint) {
+    case 'sets': {
+      const payload = envelope.data as PokeDataSetListPayload;
+      const adapted = {
+        sets: (payload.sets ?? []).map(adaptSet),
+        pagination: payload.pagination,
+      };
+      return { ...envelope, data: adapted as unknown as T };
+    }
+
+    case 'cards-by-set': {
+      const payload = envelope.data as PokeDataCardListPayload;
+      const adapted = {
+        cards: (payload.cards ?? []).map(adaptCard),
+        pagination: payload.pagination,
+      };
+      return { ...envelope, data: adapted as unknown as T };
+    }
+
+    case 'card-info': {
+      // PokeData card detail does not match Scrydex PricingResult; return
+      // an empty pricing result so the UI degrades to "no data" rather than
+      // crashing on missing variants. Phase 2 replaces this with real data.
+      return {
+        ...envelope,
+        data: { variants: [], metadata: { fromCache: false } } as unknown as T,
+      };
+    }
+
+    case 'health':
+    case 'passthrough':
+      return envelope as ApiResponse<T>;
+  }
+}

--- a/frontend/src/lib/backends/health.ts
+++ b/frontend/src/lib/backends/health.ts
@@ -1,0 +1,55 @@
+/**
+ * Healthcheck utilities shared by all backend definitions.
+ *
+ * Each path's healthcheck must resolve within `HEALTH_TIMEOUT_MS` or it is
+ * treated as unhealthy. A path that does not respond gracefully degrades
+ * out of the toggle UI rather than producing user-visible errors.
+ */
+
+import type { BackendHealth, BackendHealthStatus } from './types';
+
+export const HEALTH_TIMEOUT_MS = 2000;
+
+/** Convert an HTTP status code to a BackendHealthStatus. */
+export function statusFromHttp(httpStatus: number): BackendHealthStatus {
+  if (httpStatus === 200) return 'healthy';
+  if (httpStatus === 207) return 'degraded';
+  return 'unhealthy';
+}
+
+/**
+ * Issue a GET to `url`, abort after `HEALTH_TIMEOUT_MS`, and return a
+ * `BackendHealth` describing the outcome. Never throws.
+ */
+export async function probeHealth(url: string): Promise<BackendHealth> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
+  const start = performance.now();
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    const latencyMs = Math.round(performance.now() - start);
+    return {
+      status: statusFromHttp(response.status),
+      latencyMs,
+      checkedAt: Date.now(),
+      message: response.ok ? undefined : `HTTP ${response.status}`,
+    };
+  } catch (error) {
+    const message =
+      (error as Error).name === 'AbortError'
+        ? `timeout after ${HEALTH_TIMEOUT_MS}ms`
+        : (error as Error).message;
+    return {
+      status: 'unhealthy',
+      checkedAt: Date.now(),
+      message,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/frontend/src/lib/backends/index.ts
+++ b/frontend/src/lib/backends/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Backend abstraction — public re-exports.
+ *
+ * Consumers should only import from `$lib/backends`; internal modules
+ * (path-a-vercel, path-b-azure, adapters/*) are implementation details.
+ */
+
+export { backendStore } from './store.svelte';
+export { pathA } from './path-a-vercel';
+export { pathB } from './path-b-azure';
+export type {
+  BackendDefinition,
+  BackendFetcher,
+  BackendHealth,
+  BackendHealthStatus,
+  BackendId,
+} from './types';

--- a/frontend/src/lib/backends/path-a-vercel.ts
+++ b/frontend/src/lib/backends/path-a-vercel.ts
@@ -1,0 +1,40 @@
+/**
+ * Path A — SvelteKit BFF on Vercel.
+ *
+ * Same Vercel deployment as the frontend itself. The fetcher is a thin
+ * pass-through that prefixes `/api` and forwards the standard envelope.
+ * This is the canonical product experience and the default path.
+ */
+
+import type { ApiResponse } from '$lib/types';
+import { probeHealth } from './health';
+import type { BackendDefinition, BackendFetcher, BackendHealth } from './types';
+
+const PATH_A_BASE = '/api';
+
+const fetcher: BackendFetcher = {
+  async fetch<T>(canonicalPath: string, init?: RequestInit): Promise<ApiResponse<T>> {
+    const response = await fetch(`${PATH_A_BASE}${canonicalPath}`, {
+      headers: { 'Content-Type': 'application/json' },
+      ...init,
+    });
+
+    // Both error and success bodies are JSON. Let the caller decide how to
+    // surface non-2xx responses; we pass the envelope through unchanged.
+    return (await response.json()) as ApiResponse<T>;
+  },
+};
+
+async function healthcheck(): Promise<BackendHealth> {
+  return probeHealth(`${PATH_A_BASE}/health`);
+}
+
+export const pathA: BackendDefinition = {
+  id: 'vercel',
+  label: 'Vercel BFF (SvelteKit)',
+  shortLabel: 'Vercel',
+  description: 'SvelteKit +server.ts routes co-deployed with the frontend on Vercel.',
+  alwaysVisible: true,
+  fetcher,
+  healthcheck,
+};

--- a/frontend/src/lib/backends/path-b-azure.ts
+++ b/frontend/src/lib/backends/path-b-azure.ts
@@ -1,0 +1,105 @@
+/**
+ * Path B — Azure API Management → Functions v4 (Consumption).
+ *
+ * The Functions code currently serves PokeData-shaped responses; the
+ * pokedata→scrydex adapter reshapes them so the frontend can consume both
+ * paths interchangeably. The adapter is removed in Phase 2 along with the
+ * Functions schema migration.
+ *
+ * Base URL is configurable via the public env var
+ * `PUBLIC_AZURE_API_BASE_URL`. Until the `api.pcpc.maber.io` custom domain
+ * is provisioned in Phase 1B, the default points at the dev APIM hostname.
+ */
+
+import { env } from '$env/dynamic/public';
+import type { ApiResponse } from '$lib/types';
+import { probeHealth } from './health';
+import {
+  adaptPathBEnvelope,
+} from './adapters/pokedata-to-scrydex';
+import type { BackendDefinition, BackendFetcher, BackendHealth } from './types';
+
+/**
+ * Path B base URL.
+ *
+ * Falls back to the dev APIM hostname so the toggle works out-of-the-box
+ * for local dev without env-var setup. Each Vercel deployment should set
+ * PUBLIC_AZURE_API_BASE_URL to the matching custom domain once Phase 1B
+ * provisions them:
+ *   dev      → https://dev-api.pcpc.maber.io
+ *   staging  → https://staging-api.pcpc.maber.io
+ *   prod     → https://api.pcpc.maber.io
+ */
+const PATH_B_BASE = (() => {
+  const fromEnv = env.PUBLIC_AZURE_API_BASE_URL;
+  if (fromEnv && fromEnv.length > 0) return fromEnv.replace(/\/$/, '');
+  return 'https://pcpc-apim-dev.azure-api.net/pcpc-api/v1';
+})();
+
+type EndpointHint = Parameters<typeof adaptPathBEnvelope>[1];
+
+/**
+ * Translate the canonical path the frontend produces into a Path B URL +
+ * an endpoint hint for the response adapter. `canonicalPath` always
+ * starts with `/`.
+ *
+ *   Frontend canonical               Path B target                       hint
+ *   /sets?language=en&all=true   →   /sets?language=ENGLISH&all=true     sets
+ *   /sets/sv8/cards              →   /sets/sv8/cards                     cards-by-set
+ *   /sets/sv8/cards/12345        →   /sets/sv8/cards/12345               card-info
+ *   /health                      →   /health                             health
+ */
+function translateCanonicalPath(
+  canonicalPath: string
+): { url: string; hint: EndpointHint } {
+  const [pathPart, queryPart = ''] = canonicalPath.split('?');
+  const params = new URLSearchParams(queryPart);
+
+  // Translate language codes Scrydex → PokeData.
+  const language = params.get('language');
+  if (language) {
+    if (language === 'en') params.set('language', 'ENGLISH');
+    else if (language === 'ja' || language === 'jp') params.set('language', 'JAPANESE');
+  }
+
+  let hint: EndpointHint = 'passthrough';
+  if (pathPart === '/sets') hint = 'sets';
+  else if (/^\/sets\/[^/]+\/cards\/[^/]+$/.test(pathPart)) hint = 'card-info';
+  else if (/^\/sets\/[^/]+\/cards$/.test(pathPart)) hint = 'cards-by-set';
+  else if (pathPart === '/health') hint = 'health';
+
+  const query = params.toString();
+  const url = `${PATH_B_BASE}${pathPart}${query ? `?${query}` : ''}`;
+  return { url, hint };
+}
+
+const fetcher: BackendFetcher = {
+  async fetch<T>(canonicalPath: string, init?: RequestInit): Promise<ApiResponse<T>> {
+    const { url, hint } = translateCanonicalPath(canonicalPath);
+
+    const response = await fetch(url, {
+      headers: { 'Content-Type': 'application/json' },
+      ...init,
+    });
+
+    const envelope = (await response.json()) as ApiResponse<unknown>;
+    return adaptPathBEnvelope<T>(envelope, hint);
+  },
+};
+
+async function healthcheck(): Promise<BackendHealth> {
+  return probeHealth(`${PATH_B_BASE}/health`);
+}
+
+export const pathB: BackendDefinition = {
+  id: 'azure',
+  label: 'APIM + Azure Functions',
+  shortLabel: 'Azure',
+  description:
+    'Azure API Management (Consumption) routing to Azure Functions v4 (Node.js 22).',
+  alwaysVisible: false,
+  fetcher,
+  healthcheck,
+};
+
+export const __PATH_B_BASE_FOR_TESTS = PATH_B_BASE;

--- a/frontend/src/lib/backends/store.svelte.ts
+++ b/frontend/src/lib/backends/store.svelte.ts
@@ -1,0 +1,179 @@
+/**
+ * Backend selection store (Svelte 5 runes).
+ *
+ * Responsibilities:
+ *   - Hold the currently active `BackendDefinition`.
+ *   - Sync to/from the `?backend=` URL query parameter.
+ *   - Persist the user's last choice in localStorage so toggling survives
+ *     page reloads.
+ *   - Run an initial healthcheck for every registered backend and refresh
+ *     periodically.
+ *   - Auto-fall-back to the default backend if the active one becomes
+ *     unhealthy.
+ */
+
+import { browser } from '$app/environment';
+import { createContextLogger } from '$lib/services/logger';
+import { pathA } from './path-a-vercel';
+import { pathB } from './path-b-azure';
+import type {
+  BackendDefinition,
+  BackendHealth,
+  BackendId,
+} from './types';
+
+const log = createContextLogger('backendStore');
+
+const STORAGE_KEY = 'pcpc_active_backend';
+const QUERY_PARAM = 'backend';
+const HEALTH_REFRESH_MS = 60_000;
+
+const REGISTRY: Record<BackendId, BackendDefinition> = {
+  vercel: pathA,
+  azure: pathB,
+};
+
+const ALL: BackendDefinition[] = [pathA, pathB];
+
+const DEFAULT_ID: BackendId = 'vercel';
+
+function isBackendId(value: string | null): value is BackendId {
+  return value === 'vercel' || value === 'azure';
+}
+
+function readUrlBackendId(): BackendId | null {
+  if (!browser) return null;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get(QUERY_PARAM);
+  return isBackendId(value) ? value : null;
+}
+
+function readStoredBackendId(): BackendId | null {
+  if (!browser) return null;
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    return isBackendId(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredBackendId(id: BackendId): void {
+  if (!browser) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    /* quota errors ignored */
+  }
+}
+
+function writeUrlBackendId(id: BackendId): void {
+  if (!browser) return;
+  const url = new URL(window.location.href);
+  if (id === DEFAULT_ID) {
+    url.searchParams.delete(QUERY_PARAM);
+  } else {
+    url.searchParams.set(QUERY_PARAM, id);
+  }
+  history.replaceState(history.state, '', url.toString());
+}
+
+function resolveInitialId(): BackendId {
+  return readUrlBackendId() ?? readStoredBackendId() ?? DEFAULT_ID;
+}
+
+function createBackendStore() {
+  let activeId: BackendId = $state(DEFAULT_ID);
+  const healthMap: Record<BackendId, BackendHealth> = $state({
+    vercel: { status: 'unknown' },
+    azure: { status: 'unknown' },
+  });
+
+  let pollHandle: ReturnType<typeof setInterval> | null = null;
+
+  function setActive(id: BackendId): void {
+    if (!REGISTRY[id]) return;
+    if (activeId === id) return;
+    activeId = id;
+    writeStoredBackendId(id);
+    writeUrlBackendId(id);
+    log.info(`Active backend → ${id}`);
+  }
+
+  async function refreshHealth(id: BackendId): Promise<BackendHealth> {
+    const def = REGISTRY[id];
+    try {
+      const result = await def.healthcheck();
+      healthMap[id] = result;
+      return result;
+    } catch (err) {
+      const result: BackendHealth = {
+        status: 'unhealthy',
+        checkedAt: Date.now(),
+        message: (err as Error).message,
+      };
+      healthMap[id] = result;
+      return result;
+    }
+  }
+
+  async function refreshAllHealth(): Promise<void> {
+    await Promise.all(ALL.map((def) => refreshHealth(def.id)));
+    // If the active backend went unhealthy and the default is healthy,
+    // fall back automatically. Don't override a user-pinned choice that
+    // happens to be unhealthy if the alternative is also unhealthy.
+    const activeHealth = healthMap[activeId];
+    if (
+      activeId !== DEFAULT_ID &&
+      activeHealth.status === 'unhealthy' &&
+      healthMap[DEFAULT_ID].status !== 'unhealthy'
+    ) {
+      log.warn(
+        `Active backend "${activeId}" is unhealthy; reverting to "${DEFAULT_ID}"`
+      );
+      setActive(DEFAULT_ID);
+    }
+  }
+
+  function init(): void {
+    if (!browser) return;
+    activeId = resolveInitialId();
+    writeUrlBackendId(activeId);
+    writeStoredBackendId(activeId);
+    void refreshAllHealth();
+    if (pollHandle === null) {
+      pollHandle = setInterval(() => {
+        void refreshAllHealth();
+      }, HEALTH_REFRESH_MS);
+    }
+  }
+
+  return {
+    /** All registered backends in declaration order. */
+    get all() {
+      return ALL;
+    },
+    /** ID of the currently active backend. */
+    get activeId() {
+      return activeId;
+    },
+    /** Active `BackendDefinition`. */
+    get active() {
+      return REGISTRY[activeId];
+    },
+    /** Latest health snapshot for every backend. */
+    get health() {
+      return healthMap;
+    },
+    /** Default backend ID (the user-facing fallback). */
+    get defaultId() {
+      return DEFAULT_ID;
+    },
+    setActive,
+    refreshHealth,
+    refreshAllHealth,
+    init,
+  };
+}
+
+export const backendStore = createBackendStore();

--- a/frontend/src/lib/backends/types.ts
+++ b/frontend/src/lib/backends/types.ts
@@ -1,0 +1,54 @@
+/**
+ * Backend abstraction types
+ *
+ * The frontend talks to a single `BackendDefinition` at a time. Switching
+ * paths (?backend=vercel|azure) swaps the active definition; everything
+ * downstream — routes, stores, services — stays unchanged.
+ *
+ * See docs/PORTFOLIO_PLAN.md (Phase 1) and docs/adr/ADR-008 for context.
+ */
+
+import type { ApiResponse } from '$lib/types';
+
+export type BackendId = 'vercel' | 'azure';
+
+/**
+ * Health states map directly onto the existing /api/health response codes:
+ *   200 → healthy, 207 → degraded, 503 → unhealthy.
+ * `unknown` covers the pre-first-check window so the UI can render a
+ * neutral state rather than incorrectly claiming a path is broken.
+ */
+export type BackendHealthStatus =
+  | 'healthy'
+  | 'degraded'
+  | 'unhealthy'
+  | 'unknown';
+
+export interface BackendHealth {
+  status: BackendHealthStatus;
+  latencyMs?: number;
+  checkedAt?: number;
+  message?: string;
+}
+
+/**
+ * A `BackendFetcher` accepts the same path strings the existing api.ts
+ * service produces (e.g. `/sets?language=en&all=true`) and returns the
+ * canonical Scrydex-shaped envelope. Path A is a thin pass-through;
+ * Path B translates query params and reshapes responses via the
+ * pokedata→scrydex adapter (removed in Phase 2).
+ */
+export interface BackendFetcher {
+  fetch<T>(canonicalPath: string, init?: RequestInit): Promise<ApiResponse<T>>;
+}
+
+export interface BackendDefinition {
+  id: BackendId;
+  label: string;
+  shortLabel: string;
+  description: string;
+  /** Always-on backends are visible in the toggle even before the first healthcheck. */
+  alwaysVisible: boolean;
+  fetcher: BackendFetcher;
+  healthcheck: () => Promise<BackendHealth>;
+}

--- a/frontend/src/lib/components/BackendToggle.svelte
+++ b/frontend/src/lib/components/BackendToggle.svelte
@@ -1,0 +1,346 @@
+<script lang="ts">
+  /**
+   * BackendToggle — corner badge that surfaces and switches the active
+   * backend. Healthcheck-driven graceful degradation: backends whose
+   * healthcheck does not return healthy/degraded within
+   * HEALTH_TIMEOUT_MS are dimmed and unselectable. The default backend
+   * (Path A) is always visible.
+   *
+   * Click the badge to open a small popover listing every registered
+   * backend with status + latency. Selecting one mutates the URL,
+   * persists the choice in localStorage, and triggers a page-state
+   * refresh by reloading the home route's data.
+   */
+
+  import { onMount } from 'svelte';
+  import { backendStore } from '$lib/backends';
+  import type { BackendDefinition, BackendHealthStatus } from '$lib/backends';
+
+  let isOpen = $state(false);
+  let buttonRef: HTMLButtonElement | null = $state(null);
+
+  let activeId = $derived(backendStore.activeId);
+  let active = $derived(backendStore.active);
+  let health = $derived(backendStore.health);
+
+  let activeStatus: BackendHealthStatus = $derived(health[activeId].status);
+  let activeLatency = $derived(health[activeId].latencyMs);
+
+  function statusDot(status: BackendHealthStatus): string {
+    if (status === 'healthy') return '●';
+    if (status === 'degraded') return '◐';
+    if (status === 'unhealthy') return '○';
+    return '◌';
+  }
+
+  function statusLabel(status: BackendHealthStatus): string {
+    if (status === 'healthy') return 'healthy';
+    if (status === 'degraded') return 'degraded';
+    if (status === 'unhealthy') return 'unhealthy';
+    return 'checking…';
+  }
+
+  function isSelectable(def: BackendDefinition): boolean {
+    if (def.alwaysVisible) return true;
+    const status = health[def.id].status;
+    return status === 'healthy' || status === 'degraded';
+  }
+
+  function visibleBackends(): BackendDefinition[] {
+    return backendStore.all.filter(
+      (def) => def.alwaysVisible || isSelectable(def) || def.id === activeId
+    );
+  }
+
+  function handleSelect(def: BackendDefinition): void {
+    if (!isSelectable(def)) return;
+    backendStore.setActive(def.id);
+    isOpen = false;
+    // Reload so stores re-fetch through the new backend. A soft
+    // re-fetch would also work but means re-coordinating every store;
+    // a full reload is the most honest demonstration of the swap.
+    if (typeof window !== 'undefined') {
+      window.location.reload();
+    }
+  }
+
+  function handleClickOutside(event: MouseEvent): void {
+    if (!isOpen) return;
+    const target = event.target as Node;
+    if (buttonRef && !buttonRef.contains(target)) {
+      isOpen = false;
+    }
+  }
+
+  function handleKey(event: KeyboardEvent): void {
+    if (event.key === 'Escape' && isOpen) isOpen = false;
+  }
+
+  onMount(() => {
+    backendStore.init();
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKey);
+    };
+  });
+</script>
+
+<div class="backend-toggle" data-status={activeStatus}>
+  <button
+    bind:this={buttonRef}
+    class="badge"
+    type="button"
+    aria-haspopup="menu"
+    aria-expanded={isOpen}
+    aria-label={`Backend: ${active.shortLabel} (${statusLabel(activeStatus)}). Click to switch.`}
+    onclick={() => (isOpen = !isOpen)}
+  >
+    <span class="dot" aria-hidden="true">{statusDot(activeStatus)}</span>
+    <span class="label">{active.shortLabel}</span>
+    {#if activeLatency !== undefined}
+      <span class="latency">{activeLatency}ms</span>
+    {/if}
+  </button>
+
+  {#if isOpen}
+    <div class="popover" role="menu">
+      <div class="popover-header">
+        <span class="popover-title">Backend</span>
+        <span class="popover-help">?backend=…</span>
+      </div>
+      <ul class="options">
+        {#each visibleBackends() as def (def.id)}
+          {@const status = health[def.id].status}
+          {@const latency = health[def.id].latencyMs}
+          {@const selectable = isSelectable(def)}
+          <li>
+            <button
+              type="button"
+              class="option"
+              class:active={def.id === activeId}
+              class:disabled={!selectable}
+              role="menuitemradio"
+              aria-checked={def.id === activeId}
+              aria-disabled={!selectable}
+              disabled={!selectable && def.id !== activeId}
+              onclick={() => handleSelect(def)}
+            >
+              <span class="option-row">
+                <span class="option-dot" data-status={status} aria-hidden="true">
+                  {statusDot(status)}
+                </span>
+                <span class="option-label">{def.label}</span>
+                {#if latency !== undefined}
+                  <span class="option-latency">{latency}ms</span>
+                {/if}
+              </span>
+              <span class="option-desc">{def.description}</span>
+              {#if !selectable && def.id !== activeId}
+                <span class="option-note">unavailable — {statusLabel(status)}</span>
+              {/if}
+            </button>
+          </li>
+        {/each}
+      </ul>
+      <div class="popover-footer">
+        <a
+          href="https://github.com/Abernaughty/PCPC/blob/main/docs/architecture-comparison.md"
+          target="_blank"
+          rel="noopener"
+        >
+          Compare architectures →
+        </a>
+      </div>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .backend-toggle {
+    position: fixed;
+    right: 16px;
+    bottom: 16px;
+    z-index: 50;
+    font-family: var(--font-sans, system-ui, sans-serif);
+    font-size: 12px;
+    line-height: 1;
+  }
+
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    background: rgba(20, 20, 20, 0.78);
+    color: #f5f5f5;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    cursor: pointer;
+    backdrop-filter: blur(8px);
+    transition: background 120ms ease, border-color 120ms ease;
+  }
+
+  .badge:hover {
+    background: rgba(40, 40, 40, 0.88);
+    border-color: rgba(255, 255, 255, 0.22);
+  }
+
+  .dot {
+    font-size: 10px;
+    line-height: 1;
+  }
+
+  .backend-toggle[data-status='healthy'] .dot {
+    color: #4ade80;
+  }
+  .backend-toggle[data-status='degraded'] .dot {
+    color: #facc15;
+  }
+  .backend-toggle[data-status='unhealthy'] .dot {
+    color: #f87171;
+  }
+  .backend-toggle[data-status='unknown'] .dot {
+    color: #94a3b8;
+  }
+
+  .label {
+    font-weight: 500;
+    letter-spacing: 0.01em;
+  }
+
+  .latency {
+    color: #cbd5e1;
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+  }
+
+  .popover {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 8px);
+    min-width: 280px;
+    background: rgba(15, 15, 15, 0.95);
+    color: #f5f5f5;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 10px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(12px);
+    overflow: hidden;
+  }
+
+  .popover-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 10px 12px 6px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .popover-title {
+    font-weight: 600;
+    font-size: 12px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #e2e8f0;
+  }
+
+  .popover-help {
+    color: #94a3b8;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+  }
+
+  .options {
+    list-style: none;
+    margin: 0;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .option {
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    color: inherit;
+    border: none;
+    border-radius: 6px;
+    padding: 8px 10px;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .option:hover:not(.disabled) {
+    background: rgba(255, 255, 255, 0.06);
+  }
+
+  .option.active {
+    background: rgba(74, 222, 128, 0.08);
+  }
+
+  .option.disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+  }
+
+  .option-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .option-dot[data-status='healthy'] {
+    color: #4ade80;
+  }
+  .option-dot[data-status='degraded'] {
+    color: #facc15;
+  }
+  .option-dot[data-status='unhealthy'] {
+    color: #f87171;
+  }
+  .option-dot[data-status='unknown'] {
+    color: #94a3b8;
+  }
+
+  .option-label {
+    flex: 1;
+    font-weight: 500;
+  }
+
+  .option-latency {
+    color: #cbd5e1;
+    font-variant-numeric: tabular-nums;
+    font-size: 11px;
+  }
+
+  .option-desc {
+    color: #94a3b8;
+    font-size: 11px;
+    line-height: 1.4;
+  }
+
+  .option-note {
+    color: #f87171;
+    font-size: 11px;
+  }
+
+  .popover-footer {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 8px 12px;
+  }
+
+  .popover-footer a {
+    color: #93c5fd;
+    text-decoration: none;
+    font-size: 11px;
+  }
+
+  .popover-footer a:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/frontend/src/lib/components/index.ts
+++ b/frontend/src/lib/components/index.ts
@@ -18,3 +18,4 @@ export { default as TrendSparkline } from './TrendSparkline.svelte';
 export { default as PriceCard } from './PriceCard.svelte';
 export { default as PriceDetailChart } from './PriceDetailChart.svelte';
 export { default as CompareChart } from './CompareChart.svelte';
+export { default as BackendToggle } from './BackendToggle.svelte';

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -1,5 +1,14 @@
 /**
- * API Service - Frontend calls to SvelteKit API routes
+ * API Service - Frontend calls to the active backend.
+ *
+ * The active backend is owned by `backendStore` (see $lib/backends). This
+ * service builds canonical paths (e.g. `/sets?language=en`) and hands them
+ * to the active backend's fetcher. Each backend is responsible for
+ * translating the canonical path into its own URL and reshaping responses
+ * into the canonical Scrydex envelope before returning.
+ *
+ * That seam is what lets `?backend=vercel|azure` swap implementations
+ * without any other consumer noticing.
  */
 
 import type {
@@ -8,9 +17,8 @@ import type {
   PricingResult,
   ApiResponse,
 } from '$lib/types';
+import { backendStore } from '$lib/backends';
 import { logger } from './logger';
-
-const API_BASE = '/api';
 
 /**
  * Map our LanguageFilter values to Scrydex API language codes.
@@ -22,45 +30,39 @@ function mapLanguageCode(lang: string): string {
 }
 
 /**
- * Generic API fetch wrapper with error handling
+ * Generic API fetch wrapper with error handling.
+ *
+ * Routes through whichever `BackendDefinition` is currently active in
+ * `backendStore`. The path is canonical (Scrydex-shape, Scrydex query
+ * params); each backend's fetcher handles its own translation.
  */
 async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
-  const url = `${API_BASE}${path}`;
-  logger.debug(`API request: ${url}`);
+  const backend = backendStore.active;
+  logger.debug(`API request via ${backend.id}: ${path}`);
 
   try {
-    const response = await fetch(url, {
-      headers: { 'Content-Type': 'application/json' },
-      ...options,
-    });
-
-    if (!response.ok) {
-      const errorData = await response
-        .json()
-        .catch(() => ({ error: 'Unknown error' }));
-      const errorMsg = errorData.error || `HTTP ${response.status}`;
-      logger.error(`API error (${response.status}):`, errorMsg);
-      throw new Error(errorMsg);
-    }
-
-    const result: ApiResponse<T> = await response.json();
+    const result: ApiResponse<T> = await backend.fetcher.fetch<T>(path, options);
 
     if (result.error) {
       logger.error('API returned error:', result.error);
       throw new Error(result.error);
     }
 
-    logger.debug(`API response received for ${path}`);
-    return result.data as T;
+    if (result.data === undefined) {
+      throw new Error('API returned empty payload');
+    }
+
+    logger.debug(`API response received for ${path} via ${backend.id}`);
+    return result.data;
   } catch (err) {
-    logger.error(`API fetch failed for ${path}:`, err);
+    logger.error(`API fetch failed for ${path} via ${backend.id}:`, err);
     throw err;
   }
 }
 
 export const api = {
   /**
-   * Get all Pok\u00e9mon sets.
+   * Get all Pokémon sets.
    * @param forceRefresh - Bypass server cache
    * @param language - Language filter: 'en', 'jp', or 'both'
    */
@@ -108,7 +110,7 @@ export const api = {
   /**
    * Get full card data including pricing for a specific card.
    * The card detail route returns the full card with variants/pricing inline.
-   * This is now a fallback for deep-link entry and global search \u2014
+   * This is now a fallback for deep-link entry and global search —
    * the primary flow gets pricing from the card list fetch.
    */
   async getCardPricing(

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,6 +1,9 @@
-<script>
+<script lang="ts">
 	import '../app.css';
+	import { BackendToggle } from '$lib/components';
 	let { children } = $props();
 </script>
 
 {@render children()}
+
+<BackendToggle />


### PR DESCRIPTION
## Summary

Phase 1A of the portfolio plan ([`docs/PORTFOLIO_PLAN.md`](docs/PORTFOLIO_PLAN.md)). Local-only, fully reversible work — no Azure infra, no Terraform, no APIM changes. Phase 1B (custom domain + CORS) lands separately.

- **Backend abstraction** at `frontend/src/lib/backends/` — `BackendDefinition` per path with a `fetcher` that translates the canonical Scrydex-shape path to its own backend URL and reshapes responses back to the canonical envelope. Svelte 5 runes store syncs the active backend with the `?backend=` URL param + localStorage; polls every backend's `/health` on mount + every 60s; auto-reverts to Path A if the active backend goes unhealthy mid-session.
- **Path A — Vercel BFF** is a thin pass-through over the existing `/api/*` SvelteKit routes (the canonical product experience, default).
- **Path B — APIM + Functions** points at the dev APIM (`pcpc-apim-dev.azure-api.net/pcpc-api/v1`) by default; `PUBLIC_AZURE_API_BASE_URL` overrides for prod/staging once Phase 1B provisions `dev-api.pcpc.maber.io`, `staging-api.pcpc.maber.io`, `api.pcpc.maber.io`.
- **PokeData → Scrydex adapter** bridges the Phase 1 schema gap on the frontend so the toggle returns real data from both paths today. Adapter is removed in Phase 2 alongside the Functions schema migration. Honest about its limits — Path B card detail returns empty `variants[]` because PokeData has no per-variant pricing; the UI degrades to "no pricing available" rather than crashing.
- **BackendToggle component** — bottom-right pill showing active backend + status dot + last healthcheck latency. Click for a popover listing every registered backend with status, latency, description; healthcheck-driven graceful degradation dims unhealthy/undeployed paths. Mounted in the root `+layout`.
- **ADR-007** (API Architecture Spectrum) and **ADR-008** (APIM vs SvelteKit BFF as Gateway) — both Accepted, dated 2026-05-06. ADR-007 is the front door; ADR-008 covers the narrower gateway-shaped tradeoff between Paths A and B.
- **`docs/architecture-comparison.md`** — two-column tables across request flow, ops, scaling, security, schema. Phase 1 caveats called out explicitly. Path C lands as a third column in Phase 2.
- **README** Live Demo section rewritten with real toggle URLs, the Path B Phase 1 caveat inline, and updated phase-status table.

## Validation

- `pnpm --filter @pcpc/frontend check` — **0 errors**, 18 pre-existing warnings (all unrelated)
- `pnpm --filter @pcpc/frontend build` — Vite build succeeds (the only error locally is the Vercel adapter's Windows-symlink limitation, which doesn't affect Vercel's Linux CI)
- Vercel preview will exercise Path A; **Path B will show as "unhealthy" in the preview until Phase 1B configures CORS** for `pcpc.maber.io` + the Vercel preview origin — expected and acknowledged

## What's NOT in this PR (Phase 1B, separate)

- APIM custom domain provisioning (`dev-api.pcpc.maber.io`, etc.) with Azure-managed certs
- APIM CORS for `pcpc.maber.io`
- Cloudflare CNAME records (manual)

## Rollback

Tag `phase-1/pre-toggle-work` was pushed before this work began.

## Test plan

- [ ] Vercel preview build succeeds (Linux CI handles symlinks)
- [ ] Open the preview URL: corner badge appears, shows "Vercel" healthy with latency
- [ ] Click the badge: popover lists Vercel (active, healthy) and Azure (unhealthy — CORS expected to block)
- [ ] Default behavior: app loads sets/cards/pricing identically to pre-PR (Path A unchanged)
- [ ] `?backend=vercel` in URL: same as default
- [ ] Manually open `pcpc.maber.io/?backend=azure` after Phase 1B lands and verify the toggle now offers Azure as healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)