### PR TITLE
fix(pipelines): handle legacy URL-format APIM_CORS_ORIGINS gracefully

### DIFF
--- a/pipelines/ado/templates/deploy-apim.yml
+++ b/pipelines/ado/templates/deploy-apim.yml
@@ -141,6 +141,22 @@ steps:
         # group continuity; only the value semantics changed (URL → pattern).
         CORS_ORIGINS_RAW="${APIM_CORS_ORIGINS:-}"
 
+        # Backward-compat guard: ADR-013 changed the value format from URLs
+        # to glob-style hostname patterns. If the variable group still holds
+        # legacy URL values (anything starting with http:// or https://),
+        # the new Terraform validator will reject them and `terraform plan`
+        # will fail. Detect this and fall back to per-env code defaults
+        # with a loud warning so the operator knows to clean up the
+        # variable group at their convenience.
+        if [ -n "$CORS_ORIGINS_RAW" ] && echo "$CORS_ORIGINS_RAW" | grep -qiE '(^|,)[[:space:]]*https?://'; then
+          echo "⚠️  WARNING: APIM_CORS_ORIGINS contains URL-format values (legacy ADR-008 format)."
+          echo "⚠️  ADR-013 changed the format to glob-style hostname patterns (e.g. 'pcpc.maber.io')."
+          echo "⚠️  Raw value: [$CORS_ORIGINS_RAW]"
+          echo "⚠️  Falling back to per-env Terraform code defaults (apim/environments/*/main.tf)."
+          echo "⚠️  To fix: clear APIM_CORS_ORIGINS in vg-pcpc-${{ parameters.environment }}-config OR replace with the new pattern format."
+          CORS_ORIGINS_RAW=""
+        fi
+
         if [ -n "$CORS_ORIGINS_RAW" ]; then
           echo "Using custom CORS origin patterns override supplied by pipeline variable"
           echo "DEBUG: Raw CORS patterns value: [$CORS_ORIGINS_RAW]"

--- a/pipelines/ado/templates/deploy-apim.yml
+++ b/pipelines/ado/templates/deploy-apim.yml
@@ -143,12 +143,16 @@ steps:
 
         # Backward-compat guard: ADR-013 changed the value format from URLs
         # to glob-style hostname patterns. If the variable group still holds
-        # legacy URL values (anything starting with http:// or https://),
-        # the new Terraform validator will reject them and `terraform plan`
-        # will fail. Detect this and fall back to per-env code defaults
-        # with a loud warning so the operator knows to clean up the
-        # variable group at their convenience.
-        if [ -n "$CORS_ORIGINS_RAW" ] && echo "$CORS_ORIGINS_RAW" | grep -qiE '(^|,)[[:space:]]*https?://'; then
+        # legacy URL values (anything containing http:// or https://, in
+        # either CSV or JSON-array format), the new Terraform validator
+        # will reject them and `terraform plan` will fail. Detect this and
+        # fall back to per-env code defaults with a loud warning so the
+        # operator knows to clean up the variable group at their convenience.
+        #
+        # The substring match is safe: ADR-013's pattern validator only
+        # accepts [a-z0-9.*-], so a legitimate hostname pattern can never
+        # contain the ':' or '/' chars in 'http://'.
+        if [ -n "$CORS_ORIGINS_RAW" ] && echo "$CORS_ORIGINS_RAW" | grep -qiE 'https?://'; then
           echo "⚠️  WARNING: APIM_CORS_ORIGINS contains URL-format values (legacy ADR-008 format)."
           echo "⚠️  ADR-013 changed the format to glob-style hostname patterns (e.g. 'pcpc.maber.io')."
           echo "⚠️  Raw value: [$CORS_ORIGINS_RAW]"


### PR DESCRIPTION
## Summary

Hotfix for the dev CD pipeline failure that surfaced after PR #135 (ADR-013) merged. The new \`cors_origin_patterns\` validator rejected the ADO variable group's legacy URL-format values, causing \`terraform plan\` to fail with:

\`\`\`
Error: Invalid value for variable
  var.cors_origin_patterns is list of string with 2 elements
  Each pattern must be a hostname-style glob (lowercase alphanumerics, '.', '-', '*').
  Standalone '*' is not supported; allow-any-origin is rejected by ADR-013.
\`\`\`

The legacy values (per the failed pipeline log earlier in this branch's history): \`http://localhost:3000\` and \`https://pcpc-dev.maber.io\` — both fail the new validator because of \`http(s)://\` prefixes.

## Root cause

PR #135's body called out a manual ADO variable group update needed post-merge. The CD pipeline ran before that manual update happened, so it tried to apply legacy values against the new validator.

## Fix

Adds a backward-compat guard to \`pipelines/ado/templates/deploy-apim.yml\`:

- Detects when \`APIM_CORS_ORIGINS\` contains URL-format values (starts with \`http://\` or \`https://\`)
- Logs a loud warning explaining the format change, quoting the offending raw value, and telling the operator exactly how to fix it
- Falls back to per-env Terraform code defaults instead of breaking CD

Per-env code defaults (introduced in PR #135):
- **dev:** \`pcpc.maber.io\` + Vercel preview patterns
- **staging:** \`pcpc.maber.io\` only
- **prod:** \`pcpc.maber.io\` only

These are the recommended values, so falling back to them is safe.

## Why this approach vs manual variable group update

Both work. Manual update (clearing \`APIM_CORS_ORIGINS\` in vg-pcpc-dev-config) is the documented post-merge step. This PR makes the pipeline self-healing in addition — future stale values (e.g. someone editing the variable group with the wrong format) degrade gracefully rather than breaking CD silently between merges and apply.

## Test plan

- [ ] PR-Validation passes (no terraform changes; just pipeline script update — should be a quick green)
- [ ] After merge: dev CD's APIM stage plan/apply succeeds, with the warning visible in the logs
- [ ] After dev CD: regex CORS policy applies cleanly (verify via \`curl -i -X OPTIONS https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets -H "Origin: https://pcpc.maber.io" -H "Access-Control-Request-Method: GET"\` returns 204 with matching origin echoed)
- [ ] Independently: clean up \`APIM_CORS_ORIGINS\` in vg-pcpc-{dev,staging,prod}-config to either empty or new pattern format (no time pressure)

## Rollback

Tag \`phase-1b/pre-cors-legacy-format-handler\` was pushed before this work began.

🤖 Generated with [Claude Code](https://claude.com/claude-code)