### PR TITLE
Phase 1B — APIM custom domains, CORS for pcpc.maber.io, /health, ADR-011

### DIFF
--- a/apim/environments/dev/main.tf
+++ b/apim/environments/dev/main.tf
@@ -34,8 +34,14 @@ provider "azurerm" {
 # -----------------------------------------------------------------------------
 
 locals {
+  # Phase 1B: the frontend is a single Vercel deployment at pcpc.maber.io
+  # plus per-PR preview URLs at pcpc-git-*.vercel.app. APIM's CORS policy
+  # accepts only literal origins (no wildcards), so dev — which is where
+  # Vercel previews exercise the toggle — uses "*" to keep preview URLs
+  # working without re-applying APIM on every PR. Staging/prod are locked
+  # down to the production frontend hostname.
   base_cors_origins = [
-    "https://pcpc-dev.maber.io"
+    "*"
   ]
 
   configured_cors_origins = length(var.cors_origins) > 0 ? var.cors_origins : local.base_cors_origins

--- a/apim/environments/prod/main.tf
+++ b/apim/environments/prod/main.tf
@@ -34,8 +34,11 @@ provider "azurerm" {
 # -----------------------------------------------------------------------------
 
 locals {
+  # Phase 1B: the frontend is a single Vercel deployment at pcpc.maber.io.
+  # Prod APIM only accepts the production frontend hostname; preview URLs
+  # are intentionally blocked here so prod data only serves the prod URL.
   base_cors_origins = [
-    "https://pcpc-prod.maber.io"
+    "https://pcpc.maber.io"
   ]
 
   configured_cors_origins = length(var.cors_origins) > 0 ? var.cors_origins : local.base_cors_origins

--- a/apim/environments/staging/main.tf
+++ b/apim/environments/staging/main.tf
@@ -34,8 +34,12 @@ provider "azurerm" {
 # -----------------------------------------------------------------------------
 
 locals {
+  # Phase 1B: the frontend is a single Vercel deployment at pcpc.maber.io.
+  # Staging APIM only accepts the production frontend hostname so toggling
+  # to ?backend=azure from pcpc.maber.io can hit the staging API for
+  # validation work, while ad-hoc origins are blocked.
   base_cors_origins = [
-    "https://pcpc-staging.maber.io"
+    "https://pcpc.maber.io"
   ]
 
   configured_cors_origins = length(var.cors_origins) > 0 ? var.cors_origins : local.base_cors_origins

--- a/apim/specs/pcpc-api-v1.yaml
+++ b/apim/specs/pcpc-api-v1.yaml
@@ -123,6 +123,38 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /health:
+    get:
+      summary: Health Check
+      description: |
+        System health check endpoint.
+
+        Returns 200 when all backend components are healthy, 207 when one
+        or more non-critical components are degraded, 503 when any
+        critical component is unhealthy.
+      operationId: get-health
+      tags:
+        - System
+      responses:
+        "200":
+          description: All components healthy
+          content:
+            application/json:
+              schema:
+                type: object
+        "207":
+          description: At least one component degraded
+          content:
+            application/json:
+              schema:
+                type: object
+        "503":
+          description: Service unhealthy
+          content:
+            application/json:
+              schema:
+                type: object
+
   "/sets/{setCode}/cards":
     get:
       summary: Get Cards By Set

--- a/apim/terraform/apis.tf
+++ b/apim/terraform/apis.tf
@@ -61,6 +61,46 @@ resource "azurerm_api_management_backend" "function_app" {
 # API OPERATIONS
 # -----------------------------------------------------------------------------
 
+# Health Check Operation — exposed through APIM so the frontend backend
+# toggle can probe Path B without bypassing the gateway. Anonymous,
+# subscription-not-required, intentionally no operation-level policy
+# (the global API policy still applies, but rate-limit calls are
+# generous enough to handle healthcheck polling).
+resource "azurerm_api_management_api_operation" "get_health" {
+  operation_id        = "get-health"
+  api_name            = azurerm_api_management_api.pcpc_api.name
+  api_management_name = var.api_management_name
+  resource_group_name = var.resource_group_name
+  display_name        = "Health Check"
+  method              = "GET"
+  url_template        = "/health"
+  description         = "System health check endpoint"
+
+  response {
+    status_code = 200
+    description = "All components healthy"
+    representation {
+      content_type = "application/json"
+    }
+  }
+
+  response {
+    status_code = 207
+    description = "At least one component degraded"
+    representation {
+      content_type = "application/json"
+    }
+  }
+
+  response {
+    status_code = 503
+    description = "Service unhealthy"
+    representation {
+      content_type = "application/json"
+    }
+  }
+}
+
 # Get Set List Operation
 resource "azurerm_api_management_api_operation" "get_sets" {
   operation_id        = "get-set-list"

--- a/apim/terraform/outputs.tf
+++ b/apim/terraform/outputs.tf
@@ -77,6 +77,11 @@ output "function_app_url" {
 output "api_operations" {
   description = "List of API operations"
   value = {
+    get_health = {
+      operation_id = azurerm_api_management_api_operation.get_health.operation_id
+      method       = azurerm_api_management_api_operation.get_health.method
+      url_template = azurerm_api_management_api_operation.get_health.url_template
+    }
     get_sets = {
       operation_id = azurerm_api_management_api_operation.get_sets.operation_id
       method       = azurerm_api_management_api_operation.get_sets.method

--- a/apim/terraform/variables.tf
+++ b/apim/terraform/variables.tf
@@ -43,17 +43,24 @@ variable "function_app_key" {
 # -----------------------------------------------------------------------------
 
 variable "cors_origins" {
-  description = "List of allowed CORS origins"
+  description = <<-EOT
+    List of allowed CORS origins. Each entry must be either:
+      - A wildcard "*" (allow any origin — appropriate for dev/preview)
+      - An HTTP/HTTPS URL (e.g. https://pcpc.maber.io)
+
+    APIM's CORS policy does not support wildcard subdomains in origins
+    (e.g. https://*.vercel.app is invalid). For environments that need to
+    accept many ephemeral origins (Vercel preview URLs), use "*".
+  EOT
   type        = list(string)
-  default = [
-    "http://localhost:3000"
-  ]
+  default     = ["http://localhost:3000"]
 
   validation {
     condition = alltrue([
-      for origin in var.cors_origins : can(regex("^https?://", origin))
+      for origin in var.cors_origins :
+      origin == "*" || can(regex("^https?://", origin))
     ])
-    error_message = "All CORS origins must be valid HTTP or HTTPS URLs."
+    error_message = "Each CORS origin must be \"*\" or a valid HTTP/HTTPS URL."
   }
 }
 

--- a/docs/adr/ADR-011-deployment-topology-and-testing-model.md
+++ b/docs/adr/ADR-011-deployment-topology-and-testing-model.md
@@ -1,0 +1,226 @@
+# ADR-011: Deployment Topology and Testing Model
+
+## Status
+
+Accepted
+
+Date: 2026-05-06
+
+## Context
+
+PCPC has three Azure environments — dev, staging, and prod — each with its
+own resource group, APIM service, Function App, Cosmos DB, storage account,
+Key Vault, App Insights, and Log Analytics workspace. The CD pipeline at
+`pipelines/ado/azure-pipelines.yml` is a single multi-stage pipeline:
+**Build → Deploy_Dev (auto) → Deploy_Staging (manual approval) →
+Deploy_Prod (manual approval)**.
+
+The three environments are not cosmetic copies. They differ in ways that
+reflect distinct operational postures:
+
+| | Dev | Staging | Prod |
+|---|---|---|---|
+| Storage replication | LRS | GRS | GRS |
+| Cosmos failover | off | on | on |
+| Log Analytics retention | 30 d | 90 d | 365 d |
+| App Insights sampling | 100% | 50% | 10% |
+| App Insights daily cap | 1 GB | 5 GB | 100 GB |
+| Alert thresholds | 10 fails | 10 fails | 5 fails (stricter) |
+| Terraform safety | none | none | `prevent_deletion_if_contains_resources` |
+| Key Vault on destroy | purge | purge | keep (`purge_soft_delete_on_destroy = false`) |
+| APIM CORS (Phase 1B) | `*` | `https://pcpc.maber.io` | `https://pcpc.maber.io` |
+| Custom hostname (Phase 1B) | `dev-api.pcpc.maber.io` | `staging-api.pcpc.maber.io` | `api.pcpc.maber.io` |
+
+Despite all that engineering, no ADR existed explaining *why* three
+environments. The shape was inherited convention, not a documented
+decision. That gap is the problem this ADR resolves.
+
+A second issue surfaced during Phase 1B planning: the frontend is a single
+Vercel deployment at `pcpc.maber.io` with three Vercel scopes (Production,
+Preview, Development). With one Vercel deployment and three Azure backends,
+how does staging get tested? It doesn't have a corresponding frontend URL,
+so a naive "you visit staging at staging.pcpc.maber.io" model isn't
+available. Either staging needs a separate Vercel deployment (operationally
+heavy for one developer), or staging needs a different testing model than
+dev and prod.
+
+A third question — was three environments financially justifiable? — was
+investigated and resolved during planning. At Consumption-tier SKUs and
+portfolio traffic, the all-three total runs roughly $6–45/month, which sits
+inside the project's stated $10–25/month target when traffic is low. Cost
+is not the deciding factor; the testing model is.
+
+## Decision
+
+**Keep all three Azure environments (dev/staging/prod) and define
+their testing layers explicitly.**
+
+The three environments serve three distinct purposes, mapped to three
+testing layers:
+
+### Layer 1 — Infrastructure / API validation (staging's actual job)
+
+Each environment has its own ADO stage that runs:
+- `terraform validate` and `terraform plan`
+- `terraform apply` (gated by manual approval for staging and prod)
+- Smoke tests (curl-based) directly against the env's APIM hostname
+
+**Staging is the gate that catches IaC and API regressions before prod.**
+Promotion is gated by manual approval in ADO. The gate's value is "the
+Terraform plan applied cleanly + the smoke tests passed against the
+staging APIM," not "an engineer dogfooded staging in a browser." This is
+why staging is worth keeping despite having no frontend consumer.
+
+### Layer 2 — Frontend integration testing
+
+The Vercel deployment uses Vercel's three scopes to map cleanly onto the
+backend environments:
+
+| Vercel scope | Where it applies | `PUBLIC_AZURE_API_BASE_URL` |
+|---|---|---|
+| Production | `pcpc.maber.io` (live demo) | `https://api.pcpc.maber.io` |
+| Preview | every PR's `*.vercel.app` URL | `https://dev-api.pcpc.maber.io` |
+| Development | `vercel dev` locally | `https://dev-api.pcpc.maber.io` |
+
+PR previews exercise the dev backend; the production deploy exercises the
+prod backend. **Staging APIM is intentionally not mapped to any Vercel
+scope.** It has no frontend consumer by design.
+
+### Layer 3 — On-demand env switching from the live site
+
+Out of scope for Phase 1. Could be added later by extending
+`BackendToggle` (see [ADR-007](./ADR-007-api-architecture-spectrum.md))
+with a `?apiBase=<url>` URL-param override (~30 LOC). Not pursued now
+because Layer 1 + Layer 2 covers actual portfolio needs and adding Layer 3
+without a concrete use case would be feature creep.
+
+## Consequences
+
+### Positive
+
+- **Honest staging.** Staging's purpose is well-scoped: catch infra and API
+  regressions before prod via CI smoke tests. It's not pretending to be a
+  browser-testing environment, and the lack of a frontend mapping is a
+  feature, not a gap.
+- **Real promotion gate.** Manual approval between dev → staging → prod is
+  a meaningful demonstration of enterprise CD discipline, not theatre.
+- **Audience-flexibility goal preserved.** Three envs read as enterprise
+  IaC competence; the clean per-env divergence (retention, sampling,
+  alerts, safety flags) shows the engineer understands *why* envs differ,
+  not just *that* they should. The decision-doc-explaining-the-choice is
+  itself a senior signal.
+- **Within budget.** Three envs at portfolio traffic stay within the
+  $10–25/month target documented in `docs/PORTFOLIO_PLAN.md`. No financial
+  pressure to simplify.
+- **Cleanly composable with Vercel scopes.** The Vercel
+  Production/Preview/Development model maps onto two of the three Azure
+  envs (prod ← Production, dev ← Preview/Development) without contortion.
+- **Easy to evolve.** If a Layer 3 need ever materializes (e.g. adding
+  manual browser regression against staging), it's a small addition to
+  `BackendToggle`, not a rework.
+
+### Negative
+
+- **Three Cloudflare CNAMEs to manage manually.** `dev-api`, `staging-api`,
+  and `api`, each as DNS-only records. The maintenance burden is small
+  (set once) but real.
+- **Two manual approval gates per release.** Staging then prod. For a
+  one-developer project, this is also two manual clicks. Acceptable but
+  worth noting.
+- **Staging is never browser-tested by default.** Engineers must trust
+  pipeline smoke tests for staging. If a frontend regression shows up only
+  against staging-shaped data, it won't be caught until prod. Mitigated by
+  Path B serving the same Cosmos data across all three envs (no per-env
+  data divergence).
+- **No "easy" way to point the live site at staging for ad-hoc browser
+  testing without redeploying with a different env var.** This is the
+  Layer 3 gap. Acceptable for now; Layer 3 work documented as a future
+  enhancement.
+
+## Alternatives Considered
+
+### Option A — Drop staging; use dev + prod only
+
+- **Pros:** Half the operational surface; only two CNAMEs and one approval
+  gate per release; cleaner repo (delete staging Terraform code, env
+  config, and pipeline stage); ~$4–30/month vs ~$6–45/month.
+- **Cons:** Loses the explicit pre-prod gate that staging provides. Any
+  IaC or API regression goes straight to prod after dev passes. The
+  enterprise multi-env IaC story shrinks. Reverting to three envs later
+  is not free — staging would need to be re-introduced from scratch.
+- **Reason for rejection:** The marginal cost of staging is low (one extra
+  pipeline stage, one CNAME, one approval click), and the value of having
+  a real promotion gate before prod is worth more in the portfolio
+  narrative than the operational simplification is worth in actual ops
+  effort.
+
+### Option B — Single environment (rename dev → "live")
+
+- **Pros:** Most aggressive simplification. One Azure env serving the
+  live demo. One CNAME. Cheapest possible footprint (~$2–15/month).
+- **Cons:** Demolishes the multi-env IaC demonstration almost entirely.
+  Loses both the dev-vs-prod separation and the promotion-gate story.
+  Sends a signal that the engineer doesn't understand or can't
+  operationalize multi-env patterns — the opposite of what the portfolio
+  is trying to demonstrate. A real production deploy with no separate
+  dev environment is amateur, not pragmatic.
+- **Reason for rejection:** Audience-flexibility goal is explicitly
+  stated in `docs/PORTFOLIO_PLAN.md`. Single-env collapses the enterprise
+  audience entirely.
+
+### Option C — Per-env Vercel deployments matching per-env APIMs
+
+- **Pros:** Closest to "real enterprise product" shape. Each frontend
+  env hits its matching backend env. Browser-level testing of all three
+  envs is trivial.
+- **Cons:** Operationally heavy for one developer (three Vercel projects,
+  three production domains, possibly per-env git branches with branch
+  protection). Loses the "one URL, swap at runtime" headline UX that's
+  the centerpiece of [ADR-007](./ADR-007-api-architecture-spectrum.md).
+  The multi-Vercel pattern doesn't match the portfolio's single-frontend
+  thesis.
+- **Reason for rejection:** Conflicts with ADR-007's explicit choice of
+  one URL with a runtime backend toggle. Adopting Option C would require
+  retracting that decision.
+
+### Option D — Extend BackendToggle with `?apiBase=<url>` URL override
+
+- **Pros:** Lets any Vercel deploy point at any backend env via URL
+  parameter. Most composable, ~30 LOC. Strongest "the toggle is a
+  general-purpose backend probe" portfolio story.
+- **Cons:** Adds a runtime feature with no concrete current use case.
+  The `?backend=` parameter already lets visitors swap between Vercel
+  BFF and Azure APIM; this would add the ability to point at *which*
+  Azure APIM, but the only consumer is "an engineer manually testing
+  staging from the prod URL," which can be solved by visiting the
+  staging API directly with curl/Postman.
+- **Reason for rejection (for now):** No concrete current need. Flagged
+  as a future Layer 3 enhancement if the use case materializes.
+
+## Implementation Notes
+
+This ADR codifies the existing topology rather than introducing it. The
+three-environment Terraform structure already existed in
+`infra/envs/{dev,staging,prod}/` and `apim/environments/{dev,staging,prod}/`
+before this ADR was written. The ADO pipeline at
+`pipelines/ado/azure-pipelines.yml` already implemented the
+Build → Dev → Staging → Prod sequence with manual approval gates.
+
+What Phase 1B adds on top of that pre-existing structure:
+- Custom hostnames per env (`dev-api`, `staging-api`, `api`) via the new
+  `gateway_hostnames` variable on the api-management module
+- CORS retarget per env (dev=`*`, staging/prod=`https://pcpc.maber.io`)
+- `/health` exposure through APIM so the BackendToggle's healthcheck can
+  probe Path B without bypassing the gateway
+
+The Vercel env var mapping (Production → prod APIM, Preview → dev APIM,
+Development → dev APIM) is documented in the Phase 1B PR body and in
+`docs/architecture-comparison.md`. It is operator-managed (set in Vercel
+project settings), not Terraform-managed.
+
+## Related Decisions
+
+- [ADR-007: API Architecture Spectrum (three paths)](./ADR-007-api-architecture-spectrum.md)
+- [ADR-008: APIM vs SvelteKit BFF as Gateway](./ADR-008-apim-vs-bff-gateway.md)
+- ADR-009: Functions Consumption vs Container Apps *(planned, Phase 2)*
+- ADR-010: Path to AKS *(planned, Phase 3, optional)*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -28,6 +28,7 @@ Each ADR follows a standardized format:
 | [ADR-004](./ADR-004-devcontainer-acr-optimization.md) | DevContainer ACR Optimization | Accepted | 2025-09-28 |
 | [ADR-005](./ADR-005-database-schema-design.md) | Database Schema Design | Accepted | 2025-09-28 |
 | [ADR-006](./ADR-006-api-integration-strategy.md) | API Integration Strategy | Accepted | 2025-09-22 |
+| [ADR-011](./ADR-011-deployment-topology-and-testing-model.md) | Deployment Topology and Testing Model | Accepted | 2026-05-06 |
 
 ### Planned (three-path portfolio story)
 

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -366,6 +366,11 @@ module "api_management" {
   publisher_email = var.apim_publisher_email
   sku_name        = var.apim_sku_name
 
+  # Phase 1B: bind dev-api.pcpc.maber.io to the gateway with an Azure-managed
+  # cert. The CNAME record (dev-api.pcpc.maber.io -> pcpc-apim-dev.azure-api.net)
+  # must exist in Cloudflare before this applies.
+  gateway_hostnames = var.apim_gateway_hostnames
+
   tags = local.common_tags
 
   depends_on = [module.resource_group]

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -280,6 +280,22 @@ variable "apim_sku_name" {
   default     = "Consumption_0"
 }
 
+variable "apim_gateway_hostnames" {
+  description = <<-EOT
+    Custom hostnames for the APIM gateway in this environment. Each hostname
+    requires a CNAME record in Cloudflare pointing at pcpc-apim-dev.azure-api.net
+    BEFORE `terraform apply`, otherwise Azure-managed cert provisioning will hang.
+    Default uses the dev-api.pcpc.maber.io hostname per Phase 1B.
+  EOT
+  type = list(object({
+    host_name           = string
+    default_ssl_binding = optional(bool, false)
+  }))
+  default = [
+    { host_name = "dev-api.pcpc.maber.io", default_ssl_binding = true }
+  ]
+}
+
 # Log Analytics Configuration
 variable "log_analytics_sku" {
   description = "The SKU of the Log Analytics workspace"

--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -382,6 +382,11 @@ module "api_management" {
   publisher_email = var.apim_publisher_email
   sku_name        = var.apim_sku_name
 
+  # Phase 1B: bind api.pcpc.maber.io to the gateway with an Azure-managed
+  # cert. The CNAME record (api.pcpc.maber.io -> pcpc-apim-prod.azure-api.net)
+  # must exist in Cloudflare before this applies.
+  gateway_hostnames = var.apim_gateway_hostnames
+
   tags = local.common_tags
 
   depends_on = [module.resource_group]

--- a/infra/envs/prod/variables.tf
+++ b/infra/envs/prod/variables.tf
@@ -275,6 +275,22 @@ variable "apim_sku_name" {
   default     = "Consumption_0" # Can upgrade to Standard/Premium for production needs
 }
 
+variable "apim_gateway_hostnames" {
+  description = <<-EOT
+    Custom hostnames for the APIM gateway in this environment. Each hostname
+    requires a CNAME record in Cloudflare pointing at pcpc-apim-prod.azure-api.net
+    BEFORE `terraform apply`, otherwise Azure-managed cert provisioning will hang.
+    Default uses the api.pcpc.maber.io hostname per Phase 1B.
+  EOT
+  type = list(object({
+    host_name           = string
+    default_ssl_binding = optional(bool, false)
+  }))
+  default = [
+    { host_name = "api.pcpc.maber.io", default_ssl_binding = true }
+  ]
+}
+
 # Log Analytics Configuration
 variable "log_analytics_sku" {
   description = "The SKU of the Log Analytics workspace"

--- a/infra/envs/staging/main.tf
+++ b/infra/envs/staging/main.tf
@@ -364,6 +364,12 @@ module "api_management" {
   publisher_email = var.apim_publisher_email
   sku_name        = var.apim_sku_name
 
+  # Phase 1B: bind staging-api.pcpc.maber.io to the gateway with an
+  # Azure-managed cert. The CNAME record (staging-api.pcpc.maber.io ->
+  # pcpc-apim-staging.azure-api.net) must exist in Cloudflare before
+  # this applies.
+  gateway_hostnames = var.apim_gateway_hostnames
+
   tags = local.common_tags
 
   depends_on = [module.resource_group]

--- a/infra/envs/staging/variables.tf
+++ b/infra/envs/staging/variables.tf
@@ -275,6 +275,22 @@ variable "apim_sku_name" {
   default     = "Consumption_0"
 }
 
+variable "apim_gateway_hostnames" {
+  description = <<-EOT
+    Custom hostnames for the APIM gateway in this environment. Each hostname
+    requires a CNAME record in Cloudflare pointing at pcpc-apim-staging.azure-api.net
+    BEFORE `terraform apply`, otherwise Azure-managed cert provisioning will hang.
+    Default uses the staging-api.pcpc.maber.io hostname per Phase 1B.
+  EOT
+  type = list(object({
+    host_name           = string
+    default_ssl_binding = optional(bool, false)
+  }))
+  default = [
+    { host_name = "staging-api.pcpc.maber.io", default_ssl_binding = true }
+  ]
+}
+
 # Log Analytics Configuration
 variable "log_analytics_sku" {
   description = "The SKU of the Log Analytics workspace"

--- a/infra/modules/api-management/main.tf
+++ b/infra/modules/api-management/main.tf
@@ -61,6 +61,25 @@ resource "azurerm_api_management" "this" {
     type = var.identity_type
   }
 
+  # Custom hostnames bound to the gateway with Azure-managed TLS certs.
+  # See variables.tf for the CNAME-must-exist-first precondition. The block
+  # is skipped entirely when no hostnames are configured so the resource
+  # remains idempotent for envs that haven't enabled custom domains yet.
+  dynamic "hostname_configuration" {
+    for_each = length(var.gateway_hostnames) > 0 ? [1] : []
+    content {
+      dynamic "proxy" {
+        for_each = var.gateway_hostnames
+        content {
+          host_name                    = proxy.value.host_name
+          certificate_source           = "Managed"
+          default_ssl_binding          = proxy.value.default_ssl_binding
+          negotiate_client_certificate = false
+        }
+      }
+    }
+  }
+
   timeouts {
     create = "60m"
     delete = "60m"

--- a/infra/modules/api-management/variables.tf
+++ b/infra/modules/api-management/variables.tf
@@ -148,3 +148,41 @@ variable "triple_des_enabled" {
   type        = bool
   default     = false
 }
+
+# -----------------------------------------------------------------------------
+# CUSTOM DOMAIN CONFIGURATION
+# -----------------------------------------------------------------------------
+
+variable "gateway_hostnames" {
+  description = <<-EOT
+    Custom hostnames bound to the APIM gateway with Azure-managed TLS certs.
+
+    PRECONDITION: For each hostname, a CNAME record pointing at the APIM
+    service's default `*.azure-api.net` gateway hostname must exist before
+    `terraform apply`. Azure validates the cert via that DNS record. Apply
+    will hang or fail if the CNAME is not in place.
+
+    Set `default_ssl_binding = true` on exactly one hostname per APIM if
+    you want SNI clients without SNI to land on it; otherwise leave it
+    false on all of them.
+  EOT
+  type = list(object({
+    host_name           = string
+    default_ssl_binding = optional(bool, false)
+  }))
+  default = []
+
+  validation {
+    condition = alltrue([
+      for h in var.gateway_hostnames : can(regex("^[a-z0-9.-]+\\.[a-z]{2,}$", h.host_name))
+    ])
+    error_message = "Each gateway hostname must be a lowercase FQDN (e.g. dev-api.pcpc.maber.io)."
+  }
+
+  validation {
+    condition = length([
+      for h in var.gateway_hostnames : h if h.default_ssl_binding == true
+    ]) <= 1
+    error_message = "At most one gateway hostname may set default_ssl_binding = true."
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1B of the portfolio plan ([`docs/PORTFOLIO_PLAN.md`](docs/PORTFOLIO_PLAN.md)). Azure infrastructure changes that turn the Phase 1A frontend toggle into a real two-path live demo. Resolves Open Questions #4 (custom domain naming) and #6 (APIM SSL cert).

Five commits:

1. **`feat(infra): add gateway_hostnames support to api-management module`** — new \`gateway_hostnames\` variable + dynamic \`hostname_configuration\` block on \`azurerm_api_management\`. Backwards-compatible (empty list = no change). Validations enforce FQDN shape and at most one default-SSL-binding hostname per APIM.
2. **`feat(infra): bind per-env APIM custom hostnames`** — per-env defaults (\`dev-api.pcpc.maber.io\`, \`staging-api.pcpc.maber.io\`, \`api.pcpc.maber.io\`), all with \`default_ssl_binding = true\`.
3. **`feat(apim): retarget CORS at pcpc.maber.io and allow * for dev previews`** — CORS origins per env: dev=\`*\` (Vercel preview URLs are ephemeral), staging/prod=\`https://pcpc.maber.io\`. \`cors_origins\` validator relaxed to accept \`*\`.
4. **`feat(apim): expose /health through APIM for backend toggle probes`** — adds \`/health\` operation to the OpenAPI spec, the APIM Terraform, and the outputs map. Functions already serves it at \`/api/health\` anonymously; this is the gateway exposure.
5. **`docs(adr): add ADR-011 documenting the deployment topology decision`** — new ADR explaining why three envs (dev/staging/prod) are kept and how staging maps to a pipeline-only testing layer rather than a frontend-dogfooding env. Closes the \"no decision documentation\" gap the planning research surfaced.

## Validation

- \`terraform fmt\` — clean
- \`terraform init -backend=false\` + \`terraform validate\` — green across \`infra/modules/api-management\`, \`apim/terraform\`, \`infra/envs/{dev,staging,prod}\`, \`apim/environments/{dev,staging,prod}\`
- ADO PR-Validation should run (does not require infra apply)

## Manual ops steps required after merge (operator-owned)

These are documented in detail in [ADR-011](docs/adr/ADR-011-deployment-topology-and-testing-model.md). Summary:

### 1. Cloudflare DNS — three CNAMEs, all DNS-only (gray cloud)

| Type | Name | Target | Proxy |
|---|---|---|---|
| CNAME | \`dev-api\` | \`pcpc-apim-dev.azure-api.net\` | DNS only |
| CNAME | \`staging-api\` | \`pcpc-apim-staging.azure-api.net\` | DNS only |
| CNAME | \`api\` | \`pcpc-apim-prod.azure-api.net\` | DNS only |

**At minimum \`dev-api\` must exist before the dev CD pipeline next runs.** Otherwise the Terraform Azure-managed cert provisioning step will hang for ~30 min before failing. Add \`staging-api\` + \`api\` before clicking the staging/prod approval gates.

Proxied mode would (a) break Azure-managed cert validation and (b) hide the Azure-issued cert behind Cloudflare's. Keep all three off the orange cloud.

### 2. Vercel env vars — \`PUBLIC_AZURE_API_BASE_URL\` per scope

Set in Vercel project settings → Environment Variables. Add the same name three times, each scoped to one of Vercel's three environments:

| Vercel scope | Value |
|---|---|
| Production | \`https://api.pcpc.maber.io\` |
| Preview | \`https://dev-api.pcpc.maber.io\` |
| Development | \`https://dev-api.pcpc.maber.io\` |

Set after the matching Azure env is actually deployed. Until set, \`path-b-azure.ts\` (Phase 1A branch) falls back to \`pcpc-apim-dev.azure-api.net/pcpc-api/v1\` so the toggle still works against the dev APIM out-of-the-box.

### 3. ADO manual approvals

After merge, the next CD pipeline run will deploy dev automatically, then wait for manual approval to proceed to staging then prod. Approve both in order to roll out the new APIM hostname binding + CORS + \`/health\` to all three envs.

## Test plan

- [ ] Vercel preview build succeeds (no frontend code changes; preview should be a no-op build but still verifies CI)
- [ ] ADO PR-Validation passes (terraform validate / infra-validation / apim-validation)
- [ ] After merge + dev CD: \`dig dev-api.pcpc.maber.io\` resolves to \`pcpc-apim-dev.azure-api.net\`
- [ ] After dev CD: \`curl https://dev-api.pcpc.maber.io/pcpc-api/v1/health\` returns 200/207/503 JSON
- [ ] After dev CD: \`curl -I -X OPTIONS https://dev-api.pcpc.maber.io/pcpc-api/v1/sets -H \"Origin: https://example.vercel.app\" -H \"Access-Control-Request-Method: GET\"\` returns 200 with \`Access-Control-Allow-Origin: *\`
- [ ] After Vercel env vars set: BackendToggle on a Vercel preview shows Azure as healthy with sub-second latency
- [ ] After staging/prod CD + CNAMEs: \`dig staging-api.pcpc.maber.io\` and \`dig api.pcpc.maber.io\` resolve correctly
- [ ] After prod CD: visit \`pcpc.maber.io\`, confirm Azure path is healthy and CORS rejects non-pcpc.maber.io origins

## Rollback

Tag \`phase-1b/pre-apim-domain\` was pushed before this work began. \`gateway_hostnames\` defaults to an empty list at the module level, so reverting just the per-env wiring (keeping the module change) leaves everything backwards-compatible.

## What's NOT in this PR

- Containerizing Functions / ACA path (Phase 2)
- Functions schema migration to Scrydex (Phase 2)
- Frontend-side BackendToggle changes (those landed in Phase 1A — PR #131)
- Any URL-override extension to BackendToggle (deferred Layer 3 per ADR-011)

🤖 Generated with [Claude Code](https://claude.com/claude-code)