### PR TITLE
feat(apim): regex-based CORS allowlist (ADR-013) — replaces dev=*

### DIFF
--- a/apim/environments/dev/main.tf
+++ b/apim/environments/dev/main.tf
@@ -34,18 +34,23 @@ provider "azurerm" {
 # -----------------------------------------------------------------------------
 
 locals {
-  # Phase 1B: the frontend is a single Vercel deployment at pcpc.maber.io
-  # plus per-PR preview URLs at pcpc-git-*.vercel.app. APIM's CORS policy
-  # accepts only literal origins (no wildcards), so dev — which is where
-  # Vercel previews exercise the toggle — uses "*" to keep preview URLs
-  # working without re-applying APIM on every PR. Staging/prod are locked
-  # down to the production frontend hostname.
-  base_cors_origins = [
-    "*"
+  # Phase 1B (per ADR-013): dev allows the production frontend hostname
+  # plus glob-style patterns matching Vercel's per-PR preview URLs and
+  # commit-level URLs. The cors_origin_regex local in apim/terraform/main.tf
+  # converts these to a regex applied by the policy template.
+  #
+  # Patterns matched here (after https:// prefix is automatically added):
+  #   - pcpc.maber.io                                  — production custom domain
+  #   - pcpc-git-{branch}-abernaughtys-projects.vercel.app — Vercel per-PR previews
+  #   - pcpc-{commit-hash}-abernaughtys-projects.vercel.app — Vercel commit-level URLs
+  base_cors_origin_patterns = [
+    "pcpc.maber.io",
+    "pcpc-git-*-abernaughtys-projects.vercel.app",
+    "pcpc-*-abernaughtys-projects.vercel.app",
   ]
 
-  configured_cors_origins = length(var.cors_origins) > 0 ? var.cors_origins : local.base_cors_origins
-  effective_cors_origins  = distinct(concat(local.configured_cors_origins, var.additional_cors_origins))
+  configured_cors_origin_patterns = length(var.cors_origin_patterns) > 0 ? var.cors_origin_patterns : local.base_cors_origin_patterns
+  effective_cors_origin_patterns  = distinct(concat(local.configured_cors_origin_patterns, var.additional_cors_origin_patterns))
 
   effective_rate_limit_calls  = coalesce(var.rate_limit_calls, var.override_rate_limit_calls, 300)
   effective_rate_limit_period = coalesce(var.rate_limit_period, 60)
@@ -88,8 +93,8 @@ module "pcpc_apim" {
   environment         = var.environment
   function_app_key    = var.function_app_key
 
-  # CORS configuration for development
-  cors_origins = local.effective_cors_origins
+  # CORS configuration for development (regex-based; see ADR-013)
+  cors_origin_patterns = local.effective_cors_origin_patterns
 
   # Rate limiting configuration
   rate_limit_calls  = local.effective_rate_limit_calls

--- a/apim/environments/dev/variables.tf
+++ b/apim/environments/dev/variables.tf
@@ -46,8 +46,13 @@ variable "application_insights_name" {
 # OPTIONAL OVERRIDES (PIPELINE/LOCAL)
 # -----------------------------------------------------------------------------
 
-variable "cors_origins" {
-  description = "Explicit list of allowed CORS origins (overrides defaults when non-empty)"
+variable "cors_origin_patterns" {
+  description = <<-EOT
+    Explicit list of CORS origin patterns (glob-style hostname patterns)
+    that overrides the per-env defaults when non-empty. Pipeline supplies
+    this via cors-origins.auto.tfvars.json from APIM_CORS_ORIGINS variable
+    group entry. See ADR-013 for pattern syntax.
+  EOT
   type        = list(string)
   default     = []
 }
@@ -98,8 +103,8 @@ variable "api_version" {
 # ADDITIONAL CONFIGURATION
 # -----------------------------------------------------------------------------
 
-variable "additional_cors_origins" {
-  description = "Additional CORS origins specific to development environment"
+variable "additional_cors_origin_patterns" {
+  description = "Additional CORS origin patterns specific to development environment (appended to base set, deduplicated)"
   type        = list(string)
   default     = []
 }

--- a/apim/environments/prod/main.tf
+++ b/apim/environments/prod/main.tf
@@ -34,15 +34,16 @@ provider "azurerm" {
 # -----------------------------------------------------------------------------
 
 locals {
-  # Phase 1B: the frontend is a single Vercel deployment at pcpc.maber.io.
-  # Prod APIM only accepts the production frontend hostname; preview URLs
-  # are intentionally blocked here so prod data only serves the prod URL.
-  base_cors_origins = [
-    "https://pcpc.maber.io"
+  # Phase 1B (per ADR-013): prod accepts only the production frontend
+  # hostname. Preview URLs are intentionally blocked — prod serves only
+  # the prod URL. ADR-013 explains the regex-policy mechanism that makes
+  # this match uniform across envs.
+  base_cors_origin_patterns = [
+    "pcpc.maber.io",
   ]
 
-  configured_cors_origins = length(var.cors_origins) > 0 ? var.cors_origins : local.base_cors_origins
-  effective_cors_origins  = distinct(concat(local.configured_cors_origins, var.additional_cors_origins))
+  configured_cors_origin_patterns = length(var.cors_origin_patterns) > 0 ? var.cors_origin_patterns : local.base_cors_origin_patterns
+  effective_cors_origin_patterns  = distinct(concat(local.configured_cors_origin_patterns, var.additional_cors_origin_patterns))
 
   effective_rate_limit_calls  = coalesce(var.rate_limit_calls, var.override_rate_limit_calls, 300)
   effective_rate_limit_period = coalesce(var.rate_limit_period, 60)
@@ -86,8 +87,8 @@ module "pcpc_apim" {
   environment         = var.environment
   function_app_key    = var.function_app_key
 
-  # CORS configuration
-  cors_origins = local.effective_cors_origins
+  # CORS configuration (regex-based; see ADR-013)
+  cors_origin_patterns = local.effective_cors_origin_patterns
 
   # Rate limiting configuration
   rate_limit_calls  = local.effective_rate_limit_calls

--- a/apim/environments/prod/variables.tf
+++ b/apim/environments/prod/variables.tf
@@ -45,8 +45,13 @@ variable "application_insights_name" {
 # OPTIONAL OVERRIDES (PIPELINE/LOCAL)
 # -----------------------------------------------------------------------------
 
-variable "cors_origins" {
-  description = "Explicit list of allowed CORS origins (overrides defaults when non-empty)"
+variable "cors_origin_patterns" {
+  description = <<-EOT
+    Explicit list of CORS origin patterns (glob-style hostname patterns)
+    that overrides the per-env defaults when non-empty. Pipeline supplies
+    this via cors-origins.auto.tfvars.json from APIM_CORS_ORIGINS variable
+    group entry. See ADR-013 for pattern syntax.
+  EOT
   type        = list(string)
   default     = []
 }
@@ -97,8 +102,8 @@ variable "api_version" {
 # ADDITIONAL CONFIGURATION
 # -----------------------------------------------------------------------------
 
-variable "additional_cors_origins" {
-  description = "Additional CORS origins specific to production environment"
+variable "additional_cors_origin_patterns" {
+  description = "Additional CORS origin patterns specific to production environment (appended to base set, deduplicated)"
   type        = list(string)
   default     = []
 }

--- a/apim/environments/staging/main.tf
+++ b/apim/environments/staging/main.tf
@@ -34,16 +34,15 @@ provider "azurerm" {
 # -----------------------------------------------------------------------------
 
 locals {
-  # Phase 1B: the frontend is a single Vercel deployment at pcpc.maber.io.
-  # Staging APIM only accepts the production frontend hostname so toggling
-  # to ?backend=azure from pcpc.maber.io can hit the staging API for
-  # validation work, while ad-hoc origins are blocked.
-  base_cors_origins = [
-    "https://pcpc.maber.io"
+  # Phase 1B (per ADR-013): staging accepts only the production frontend
+  # hostname. No Vercel preview support — staging exists for pipeline-only
+  # validation per ADR-011, not for browser-level testing.
+  base_cors_origin_patterns = [
+    "pcpc.maber.io",
   ]
 
-  configured_cors_origins = length(var.cors_origins) > 0 ? var.cors_origins : local.base_cors_origins
-  effective_cors_origins  = distinct(concat(local.configured_cors_origins, var.additional_cors_origins))
+  configured_cors_origin_patterns = length(var.cors_origin_patterns) > 0 ? var.cors_origin_patterns : local.base_cors_origin_patterns
+  effective_cors_origin_patterns  = distinct(concat(local.configured_cors_origin_patterns, var.additional_cors_origin_patterns))
 
   effective_rate_limit_calls  = coalesce(var.rate_limit_calls, var.override_rate_limit_calls, 300)
   effective_rate_limit_period = coalesce(var.rate_limit_period, 60)
@@ -87,8 +86,8 @@ module "pcpc_apim" {
   environment         = var.environment
   function_app_key    = var.function_app_key
 
-  # CORS configuration
-  cors_origins = local.effective_cors_origins
+  # CORS configuration (regex-based; see ADR-013)
+  cors_origin_patterns = local.effective_cors_origin_patterns
 
   # Rate limiting configuration
   rate_limit_calls  = local.effective_rate_limit_calls

--- a/apim/environments/staging/variables.tf
+++ b/apim/environments/staging/variables.tf
@@ -45,8 +45,13 @@ variable "application_insights_name" {
 # OPTIONAL OVERRIDES (PIPELINE/LOCAL)
 # -----------------------------------------------------------------------------
 
-variable "cors_origins" {
-  description = "Explicit list of allowed CORS origins (overrides defaults when non-empty)"
+variable "cors_origin_patterns" {
+  description = <<-EOT
+    Explicit list of CORS origin patterns (glob-style hostname patterns)
+    that overrides the per-env defaults when non-empty. Pipeline supplies
+    this via cors-origins.auto.tfvars.json from APIM_CORS_ORIGINS variable
+    group entry. See ADR-013 for pattern syntax.
+  EOT
   type        = list(string)
   default     = []
 }
@@ -97,8 +102,8 @@ variable "api_version" {
 # ADDITIONAL CONFIGURATION
 # -----------------------------------------------------------------------------
 
-variable "additional_cors_origins" {
-  description = "Additional CORS origins specific to staging environment"
+variable "additional_cors_origin_patterns" {
+  description = "Additional CORS origin patterns specific to staging environment (appended to base set, deduplicated)"
   type        = list(string)
   default     = []
 }

--- a/apim/policies/templates/global-policy.xml.tpl
+++ b/apim/policies/templates/global-policy.xml.tpl
@@ -1,34 +1,85 @@
+<!--
+  PCPC API global policy.
+
+  CORS is implemented as a custom regex-based allowlist rather than the
+  built-in <cors> element, because <cors>'s <allowed-origins> doesn't
+  support wildcard subdomains and we need to allow Vercel preview URLs
+  whose host segment varies per PR. See ADR-013 for the design rationale.
+
+  The regex (`${cors_origin_regex}`) is assembled by Terraform from the
+  glob-style patterns in var.cors_origin_patterns. Each request's Origin
+  header is matched against it; matched origins are echoed back as
+  Access-Control-Allow-Origin (both for preflight responses and for
+  outbound headers on actual responses).
+
+  Rate limiting is unchanged from the previous template.
+-->
 <policies>
     <inbound>
         <base />
-        <cors>
-            <allowed-origins>
-%{ for origin in cors_origins ~}
-                <origin>${origin}</origin>
-%{ endfor }
-            </allowed-origins>
-            <allowed-methods>
-                <method>GET</method>
-                <method>OPTIONS</method>
-            </allowed-methods>
-            <allowed-headers>
-                <header>Content-Type</header>
-                <header>Ocp-Apim-Subscription-Key</header>
-            </allowed-headers>
-            <expose-headers>
-                <header>X-RateLimit-Remaining</header>
-            </expose-headers>
-        </cors>
+        <!-- Resolve the request's Origin once and decide whether it matches the allowlist. -->
+        <set-variable name="originHeader" value="@(context.Request.Headers.GetValueOrDefault(&quot;Origin&quot;, &quot;&quot;))" />
+        <set-variable name="isOriginAllowed" value="@(((string)context.Variables[&quot;originHeader&quot;]).Length > 0 &amp;&amp; System.Text.RegularExpressions.Regex.IsMatch((string)context.Variables[&quot;originHeader&quot;], @&quot;${cors_origin_regex}&quot;))" />
+
+        <!-- CORS preflight handler: short-circuit OPTIONS requests with the appropriate response. -->
+        <choose>
+            <when condition="@(context.Request.Method == &quot;OPTIONS&quot;)">
+                <choose>
+                    <when condition="@((bool)context.Variables[&quot;isOriginAllowed&quot;])">
+                        <return-response>
+                            <set-status code="204" reason="No Content" />
+                            <set-header name="Access-Control-Allow-Origin" exists-action="override">
+                                <value>@((string)context.Variables["originHeader"])</value>
+                            </set-header>
+                            <set-header name="Access-Control-Allow-Methods" exists-action="override">
+                                <value>GET, OPTIONS</value>
+                            </set-header>
+                            <set-header name="Access-Control-Allow-Headers" exists-action="override">
+                                <value>Content-Type, Ocp-Apim-Subscription-Key</value>
+                            </set-header>
+                            <set-header name="Access-Control-Max-Age" exists-action="override">
+                                <value>86400</value>
+                            </set-header>
+                            <set-header name="Vary" exists-action="override">
+                                <value>Origin</value>
+                            </set-header>
+                        </return-response>
+                    </when>
+                    <otherwise>
+                        <return-response>
+                            <set-status code="403" reason="Origin not allowed by CORS policy" />
+                        </return-response>
+                    </otherwise>
+                </choose>
+            </when>
+        </choose>
+
         <!-- Rate limiting with environment-specific configuration -->
-        <rate-limit calls="${rate_limit_calls}" renewal-period="${rate_limit_period}" 
+        <rate-limit calls="${rate_limit_calls}" renewal-period="${rate_limit_period}"
                    total-calls-header-name="X-RateLimit-Limit"
-                   remaining-calls-header-name="X-RateLimit-Remaining" 
+                   remaining-calls-header-name="X-RateLimit-Remaining"
                    remaining-calls-variable-name="remainingCalls" />
     </inbound>
     <backend>
         <forward-request />
     </backend>
-    <outbound />
+    <outbound>
+        <base />
+        <!-- For non-preflight requests with an allowed Origin, add CORS response headers. -->
+        <choose>
+            <when condition="@((bool)context.Variables[&quot;isOriginAllowed&quot;])">
+                <set-header name="Access-Control-Allow-Origin" exists-action="override">
+                    <value>@((string)context.Variables["originHeader"])</value>
+                </set-header>
+                <set-header name="Vary" exists-action="override">
+                    <value>Origin</value>
+                </set-header>
+                <set-header name="Access-Control-Expose-Headers" exists-action="override">
+                    <value>X-RateLimit-Remaining</value>
+                </set-header>
+            </when>
+        </choose>
+    </outbound>
     <on-error>
         <base />
     </on-error>

--- a/apim/terraform/main.tf
+++ b/apim/terraform/main.tf
@@ -61,9 +61,30 @@ locals {
   # Function App URL
   function_app_url = "https://${data.azurerm_windows_function_app.backend.default_hostname}/api"
 
+  # Convert glob-style hostname patterns into a single regex used by the
+  # CORS policy. See apim/policies/templates/global-policy.xml.tpl and
+  # ADR-013 for the design.
+  #
+  # Pipeline:
+  #   1. Escape literal `.` so regex sees an escaped dot
+  #   2. Convert glob `*` into [a-z0-9-]+ (one-or-more hostname-safe chars)
+  #   3. Join with `|` and anchor with ^https://(...)$
+  #
+  # Example: ["pcpc.maber.io", "pcpc-git-*-abernaughtys-projects.vercel.app"]
+  # becomes "^https://(pcpc\.maber\.io|pcpc-git-[a-z0-9-]+-abernaughtys-projects\.vercel\.app)$"
+  cors_patterns_dot_escaped = [
+    for p in var.cors_origin_patterns :
+    replace(p, ".", "\\.")
+  ]
+  cors_patterns_with_classes = [
+    for p in local.cors_patterns_dot_escaped :
+    replace(p, "*", "[a-z0-9-]+")
+  ]
+  cors_origin_regex = "^https://(${join("|", local.cors_patterns_with_classes)})$"
+
   # Policy template variables
   policy_vars = {
-    cors_origins        = var.cors_origins
+    cors_origin_regex   = local.cors_origin_regex
     rate_limit_calls    = var.rate_limit_calls
     rate_limit_period   = var.rate_limit_period
     cache_duration_sets = var.cache_duration_sets

--- a/apim/terraform/outputs.tf
+++ b/apim/terraform/outputs.tf
@@ -124,9 +124,14 @@ output "environment" {
   value       = var.environment
 }
 
-output "cors_origins" {
-  description = "Configured CORS origins"
-  value       = var.cors_origins
+output "cors_origin_patterns" {
+  description = "Configured CORS origin patterns (glob-style hostname patterns)"
+  value       = var.cors_origin_patterns
+}
+
+output "cors_origin_regex" {
+  description = "Assembled regex applied to the Origin header by the CORS policy (for debugging / audit)"
+  value       = local.cors_origin_regex
 }
 
 output "rate_limiting" {

--- a/apim/terraform/variables.tf
+++ b/apim/terraform/variables.tf
@@ -42,25 +42,39 @@ variable "function_app_key" {
 # CORS CONFIGURATION
 # -----------------------------------------------------------------------------
 
-variable "cors_origins" {
+variable "cors_origin_patterns" {
   description = <<-EOT
-    List of allowed CORS origins. Each entry must be either:
-      - A wildcard "*" (allow any origin — appropriate for dev/preview)
-      - An HTTP/HTTPS URL (e.g. https://pcpc.maber.io)
+    Glob-style hostname patterns allowed by the CORS policy. Each pattern
+    matches against the host portion of the Origin header. The policy
+    automatically prepends `https://` when constructing the regex, so
+    only secure origins are matched.
 
-    APIM's CORS policy does not support wildcard subdomains in origins
-    (e.g. https://*.vercel.app is invalid). For environments that need to
-    accept many ephemeral origins (Vercel preview URLs), use "*".
+    Use `*` as a wildcard inside a pattern to match one or more
+    hostname-safe characters (lowercase alphanumerics and hyphens).
+    Standalone `*` is intentionally rejected — see ADR-013.
+
+    Examples:
+      "pcpc.maber.io"
+        → matches https://pcpc.maber.io exactly
+      "pcpc-git-*-abernaughtys-projects.vercel.app"
+        → matches Vercel per-PR preview URLs
+      "pcpc-*-abernaughtys-projects.vercel.app"
+        → matches Vercel commit-level URLs
+
+    See ADR-013 (CORS Regex Policy) for the design rationale: APIM's
+    built-in <cors> element doesn't support wildcard subdomains, so this
+    list is assembled into a regex used by a custom policy that echoes
+    the matched Origin back as Access-Control-Allow-Origin.
   EOT
   type        = list(string)
-  default     = ["http://localhost:3000"]
+  default     = ["pcpc.maber.io"]
 
   validation {
     condition = alltrue([
-      for origin in var.cors_origins :
-      origin == "*" || can(regex("^https?://", origin))
+      for p in var.cors_origin_patterns :
+      p != "*" && can(regex("^[a-z0-9.*-]+$", p))
     ])
-    error_message = "Each CORS origin must be \"*\" or a valid HTTP/HTTPS URL."
+    error_message = "Each pattern must be a hostname-style glob (lowercase alphanumerics, '.', '-', '*'). Standalone '*' is not supported; allow-any-origin is rejected by ADR-013."
   }
 }
 

--- a/docs/adr/ADR-011-deployment-topology-and-testing-model.md
+++ b/docs/adr/ADR-011-deployment-topology-and-testing-model.md
@@ -28,7 +28,7 @@ reflect distinct operational postures:
 | Alert thresholds | 10 fails | 10 fails | 5 fails (stricter) |
 | Terraform safety | none | none | `prevent_deletion_if_contains_resources` |
 | Key Vault on destroy | purge | purge | keep (`purge_soft_delete_on_destroy = false`) |
-| APIM CORS (Phase 1B) | `*` | `https://pcpc.maber.io` | `https://pcpc.maber.io` |
+| APIM CORS (Phase 1B, [revised by ADR-013](./ADR-013-cors-regex-policy.md)) | regex allowlist of `pcpc.maber.io` + Vercel preview patterns | regex allowlist of `pcpc.maber.io` only | regex allowlist of `pcpc.maber.io` only |
 | Custom hostname (Phase 1B) | `dev-api.pcpc.maber.io` | `staging-api.pcpc.maber.io` | `api.pcpc.maber.io` |
 
 Despite all that engineering, no ADR existed explaining *why* three

--- a/docs/adr/ADR-013-cors-regex-policy.md
+++ b/docs/adr/ADR-013-cors-regex-policy.md
@@ -1,0 +1,269 @@
+# ADR-013: CORS Regex-Based Origin Allowlist Policy
+
+## Status
+
+Accepted
+
+Date: 2026-05-07
+
+Supersedes: row 31 of [ADR-011](./ADR-011-deployment-topology-and-testing-model.md)
+("APIM CORS (Phase 1B) | dev = `*`") and the Phase 1B intent in PR #132's
+`base_cors_origins = ["*"]`.
+
+## Context
+
+[Phase 1B](../PORTFOLIO_PLAN.md) configured CORS on the dev APIM as `*` so
+Vercel per-PR preview URLs (`https://pcpc-git-{branch-slug}-abernaughtys-projects.vercel.app`)
+could exercise the BackendToggle's Path B healthcheck. Staging and prod
+were locked to `https://pcpc.maber.io`.
+
+The `*` choice was motivated by an APIM constraint Microsoft documents:
+the built-in `<cors>` policy element accepts only literal `*` or exact
+HTTP/HTTPS URLs in `<allowed-origins>`. Wildcard subdomains
+(e.g. `https://*.vercel.app`) are not supported. With per-PR Vercel
+preview URLs being inherently ephemeral, an explicit allowlist of literal
+URLs would either need maintenance per PR or settle for `*`.
+
+This ADR was prompted by an internal architecture review of the dev `*`
+choice. Three alternatives were evaluated:
+
+- **Adopt a `preview` branch workflow** (assign a stable Vercel custom
+  domain to a long-lived branch, e.g. `preview.pcpc.maber.io`) — rejected
+  for adding workflow ceremony in a one-developer project for marginal
+  gain. (Vercel's "All Branches" UI option for custom domains does not
+  actually save without a specific branch selected.)
+- **Lock to literal stable URLs only** (`https://pcpc.maber.io` plus
+  Vercel's auto-generated stable production aliases) — defensible but
+  loses per-PR browser-level testing of Path B for no real benefit over
+  the option below.
+- **Accept `*` permanently** — defensible for read-only public Pokémon
+  pricing data with no auth or cookies, but reads as careless in a
+  portfolio review.
+
+A fourth option — a custom regex-based policy using APIM's
+`<choose>/<when>` constructs to match the Origin header against an
+assembled regex — turned out to be the right answer. It eliminates the
+APIM constraint that motivated `*`, supports Vercel per-PR previews
+without per-PR maintenance, and keeps a tight allowlist in code.
+
+## Decision
+
+**Replace the built-in `<cors>` policy element with a regex-based custom
+policy.** The allowed-origins are expressed as glob-style hostname
+patterns in Terraform (`cors_origin_patterns` variable); a `locals` block
+in `apim/terraform/main.tf` assembles them into a single regex applied by
+the policy template.
+
+### Mechanism
+
+Terraform per-env wrappers set `base_cors_origin_patterns`:
+
+| Env | Patterns |
+|---|---|
+| dev | `pcpc.maber.io`, `pcpc-git-*-abernaughtys-projects.vercel.app`, `pcpc-*-abernaughtys-projects.vercel.app` |
+| staging | `pcpc.maber.io` |
+| prod | `pcpc.maber.io` |
+
+The `apim/terraform/main.tf` `locals` block converts patterns to regex by:
+1. Escaping literal `.` (so regex sees `\.`)
+2. Replacing glob `*` with `[a-z0-9-]+` (one or more hostname-safe chars)
+3. Joining with `|` and anchoring with `^https://(...)$`
+
+Example dev regex (assembled at `terraform plan` time):
+
+```
+^https://(pcpc\.maber\.io|pcpc-git-[a-z0-9-]+-abernaughtys-projects\.vercel\.app|pcpc-[a-z0-9-]+-abernaughtys-projects\.vercel\.app)$
+```
+
+The regex is interpolated into `apim/policies/templates/global-policy.xml.tpl`,
+which uses APIM's policy expressions to:
+
+- Read the request's `Origin` header into a context variable
+- Test the regex once and store the boolean result in another context
+  variable
+- For OPTIONS preflight requests: return 204 + CORS headers if allowed,
+  403 if not — short-circuiting before rate-limit
+- For non-preflight requests: pass through to backend, then add CORS
+  headers in the outbound stage if origin matched
+
+### Validation
+
+The `cors_origin_patterns` variable validation:
+- Rejects standalone `*` (the `*` shorthand for "any origin" is no longer
+  supported; this is intentional per this ADR)
+- Restricts characters to lowercase alphanumerics, `.`, `-`, `*` —
+  preventing accidental injection of regex metacharacters that would
+  silently widen the allowlist
+
+## Consequences
+
+### Positive
+
+- **Tight allowlist with zero per-PR maintenance.** Vercel preview URLs
+  for any new branch automatically match the existing pattern; no code
+  change per PR.
+- **Uniform policy mechanism across envs.** dev/staging/prod use the
+  same template; only the input data differs. Reading any env's policy
+  XML, a reviewer sees the same `<choose>/<when>` shape — easier to
+  audit than envs that use different policy mechanisms.
+- **Stronger portfolio signal.** A regex-based allowlist with a clean
+  Terraform interface (pattern list → assembled regex via `locals`)
+  reads as "engineer who knows APIM policy XML beyond the cookbook" to
+  enterprise reviewers, and "engineer who solved the actual UX problem"
+  to startup reviewers.
+- **Echo-back semantics, not wildcard.** The policy echoes the matched
+  Origin in `Access-Control-Allow-Origin` rather than `*`, which is
+  both more correct (browsers reject `*` for credentialed requests) and
+  enables future use of `Vary: Origin` for cache correctness — both
+  already configured in the policy.
+- **Hard rejection of disallowed preflight requests.** Returning 403 on
+  unmatched origins (rather than passing through and relying on the
+  browser to enforce CORS) provides defense-in-depth.
+
+### Negative
+
+- **More complex policy XML.** ~70 lines vs the prior ~30. Mitigated by
+  comments in both the template and ADR-013, plus the fact that the
+  policy is read-once-then-trusted: reviewers don't need to re-parse it
+  on every PR.
+- **Regex injection risk** if the pattern list ever accepted untrusted
+  input. Mitigated by the strict validation regex
+  (`^[a-z0-9.*-]+$`) — any other character is rejected at `terraform
+  plan` time.
+- **`<cors>` element's automatic preflight handling is replaced by
+  manual XML.** If APIM ever changes how `<cors>` handles edge cases
+  (e.g. malformed Origin headers), this policy won't get those changes
+  for free. Acceptable cost; the manual implementation is small enough
+  to audit.
+- **The `*` escape hatch is gone.** If a future use case genuinely
+  needs `Access-Control-Allow-Origin: *` (e.g. embedding the API in a
+  truly cross-origin context), this policy will need to be modified.
+  No such use case exists today.
+
+## Alternatives Considered
+
+### Option A — `preview` branch + stable Vercel custom domain
+
+Create a long-lived `preview` branch (or `develop`). Assign
+`preview.pcpc.maber.io` to it as a Vercel custom domain. PRs target
+`preview` first; the latest commit on `preview` is always live at
+`preview.pcpc.maber.io`. CORS list: `pcpc.maber.io`, `preview.pcpc.maber.io`.
+
+- **Pros:** Truly stable preview URL. Tight CORS without regex.
+- **Cons:** Adds workflow ceremony (extra branch, extra merge step per
+  PR) for marginal gain in a one-developer project. ADR-011 already
+  rejected per-env Vercel deployments for this same reason.
+- **Reason for rejection:** Not worth the workflow tax for a solo workflow.
+
+### Option B — Lock to literal stable URLs only
+
+`https://pcpc.maber.io`, `https://pcpc.vercel.app`,
+`https://pcpc-abernaughtys-projects.vercel.app`. Per-PR Vercel preview
+URLs are CORS-blocked; browser-level Path B testing on previews is
+unavailable. Use curl/Postman during PR work.
+
+- **Pros:** Tight CORS without any policy complexity (uses APIM's
+  built-in `<cors>` element).
+- **Cons:** Loses per-PR browser-level testing of Path B. Mostly
+  acceptable for solo workflow but loses an ability we can have for free.
+- **Reason for rejection:** This decision was the original
+  recommendation from the implementer. An internal architecture review
+  pushed back: Option D (this ADR) gets the same security tightness AND
+  the per-PR functionality, at the cost of more policy XML. The
+  XML-complexity cost is one-time-read, not per-PR.
+
+### Option C — `*` for dev (status quo before this ADR)
+
+- **Pros:** Zero complexity; works with all current and future Vercel
+  preview URLs without code change.
+- **Cons:** Reads as careless in a portfolio review. The "read-only
+  public data, who cares" justification is technically true but invites
+  the "did you think about this?" question rather than answering it.
+- **Reason for rejection:** Portfolio narrative cost; no functional
+  benefit over the regex policy.
+
+### Option E — Cloudflare proxy + Cloudflare-side CORS
+
+Front APIM with Cloudflare Workers and handle CORS in the worker.
+
+- **Pros:** Cloudflare's HTTP framework supports wildcard origins
+  natively.
+- **Cons:** Adds Cloudflare into the request path, which ADR-012 already
+  rejected for similar reasons; obscures the APIM-as-gateway portfolio
+  story.
+- **Reason for rejection:** Solves a problem this ADR's chosen approach
+  also solves, with worse architectural-narrative properties.
+
+## Implementation Notes
+
+### Files modified
+
+- `apim/terraform/variables.tf` — `cors_origins` (list of URLs) →
+  `cors_origin_patterns` (list of glob patterns); validator restricts
+  characters and rejects standalone `*`
+- `apim/terraform/main.tf` — adds `cors_origin_regex` local that
+  assembles the regex from patterns; threads it through `policy_vars`
+- `apim/terraform/outputs.tf` — exposes `cors_origin_patterns` (input)
+  and `cors_origin_regex` (assembled) for debugging and audit
+- `apim/policies/templates/global-policy.xml.tpl` — replaces `<cors>`
+  with `<choose>/<when>` regex policy; includes preflight handler with
+  hard 403 rejection of unmatched origins
+- `apim/environments/{dev,staging,prod}/variables.tf` — renames
+  `cors_origins` and `additional_cors_origins` to
+  `cors_origin_patterns` and `additional_cors_origin_patterns`
+- `apim/environments/{dev,staging,prod}/main.tf` — sets per-env
+  `base_cors_origin_patterns` defaults; renames internal locals
+- `pipelines/ado/templates/deploy-apim.yml` — writes
+  `cors_origin_patterns` JSON key in the pipeline-generated tfvars file
+  instead of `cors_origins`; ADO variable name `APIM_CORS_ORIGINS` is
+  preserved so the variable group entry doesn't need recreation, but
+  its value semantics change (URLs → patterns)
+
+### Manual ADO variable group update required
+
+The ADO variable group `vg-pcpc-{env}-config` entry `APIM_CORS_ORIGINS`
+was previously a list of HTTP/HTTPS URLs. After this PR merges, update
+each env's variable group as follows (or leave empty to use code defaults):
+
+| Env | New `APIM_CORS_ORIGINS` value |
+|---|---|
+| dev | `pcpc.maber.io,pcpc-git-*-abernaughtys-projects.vercel.app,pcpc-*-abernaughtys-projects.vercel.app` (or leave empty) |
+| staging | `pcpc.maber.io` (or leave empty) |
+| prod | `pcpc.maber.io` (or leave empty) |
+
+If left empty, the per-env code defaults (in
+`apim/environments/{env}/main.tf`) take effect.
+
+### Testing the policy after deploy
+
+```
+# Allowed origin should get a 204 + CORS headers on preflight
+curl -i -X OPTIONS https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets \
+  -H "Origin: https://pcpc.maber.io" \
+  -H "Access-Control-Request-Method: GET"
+# → 204 No Content, Access-Control-Allow-Origin: https://pcpc.maber.io
+
+# Vercel preview URL should also pass
+curl -i -X OPTIONS https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets \
+  -H "Origin: https://pcpc-git-foo-abernaughtys-projects.vercel.app" \
+  -H "Access-Control-Request-Method: GET"
+# → 204 No Content, Access-Control-Allow-Origin: https://pcpc-git-foo-abernaughtys-projects.vercel.app
+
+# Disallowed origin should get a 403
+curl -i -X OPTIONS https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets \
+  -H "Origin: https://malicious.example.com" \
+  -H "Access-Control-Request-Method: GET"
+# → 403 Origin not allowed by CORS policy
+
+# GET on actual endpoint with allowed origin should include CORS headers in response
+curl -i https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets \
+  -H "Origin: https://pcpc.maber.io"
+# → 200 with Access-Control-Allow-Origin: https://pcpc.maber.io
+```
+
+## Related Decisions
+
+- [ADR-007: API Architecture Spectrum](./ADR-007-api-architecture-spectrum.md)
+- [ADR-008: APIM vs SvelteKit BFF as Gateway](./ADR-008-apim-vs-bff-gateway.md)
+- [ADR-011: Deployment Topology and Testing Model](./ADR-011-deployment-topology-and-testing-model.md) — row 31 superseded
+- [ADR-012: APIM Managed Cert Suspension](./ADR-012-apim-managed-cert-suspension.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ Each ADR follows a standardized format:
 | [ADR-008](./ADR-008-apim-vs-bff-gateway.md) | APIM vs SvelteKit BFF as Gateway | Accepted | 2026-05-06 |
 | [ADR-011](./ADR-011-deployment-topology-and-testing-model.md) | Deployment Topology and Testing Model | Accepted | 2026-05-06 |
 | [ADR-012](./ADR-012-apim-managed-cert-suspension.md) | APIM Managed Cert Suspension — Defer Custom Hostnames | Accepted | 2026-05-07 |
+| [ADR-013](./ADR-013-cors-regex-policy.md) | CORS Regex-Based Origin Allowlist Policy | Accepted | 2026-05-07 |
 
 ### Planned (three-path portfolio story)
 

--- a/pipelines/ado/templates/deploy-apim.yml
+++ b/pipelines/ado/templates/deploy-apim.yml
@@ -135,12 +135,15 @@ steps:
         trap 'rm -f cors-origins.auto.tfvars.json' EXIT
         rm -f cors-origins.auto.tfvars.json
 
-        # Get CORS origins from pipeline variable
+        # Get CORS origin patterns from pipeline variable. Per ADR-013, this is
+        # a comma-separated list of glob-style hostname patterns (NOT URLs).
+        # The same APIM_CORS_ORIGINS variable name is reused for ADO variable
+        # group continuity; only the value semantics changed (URL → pattern).
         CORS_ORIGINS_RAW="${APIM_CORS_ORIGINS:-}"
 
         if [ -n "$CORS_ORIGINS_RAW" ]; then
-          echo "Using custom CORS origins override supplied by pipeline variable"
-          echo "DEBUG: Raw CORS value: [$CORS_ORIGINS_RAW]"
+          echo "Using custom CORS origin patterns override supplied by pipeline variable"
+          echo "DEBUG: Raw CORS patterns value: [$CORS_ORIGINS_RAW]"
 
           # Check if already JSON array format
           if [[ "$CORS_ORIGINS_RAW" =~ ^\[.*\]$ ]]; then
@@ -180,10 +183,13 @@ steps:
 
           echo "DEBUG: Generated JSON: $ORIGINS_JSON"
 
-          # Write the JSON file with proper formatting
+          # Write the JSON file with proper formatting. The JSON key matches
+          # the Terraform variable name (cors_origin_patterns) introduced by
+          # ADR-013; the file name is kept as cors-origins.auto.tfvars.json
+          # to avoid renaming pipeline-cleanup state and lock files.
           cat <<'JSONEOF' > cors-origins.auto.tfvars.json
           {
-            "cors_origins": CORS_PLACEHOLDER
+            "cors_origin_patterns": CORS_PLACEHOLDER
           }
         JSONEOF
 
@@ -204,7 +210,7 @@ steps:
           echo "✓ JSON validation passed"
           VAR_FILES+=("-var-file=cors-origins.auto.tfvars.json")
         else
-          echo "No custom CORS origins supplied; Terraform defaults will be used"
+          echo "No custom CORS origin patterns supplied; per-env Terraform defaults will be used (see ADR-013 + apim/environments/*/main.tf)"
         fi
 
         append_tf_var "api_version" "${APIM_API_VERSION:-}"


### PR DESCRIPTION
## Summary

Replaces the built-in APIM \`<cors>\` policy with a custom regex-based \`<choose>/<when>\` allowlist. Tightens dev CORS from \`*\` to a curated pattern set while still supporting Vercel per-PR preview URLs.

This implements [ADR-013](docs/adr/ADR-013-cors-regex-policy.md) and supersedes ADR-011's row 31 (dev=\`*\` choice from PR #132).

## Why

APIM's built-in \`<cors>\` element doesn't support wildcard subdomains. PR #132 originally settled for \`*\` on dev because Vercel per-PR preview URLs (\`pcpc-git-{branch-slug}-abernaughtys-projects.vercel.app\`) are inherently ephemeral and listing them per-PR would be operationally infeasible.

An internal architecture review pushed back: a custom \`<choose>/<when>\` policy with a regex-on-Origin check gets us tight allowlist + per-PR preview support simultaneously, at the cost of more policy XML (one-time read). The Plan agent's reasoning is captured in ADR-013's "Alternatives Considered" section.

## What changed

| Layer | Change |
|---|---|
| **Module variable** | \`cors_origins\` (URL list) → \`cors_origin_patterns\` (glob hostname patterns). Validator restricts characters to \`[a-z0-9.*-]\` and rejects standalone \`*\` to prevent regex injection and accidental allow-any. |
| **Module locals** | New \`cors_origin_regex\` local assembles patterns into \`^https://(pat1\|pat2\|...)$\` regex. Glob \`*\` becomes \`[a-z0-9-]+\` (one-or-more hostname-safe chars); literal \`.\` is escaped. |
| **Policy template** | \`apim/policies/templates/global-policy.xml.tpl\` — built-in \`<cors>\` replaced with \`<choose>/<when>\` block. Inbound: read Origin once, test regex once, cache result. OPTIONS preflight: 204 + CORS headers if matched, hard 403 if not. Outbound: add CORS response headers if origin matched. \`Vary: Origin\` set in both flows. |
| **Per-env defaults** | dev = \`pcpc.maber.io\` + \`pcpc-git-*-abernaughtys-projects.vercel.app\` + \`pcpc-*-abernaughtys-projects.vercel.app\`. staging/prod = \`pcpc.maber.io\` only. |
| **Pipeline script** | \`pipelines/ado/templates/deploy-apim.yml\` writes the new \`cors_origin_patterns\` JSON key. ADO variable name \`APIM_CORS_ORIGINS\` preserved for variable-group continuity; only value semantics change. |
| **ADR-013** | New ADR with design, three rejected alternatives (preview branch workflow, literal URL allowlist, status quo \`*\`), and Cloudflare-proxy rejection. |
| **ADR-011** | Row 31 updated to reference ADR-013 supersession. |
| **Outputs** | New \`cors_origin_patterns\` and \`cors_origin_regex\` outputs for debugging/audit. |

## Validation

- \`terraform fmt\` clean
- \`terraform validate\` green for \`apim/terraform\` and all three \`apim/environments/*\` (after backend-less init)
- **Local apim-layer plan was NOT run** (would require fetching the dev function app key locally, opted to skip per author preference). Relying on PR-Validation pipeline + dev CD plan stage to catch any apply-time surprises.

## What's NOT changed

- ADR-012's hostname-binding deferral stands (no APIM custom domains until Microsoft re-enables managed certs)
- The \`/health\` operation from PR #132 unaffected
- Rate-limit policy unchanged
- BackendToggle frontend code unchanged

## Manual ADO variable group update needed post-merge

The ADO variable group entry \`APIM_CORS_ORIGINS\` was previously a comma-separated list of URLs. After this PR merges, update each env's variable group as follows OR leave empty to use code defaults (recommended — code defaults are now the source of truth):

| Env | Recommended action |
|---|---|
| dev | Clear \`APIM_CORS_ORIGINS\` (use code default with Vercel preview patterns) |
| staging | Clear \`APIM_CORS_ORIGINS\` (use code default = \`pcpc.maber.io\` only) |
| prod | Clear \`APIM_CORS_ORIGINS\` (use code default = \`pcpc.maber.io\` only) |

Alternatively, set per-env \`APIM_CORS_ORIGINS\` to a comma-separated pattern list — see ADR-013 implementation notes for the exact values.

## Pre-merge state-lock dependency

The dev APIM Terraform state has an orphaned lock from a local \`terraform plan\` that hung waiting for input. Before this PR's CD pipeline can run, that needs:

\`\`\`
cd apim/environments/dev
terraform force-unlock 5d76502f-e979-4d97-b83e-03eb96cbd3e1
\`\`\`

Independent of this PR; the lock blocks any future apim/dev terraform run regardless of branch.

## Test plan

- [ ] PR-Validation ADO pipeline passes
- [ ] After merge + state-lock release: dev CD's APIM stage \`terraform plan\` shows update to global policy XML (regex-based) and no other unintended changes
- [ ] After dev CD: \`curl -i -X OPTIONS https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets -H "Origin: https://pcpc.maber.io" -H "Access-Control-Request-Method: GET"\` returns 204 with \`Access-Control-Allow-Origin: https://pcpc.maber.io\`
- [ ] After dev CD: same with \`Origin: https://pcpc-git-foo-abernaughtys-projects.vercel.app\` returns 204 with the matching origin echoed back
- [ ] After dev CD: \`Origin: https://malicious.example.com\` returns 403
- [ ] After dev CD: BackendToggle on Vercel previews shows Path B as healthy (the previously CORS-blocked healthcheck now succeeds)
- [ ] After staging/prod CD: same tests against \`pcpc-apim-{env}.azure-api.net\` succeed for \`pcpc.maber.io\` only

## Rollback

Tag \`phase-1b/pre-cors-regex\` was pushed before this work began.

🤖 Generated with [Claude Code](https://claude.com/claude-code)