### PR TITLE
fix(infra): remove computed certificate_source from APIM hostname proxy

### DIFF
--- a/infra/modules/api-management/main.tf
+++ b/infra/modules/api-management/main.tf
@@ -65,6 +65,12 @@ resource "azurerm_api_management" "this" {
   # See variables.tf for the CNAME-must-exist-first precondition. The block
   # is skipped entirely when no hostnames are configured so the resource
   # remains idempotent for envs that haven't enabled custom domains yet.
+  #
+  # certificate_source is intentionally omitted: the azurerm provider treats
+  # it as a computed attribute and rejects explicit values. The provider
+  # derives it from what we DO provide — supplying neither `certificate`
+  # nor `key_vault_id` here yields the free Azure-managed cert (the
+  # `Managed` source), which is exactly what Phase 1B wants.
   dynamic "hostname_configuration" {
     for_each = length(var.gateway_hostnames) > 0 ? [1] : []
     content {
@@ -72,7 +78,6 @@ resource "azurerm_api_management" "this" {
         for_each = var.gateway_hostnames
         content {
           host_name                    = proxy.value.host_name
-          certificate_source           = "Managed"
           default_ssl_binding          = proxy.value.default_ssl_binding
           negotiate_client_certificate = false
         }


### PR DESCRIPTION
## Summary

Hotfix for the dev CD pipeline failure that surfaced after PR #132 merged. The pipeline's terraform plan stage failed with:

\`\`\`
Error: Value for unconfigurable attribute
  on ../../modules/api-management/main.tf line 29
  Can't configure a value for \"hostname_configuration.0.proxy.0.certificate_source\":
  its value will be decided automatically based on the result of applying this configuration.
\`\`\`

## Root cause

The azurerm provider treats \`certificate_source\` on \`azurerm_api_management.hostname_configuration.proxy\` as a **computed** attribute — it derives the value from what you DO configure on the proxy block:

| What you provide | Source the provider sets |
|---|---|
| \`certificate\` blob | \`Custom\` |
| \`key_vault_id\` | \`KeyVault\` |
| Neither (just \`host_name\`) | \`Managed\` ← Phase 1B's intent |

PR #132 set \`certificate_source = \"Managed\"\` explicitly, thinking that was the way to opt into the free Azure-managed cert. The provider's contract is the opposite: omit the field and the provider picks Managed for you because no certificate inputs were supplied.

## Fix

One-line removal of \`certificate_source = \"Managed\"\` from the proxy block in \`infra/modules/api-management/main.tf\`. Comment expanded to explain the omission so a future reader doesn't re-add it.

## Validation

- \`terraform validate\` passes locally on the api-management module
- The dev CD pipeline's plan stage should succeed after merge
- All existing PR-Validation checks (Backend / Infrastructure / APIM / Summary) should still pass since the change is small and additive-by-deletion

## What this does NOT change

- Custom hostnames per env still bound (\`dev-api\`, \`staging-api\`, \`api\`)
- CORS retarget unchanged
- \`/health\` operation unchanged
- ADR-011 unchanged
- Vercel env var setup steps in PR #132's body unchanged

## Rollback

Tag \`phase-1b/pre-cert-source-fix\` was pushed before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)