### PR TITLE
fix(infra): defer APIM custom hostnames during managed-cert suspension + ADR-012

### DIFF
--- a/docs/adr/ADR-012-apim-managed-cert-suspension.md
+++ b/docs/adr/ADR-012-apim-managed-cert-suspension.md
@@ -1,0 +1,233 @@
+# ADR-012: APIM Managed Cert Suspension — Defer Custom Hostnames
+
+## Status
+
+Accepted
+
+Date: 2026-05-07
+
+Supersedes: implementation choice in [ADR-008](./ADR-008-apim-vs-bff-gateway.md)
+"Implementation Notes" — the original Phase 1B intent of using free
+Azure-managed certs for `dev-api`/`staging-api`/`api.pcpc.maber.io` is
+deferred per this ADR.
+
+## Context
+
+[Phase 1B](../PORTFOLIO_PLAN.md) shipped APIM custom-domain plumbing that
+intended to bind `dev-api.pcpc.maber.io`, `staging-api.pcpc.maber.io`, and
+`api.pcpc.maber.io` to each environment's APIM gateway with the **free
+Azure-managed TLS certificate** option. The decision to use the managed
+cert path resolved [Open Question #6 in the
+plan](../PORTFOLIO_PLAN.md#open-questions).
+
+After the Phase 1B + hotfix PRs merged, the dev CD pipeline failed at
+`terraform apply` with:
+
+```
+Error: creating/updating Service ...: 400 Bad Request:
+EncodedCertificateOrKeyVaultIdMustBeProvided:
+EncodedCertificate or keyVaultId or freeCertificateKeyVaultId should be
+provided to retrieve the custom SSL certificate for type: Proxy and
+hostname : dev-api.pcpc.maber.io.
+```
+
+Investigation surfaced an active Azure breaking change:
+**[Azure API Management — Managed certificates suspension for custom
+domains (August
+2025)](https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/managed-certificates-suspension-august-2025).**
+Microsoft has temporarily disabled creation of new free Azure-managed
+certs for APIM custom domains from **August 15 2025 through June 30
+2026** (one Microsoft Q&A source quotes a possible earlier resume date of
+March 15 2026; neither has resumed as of today).
+
+Cause: an industry-wide deprecation of CNAME-based Domain Control
+Validation (DCV) is forcing DigiCert (the underlying CA) to migrate to a
+new open-source DCV platform. Existing managed certs continue to
+auto-renew (provided port 80 is reachable from DigiCert IPs), but **new
+cert creation is blocked** for the duration.
+
+Microsoft's documented workarounds during the suspension are limited to
+customer-supplied certs:
+
+- Provide an `EncodedCertificate` (PFX blob) directly to Terraform
+- Reference a Key Vault secret containing the cert via `key_vault_id`
+- Reference a Key Vault free-cert via `freeCertificateKeyVaultId`
+
+None of these is the Azure-managed-cert path the original ADR-008
+"Implementation Notes" assumed.
+
+## Decision
+
+**Defer custom hostname binding on APIM until Microsoft re-enables
+managed cert creation.** Keep the IaC scaffolding in place; deactivate it
+via empty per-env defaults; document the re-enable procedure.
+
+Specifically:
+
+1. The `gateway_hostnames` variable on
+   `infra/modules/api-management` remains in the module — empty by
+   default, validated, ready to accept hostname objects.
+2. The per-env wrappers in `infra/envs/{dev,staging,prod}/variables.tf`
+   set `apim_gateway_hostnames = []` until the suspension ends.
+3. The dynamic `hostname_configuration` block in the module is skipped
+   when the list is empty, so APIM provisions cleanly with its default
+   `pcpc-apim-{env}.azure-api.net` hostname only.
+4. The frontend's `BackendToggle` (Phase 1A) continues to work via the
+   existing `path-b-azure.ts` fallback to
+   `https://pcpc-apim-dev.azure-api.net/pcpc-api/v1` until custom
+   hostnames are restored, after which the `PUBLIC_AZURE_API_BASE_URL`
+   Vercel env var override starts pointing at the per-env custom
+   hostname.
+5. Cloudflare CNAMEs for `dev-api`, `staging-api`, and `api` are NOT
+   added until immediately before re-enabling, to avoid stale DNS
+   records resolving to nothing useful.
+
+The other Phase 1B work — CORS retarget at `pcpc.maber.io`, `/health`
+exposure through APIM, the cors_origins validator update — is unaffected
+and proceeds to apply.
+
+## Consequences
+
+### Positive
+
+- **Unblocks the dev CD pipeline today** without depending on a Microsoft
+  service that's known-broken for the next ~2 months minimum.
+- **Honest scoping.** The portfolio plan explicitly accepts deferring
+  cosmetic work when the alternative is a 1–2 week scope expansion (Key
+  Vault + Let's Encrypt automation) for what amounts to prettier URLs.
+- **Zero rework risk on re-enable.** The IaC scaffolding (module
+  variable, dynamic block, per-env wrapper, validators) is in place and
+  tested. Restoring custom hostnames after the suspension is a
+  one-variable flip per env plus the Cloudflare CNAMEs.
+- **Senior-judgment portfolio signal.** "Microsoft suspended the thing,
+  here's the ADR explaining the deferral and the re-enable runbook"
+  reads as deliberate and competent. An engineer who built a Let's
+  Encrypt automation around a 2-month outage would be over-engineering;
+  one who didn't notice the outage would be careless.
+- **Path B still works.** The `BackendToggle` doesn't need custom
+  hostnames to demonstrate the architectural comparison — it works
+  against the bare `pcpc-apim-dev.azure-api.net` gateway hostname today.
+
+### Negative
+
+- **`pcpc-apim-dev.azure-api.net/pcpc-api/v1` is uglier than
+  `dev-api.pcpc.maber.io/pcpc-api/v1` in the BackendToggle popover and in
+  any architecture-comparison screenshots. Cosmetic only; functional
+  parity is unchanged.
+- **One more thing to remember.** When the suspension lifts, restoring
+  hostnames requires the runbook below to be followed in the right
+  order (CNAME → variable flip → apply → Vercel env var update). The
+  ADR itself is the runbook; risk of forgetting is low.
+- **Phase 2 timing dependency.** If Phase 2 (ACA path) ships before the
+  suspension lifts, ACA's custom hostname (`aca.pcpc.maber.io`) will
+  hit the same constraint. ACA Container Apps uses a different cert
+  story (managed certs through ACA itself, which is not affected by
+  the APIM-specific suspension), so this should be safe — but worth
+  re-verifying when Phase 2 starts.
+
+## Alternatives Considered
+
+### Option B — Build a Key Vault + Let's Encrypt automation
+
+Provision Let's Encrypt certs via cert-manager / Posh-ACME / a Function
+App with an ACME client. Store in Key Vault. Reference from APIM via
+`key_vault_id` on the hostname proxy block. Wire auto-renewal.
+
+- **Pros:** Custom hostnames work immediately. Demonstrates significant
+  cert-lifecycle automation, which is a portfolio-positive skill in its
+  own right.
+- **Cons:** 1–2 weeks of engineering work (ACME client, Key Vault wiring,
+  renewal automation, secret rotation, monitoring). Scope explosion for
+  what's ultimately a cosmetic URL improvement during a temporary
+  Microsoft outage.
+- **Reason for rejection:** The cost-benefit is poor for a one-developer
+  portfolio with a 2-month suspension window. If the suspension extended
+  past 6 months, Option B would become more attractive. If it
+  becomes permanent, this ADR is superseded by ADR-013 (TBD) describing
+  the Key Vault automation.
+
+### Option C — Cloudflare proxied (orange cloud) on the APIM CNAMEs
+
+Reverse the previously-recommended DNS-only setup. Use Cloudflare's
+Universal SSL to terminate TLS at the edge with Cloudflare's cert; do
+not bind any hostname on APIM. Cloudflare proxies HTTPS requests to
+APIM's bare `*.azure-api.net` URL, possibly with Host-header rewriting
+(Page Rules / Transform Rules).
+
+- **Pros:** Works today without Azure cert provisioning at all.
+- **Cons:** Adds Cloudflare into the request path (previously rejected
+  in the Phase 1B planning conversation for reasons that mostly still
+  hold — Cloudflare features are duplicative with APIM's own gateway
+  policies). Requires Cloudflare Page Rules to rewrite the Host header
+  so APIM accepts the request, which is config that lives outside
+  Terraform. The TLS chain visitors see is Cloudflare's, not Azure's,
+  which obscures the "APIM is the gateway" portfolio story.
+- **Reason for rejection:** Adds a hop with operational + narrative cost
+  to solve a problem that deferral solves with zero ongoing complexity.
+
+### Option D — Wait
+
+Don't ship Phase 1B at all until Microsoft re-enables managed certs.
+
+- **Pros:** Zero ADR debt; the original plan executes cleanly when MSFT
+  unblocks.
+- **Cons:** Loses the CORS + `/health` exposure work that's already
+  written, validated, and merged. The BackendToggle's healthcheck on
+  Path B doesn't work without `/health` being exposed through APIM.
+- **Reason for rejection:** Phase 1B's *other* work has independent
+  value and ships fine. Holding everything for one cosmetic component
+  is poor batching.
+
+## Implementation Notes
+
+This ADR documents the deferral; the actual implementation lives in:
+
+- `infra/envs/{dev,staging,prod}/variables.tf` — per-env
+  `apim_gateway_hostnames` defaults set to `[]` with descriptions
+  explaining the post-suspension restoration values.
+- `infra/modules/api-management/variables.tf` — module variable
+  description updated to call out the suspension.
+- `infra/modules/api-management/main.tf` — module `hostname_configuration`
+  block comment updated to reflect deferred state.
+
+### Re-enable runbook (post-suspension)
+
+When Microsoft confirms managed cert creation has resumed (check
+[the breaking-change page](https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/managed-certificates-suspension-august-2025)
+for status):
+
+1. **Add Cloudflare CNAMEs** (DNS-only, gray cloud — see ADR-008
+   discussion for why proxied is wrong here):
+   - `dev-api.pcpc.maber.io` → `pcpc-apim-dev.azure-api.net`
+   - `staging-api.pcpc.maber.io` → `pcpc-apim-staging.azure-api.net`
+   - `api.pcpc.maber.io` → `pcpc-apim-prod.azure-api.net`
+2. **Restore the per-env defaults** in
+   `infra/envs/{dev,staging,prod}/variables.tf`:
+   ```
+   default = [
+     { host_name = "<env>-api.pcpc.maber.io", default_ssl_binding = true }
+   ]
+   ```
+   (For prod the hostname is `api.pcpc.maber.io` without the env
+   prefix.)
+3. **Open a PR** with the variable flip and merge it.
+4. **Watch the dev CD pipeline** — `terraform apply` should succeed and
+   provision the Azure-managed cert via DNS validation against the
+   CNAME from step 1.
+5. **Manually approve the staging and prod CD stages** in ADO once dev
+   is green.
+6. **Set `PUBLIC_AZURE_API_BASE_URL`** in Vercel project settings:
+   - Production scope → `https://api.pcpc.maber.io`
+   - Preview scope → `https://dev-api.pcpc.maber.io`
+   - Development scope → `https://dev-api.pcpc.maber.io`
+7. **Trigger a Vercel redeploy** so the new env vars get baked into the
+   frontend bundle.
+8. **Verify** the BackendToggle's Path B option resolves to the new
+   hostname with healthy status across all three Vercel scopes.
+
+## Related Decisions
+
+- [ADR-007: API Architecture Spectrum (three paths)](./ADR-007-api-architecture-spectrum.md)
+- [ADR-008: APIM vs SvelteKit BFF as Gateway](./ADR-008-apim-vs-bff-gateway.md) — Implementation Notes on cert source partially superseded by this ADR
+- [ADR-011: Deployment Topology and Testing Model](./ADR-011-deployment-topology-and-testing-model.md)
+- ADR-013 (hypothetical, would supersede this one): Key Vault + Let's Encrypt automation, IF the suspension extends past mid-2026 or becomes permanent

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,6 +31,7 @@ Each ADR follows a standardized format:
 | [ADR-007](./ADR-007-api-architecture-spectrum.md) | API Architecture Spectrum (three paths) | Accepted | 2026-05-06 |
 | [ADR-008](./ADR-008-apim-vs-bff-gateway.md) | APIM vs SvelteKit BFF as Gateway | Accepted | 2026-05-06 |
 | [ADR-011](./ADR-011-deployment-topology-and-testing-model.md) | Deployment Topology and Testing Model | Accepted | 2026-05-06 |
+| [ADR-012](./ADR-012-apim-managed-cert-suspension.md) | APIM Managed Cert Suspension — Defer Custom Hostnames | Accepted | 2026-05-07 |
 
 ### Planned (three-path portfolio story)
 

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -282,18 +282,32 @@ variable "apim_sku_name" {
 
 variable "apim_gateway_hostnames" {
   description = <<-EOT
-    Custom hostnames for the APIM gateway in this environment. Each hostname
-    requires a CNAME record in Cloudflare pointing at pcpc-apim-dev.azure-api.net
-    BEFORE `terraform apply`, otherwise Azure-managed cert provisioning will hang.
-    Default uses the dev-api.pcpc.maber.io hostname per Phase 1B.
+    Custom hostnames for the APIM gateway in this environment.
+
+    Default is empty during the Azure-managed cert creation suspension
+    (Aug 15 2025 — Jun 30 2026 per Microsoft's published breaking-change
+    notice). When the suspension lifts, restore the per-env hostname:
+
+      dev:     { host_name = "dev-api.pcpc.maber.io",     default_ssl_binding = true }
+
+    Pre-flip checklist:
+      1. Add the matching CNAME in Cloudflare (DNS-only, gray cloud)
+         pointing at pcpc-apim-dev.azure-api.net
+      2. Confirm Microsoft has resumed managed-cert creation
+      3. Set this variable's default to the hostname object above
+      4. Run `terraform apply`
+
+    Alternative path (use before Jun 30 2026): supply a Key Vault cert
+    via additional fields on the gateway_hostnames object. Out of scope
+    for Phase 1; tracked in ADR-012.
+
+    See `docs/adr/ADR-012-apim-managed-cert-suspension.md`.
   EOT
   type = list(object({
     host_name           = string
     default_ssl_binding = optional(bool, false)
   }))
-  default = [
-    { host_name = "dev-api.pcpc.maber.io", default_ssl_binding = true }
-  ]
+  default = []
 }
 
 # Log Analytics Configuration

--- a/infra/envs/prod/variables.tf
+++ b/infra/envs/prod/variables.tf
@@ -277,18 +277,21 @@ variable "apim_sku_name" {
 
 variable "apim_gateway_hostnames" {
   description = <<-EOT
-    Custom hostnames for the APIM gateway in this environment. Each hostname
-    requires a CNAME record in Cloudflare pointing at pcpc-apim-prod.azure-api.net
-    BEFORE `terraform apply`, otherwise Azure-managed cert provisioning will hang.
-    Default uses the api.pcpc.maber.io hostname per Phase 1B.
+    Custom hostnames for the APIM gateway in this environment.
+
+    Default is empty during the Azure-managed cert creation suspension
+    (Aug 15 2025 — Jun 30 2026). When the suspension lifts, restore:
+
+      prod: { host_name = "api.pcpc.maber.io", default_ssl_binding = true }
+
+    See `docs/adr/ADR-012-apim-managed-cert-suspension.md` for the
+    full deferral rationale and re-enable checklist.
   EOT
   type = list(object({
     host_name           = string
     default_ssl_binding = optional(bool, false)
   }))
-  default = [
-    { host_name = "api.pcpc.maber.io", default_ssl_binding = true }
-  ]
+  default = []
 }
 
 # Log Analytics Configuration

--- a/infra/envs/staging/variables.tf
+++ b/infra/envs/staging/variables.tf
@@ -277,18 +277,21 @@ variable "apim_sku_name" {
 
 variable "apim_gateway_hostnames" {
   description = <<-EOT
-    Custom hostnames for the APIM gateway in this environment. Each hostname
-    requires a CNAME record in Cloudflare pointing at pcpc-apim-staging.azure-api.net
-    BEFORE `terraform apply`, otherwise Azure-managed cert provisioning will hang.
-    Default uses the staging-api.pcpc.maber.io hostname per Phase 1B.
+    Custom hostnames for the APIM gateway in this environment.
+
+    Default is empty during the Azure-managed cert creation suspension
+    (Aug 15 2025 — Jun 30 2026). When the suspension lifts, restore:
+
+      staging: { host_name = "staging-api.pcpc.maber.io", default_ssl_binding = true }
+
+    See `docs/adr/ADR-012-apim-managed-cert-suspension.md` for the
+    full deferral rationale and re-enable checklist.
   EOT
   type = list(object({
     host_name           = string
     default_ssl_binding = optional(bool, false)
   }))
-  default = [
-    { host_name = "staging-api.pcpc.maber.io", default_ssl_binding = true }
-  ]
+  default = []
 }
 
 # Log Analytics Configuration

--- a/infra/modules/api-management/main.tf
+++ b/infra/modules/api-management/main.tf
@@ -61,16 +61,19 @@ resource "azurerm_api_management" "this" {
     type = var.identity_type
   }
 
-  # Custom hostnames bound to the gateway with Azure-managed TLS certs.
-  # See variables.tf for the CNAME-must-exist-first precondition. The block
-  # is skipped entirely when no hostnames are configured so the resource
-  # remains idempotent for envs that haven't enabled custom domains yet.
+  # Custom hostnames bound to the gateway. Skipped entirely when no
+  # hostnames are configured (the current default during the Azure-managed
+  # cert creation suspension — see ADR-012 and variables.tf).
   #
-  # certificate_source is intentionally omitted: the azurerm provider treats
-  # it as a computed attribute and rejects explicit values. The provider
-  # derives it from what we DO provide — supplying neither `certificate`
-  # nor `key_vault_id` here yields the free Azure-managed cert (the
-  # `Managed` source), which is exactly what Phase 1B wants.
+  # When the suspension lifts and per-env defaults are restored:
+  #   - certificate_source is intentionally omitted because the azurerm
+  #     provider treats it as a computed attribute and rejects explicit
+  #     values. The provider derives it from what we DO provide —
+  #     supplying neither `certificate` nor `key_vault_id` here yields
+  #     the free Azure-managed cert (the `Managed` source).
+  #   - The CNAME pointing the custom hostname at the
+  #     pcpc-apim-<env>.azure-api.net gateway must exist in DNS BEFORE
+  #     `terraform apply` so Azure-managed cert validation can complete.
   dynamic "hostname_configuration" {
     for_each = length(var.gateway_hostnames) > 0 ? [1] : []
     content {

--- a/infra/modules/api-management/variables.tf
+++ b/infra/modules/api-management/variables.tf
@@ -157,10 +157,20 @@ variable "gateway_hostnames" {
   description = <<-EOT
     Custom hostnames bound to the APIM gateway with Azure-managed TLS certs.
 
-    PRECONDITION: For each hostname, a CNAME record pointing at the APIM
-    service's default `*.azure-api.net` gateway hostname must exist before
-    `terraform apply`. Azure validates the cert via that DNS record. Apply
-    will hang or fail if the CNAME is not in place.
+    DEFAULT IS EMPTY during the Azure-managed cert creation suspension
+    (Aug 15 2025 — Jun 30 2026 per Microsoft's published breaking-change
+    notice). With the suspension active, configuring any hostname here
+    will cause `terraform apply` to fail with:
+        EncodedCertificateOrKeyVaultIdMustBeProvided
+    Per-env wrappers in infra/envs/{dev,staging,prod}/variables.tf set
+    this to `[]` and document the post-suspension restoration. See
+    docs/adr/ADR-012-apim-managed-cert-suspension.md.
+
+    AFTER THE SUSPENSION (or if using a Key Vault cert, which would
+    require additional fields here): for each hostname, a CNAME record
+    pointing at the APIM service's default `*.azure-api.net` gateway
+    hostname must exist before `terraform apply` so Azure can validate
+    the cert via DNS.
 
     Set `default_ssl_binding = true` on exactly one hostname per APIM if
     you want SNI clients without SNI to land on it; otherwise leave it


### PR DESCRIPTION
## Summary

Fixes the dev CD pipeline's \`terraform apply\` failure on the APIM hostname binding. The root cause is the **active Azure-managed cert creation suspension** (Aug 15 2025 → Jun 30 2026 per [Microsoft's published breaking-change notice](https://learn.microsoft.com/en-us/azure/api-management/breaking-changes/managed-certificates-suspension-august-2025)), which Phase 1B's plan didn't account for.

The actual apply error from the dev CD run:

\`\`\`
Error: 400 Bad Request: EncodedCertificateOrKeyVaultIdMustBeProvided:
EncodedCertificate or keyVaultId or freeCertificateKeyVaultId should be provided
to retrieve the custom SSL certificate for type: Proxy and hostname : dev-api.pcpc.maber.io.
\`\`\`

## Approach: Option A — defer custom hostnames

Three options were considered (full analysis in the new ADR):

- **A — Defer hostnames** *(this PR)* — empty per-env defaults, keep IaC scaffolding, document re-enable runbook
- **B — Build Key Vault + Let's Encrypt automation** — 1–2 weeks of cert lifecycle work; rejected as scope creep for a 2-month outage
- **C — Cloudflare proxied (orange cloud)** — adds Cloudflare in the request path; rejected because it obscures the Azure cert story

Codex flagged this on PR #133 ([\"Avoid creating suspended APIM managed certs\"](https://github.com/Abernaughty/PCPC/pull/133)) and was correct.

## Changes

| File | Change |
|---|---|
| \`infra/envs/{dev,staging,prod}/variables.tf\` | \`apim_gateway_hostnames\` default flipped from per-env hostname object to \`[]\`. Description updated to call out the suspension and document the post-suspension restoration values. |
| \`infra/modules/api-management/variables.tf\` | \`gateway_hostnames\` description updated to explicitly call out the suspension. |
| \`infra/modules/api-management/main.tf\` | \`hostname_configuration\` block comment updated. Block itself unchanged — already conditional on non-empty list, so empty defaults render no block at all. |
| \`docs/adr/ADR-012-apim-managed-cert-suspension.md\` | New ADR. Captures the decision, the three rejected alternatives with reasoning, and a step-by-step re-enable runbook for when MSFT lifts the suspension. |
| \`docs/adr/README.md\` | ADR-012 added to Accepted index. |

## Validation

- \`terraform fmt\` clean
- \`terraform init -backend=false\` + \`terraform validate\` green for all infra layers
- **\`terraform plan\` against real dev state run locally**: \`No changes. Your infrastructure matches the configuration.\` — confirms the deferral leaves the APIM resource in its current shape (no hostname binding) and doesn't trigger any other unintended changes
- APIM-layer plan was not run locally (would require fetching the dev function app key from Azure Portal) — relying on \`terraform validate\` + dev CD's APIM stage to catch any apim-layer surprises

## What's NOT changed

The other Phase 1B work (CORS retarget at \`pcpc.maber.io\`, \`/health\` exposure through APIM, the cors_origins validator update from PR #132, the certificate_source omission from PR #133) is all unaffected and still applies normally. This PR only touches the hostname-binding aspect.

## After merge

The dev CD pipeline should now:
1. Pass \`terraform plan\` (already passing)
2. Pass \`terraform apply\` on the infra layer — APIM gets modified WITHOUT a hostname binding, so the cert provisioning attempt that previously errored is no longer attempted
3. Proceed to the APIM layer (\`apim/environments/dev\`) which will apply the CORS retarget + \`/health\` operation
4. Proceed to the Functions deploy and smoke tests

## Re-enable when MSFT lifts the suspension

ADR-012 contains the full runbook. TL;DR:
1. Add Cloudflare CNAMEs (DNS-only)
2. Restore \`apim_gateway_hostnames\` per-env defaults to the documented hostname objects
3. Open a PR with the variable flips
4. Set \`PUBLIC_AZURE_API_BASE_URL\` Vercel env vars to point at the custom hostnames

## Rollback

Tag \`phase-1b/pre-cert-suspension-fix\` was pushed before this work began.

## Test plan

- [ ] \`PCPC-PR-Validation\` ADO pipeline passes (terraform validate / infra-validation / apim-validation)
- [ ] After merge, dev CD pipeline's infra stage \`terraform apply\` succeeds (was failing here)
- [ ] After dev CD: \`curl https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/health\` returns 200/207/503 JSON (verifies the \`/health\` operation from PR #132 actually applied)
- [ ] After dev CD: \`curl -I -X OPTIONS https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets -H \"Origin: https://example.vercel.app\" -H \"Access-Control-Request-Method: GET\"\` returns 200 with \`Access-Control-Allow-Origin: *\` (verifies the CORS retarget from PR #132 actually applied)
- [ ] BackendToggle on Vercel previews continues to show Azure as healthy (no Vercel env var changes needed in this PR — \`path-b-azure.ts\` falls back to the bare \`pcpc-apim-dev.azure-api.net/pcpc-api/v1\` which works today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)