### PR TITLE
[DRAFT] fix(apim): per-alternative regex anchoring (Phase 1B handoff)

### DIFF
--- a/apim/policies/templates/global-policy.xml.tpl
+++ b/apim/policies/templates/global-policy.xml.tpl
@@ -20,10 +20,21 @@
         <!-- Resolve the request's Origin once and decide whether it matches the allowlist.
              Uses APIM's @{ ... return X; } code-block expression form (rather than @( single-expression ))
              to keep the cast/null-check/regex-match readable inside an XML attribute.
-             `Regex` is referenced unqualified — the APIM policy sandbox has
-             System.Text.RegularExpressions pre-imported (per the docs example), and
-             the fully-qualified name `System.Text.RegularExpressions.Regex` is rejected
-             by APIM's policy validator with a generic "ValidationError" 400. -->
+
+             Two APIM-policy-parser quirks shaped this expression:
+
+             1. The fully-qualified `System.Text.RegularExpressions.Regex` is
+                NOT accepted; use unqualified `Regex` (the sandbox pre-imports
+                System.Text.RegularExpressions).
+
+             2. APIM's policy expression parser does not respect C# verbatim
+                string boundaries, so any `(` inside a `@"..."` regex literal
+                is naively counted as a code-level open paren. The assembled
+                `cors_origin_regex` (in apim/terraform/main.tf locals) therefore
+                anchors each alternative individually with `^https://...$|...`
+                rather than grouping under shared `^https://(...)$` anchors —
+                that produces a regex with zero parens and avoids tripping the
+                parser's paren-counting logic. -->
         <set-variable name="originHeader" value="@(context.Request.Headers.GetValueOrDefault(&quot;Origin&quot;, &quot;&quot;))" />
         <set-variable name="isOriginAllowed" value="@{ var origin = (string)context.Variables[&quot;originHeader&quot;]; if (string.IsNullOrEmpty(origin)) { return false; } return Regex.IsMatch(origin, @&quot;${cors_origin_regex}&quot;); }" />
 

--- a/apim/terraform/main.tf
+++ b/apim/terraform/main.tf
@@ -68,10 +68,18 @@ locals {
   # Pipeline:
   #   1. Escape literal `.` so regex sees an escaped dot
   #   2. Convert glob `*` into [a-z0-9-]+ (one-or-more hostname-safe chars)
-  #   3. Join with `|` and anchor with ^https://(...)$
+  #   3. Anchor each alternative individually with ^https://...$ and join
+  #      with `|`. Per-alternative anchoring (instead of shared anchors
+  #      around a parenthesized group) is intentional: APIM's policy
+  #      expression parser doesn't respect C# verbatim string boundaries
+  #      and naively counts parens inside @"..." as code parens. A regex
+  #      with `(...)` inside a Regex.IsMatch call therefore confuses
+  #      APIM's parser into orphaning the IsMatch( open paren, producing
+  #      a "missing closing )" ValidationError 400 at deploy time. This
+  #      pattern produces an equivalent regex with zero parens.
   #
   # Example: ["pcpc.maber.io", "pcpc-git-*-abernaughtys-projects.vercel.app"]
-  # becomes "^https://(pcpc\.maber\.io|pcpc-git-[a-z0-9-]+-abernaughtys-projects\.vercel\.app)$"
+  # becomes "^https://pcpc\.maber\.io$|^https://pcpc-git-[a-z0-9-]+-abernaughtys-projects\.vercel\.app$"
   cors_patterns_dot_escaped = [
     for p in var.cors_origin_patterns :
     replace(p, ".", "\\.")
@@ -80,7 +88,11 @@ locals {
     for p in local.cors_patterns_dot_escaped :
     replace(p, "*", "[a-z0-9-]+")
   ]
-  cors_origin_regex = "^https://(${join("|", local.cors_patterns_with_classes)})$"
+  cors_patterns_anchored = [
+    for p in local.cors_patterns_with_classes :
+    "^https://${p}$"
+  ]
+  cors_origin_regex = join("|", local.cors_patterns_anchored)
 
   # Policy template variables
   policy_vars = {

--- a/docs/adr/ADR-013-cors-regex-policy.md
+++ b/docs/adr/ADR-013-cors-regex-policy.md
@@ -67,13 +67,23 @@ Terraform per-env wrappers set `base_cors_origin_patterns`:
 The `apim/terraform/main.tf` `locals` block converts patterns to regex by:
 1. Escaping literal `.` (so regex sees `\.`)
 2. Replacing glob `*` with `[a-z0-9-]+` (one or more hostname-safe chars)
-3. Joining with `|` and anchoring with `^https://(...)$`
+3. Anchoring each alternative INDIVIDUALLY with `^https://...$` and joining
+   with `|`
 
 Example dev regex (assembled at `terraform plan` time):
 
 ```
-^https://(pcpc\.maber\.io|pcpc-git-[a-z0-9-]+-abernaughtys-projects\.vercel\.app|pcpc-[a-z0-9-]+-abernaughtys-projects\.vercel\.app)$
+^https://pcpc\.maber\.io$|^https://pcpc-git-[a-z0-9-]+-abernaughtys-projects\.vercel\.app$|^https://pcpc-[a-z0-9-]+-abernaughtys-projects\.vercel\.app$
 ```
+
+> **Why per-alternative anchoring instead of a single grouped `(...)`?**
+> APIM's policy expression parser does not respect C# verbatim string
+> boundaries — it naively counts `(` and `)` inside a `@"..."` regex
+> literal as code parens. A regex like `^https://(a|b|c)$` therefore
+> orphans the `IsMatch(` call in the surrounding C# code, producing a
+> `ValidationError: An opening "(" is missing the corresponding closing ")"`
+> 400 at deploy time. Anchoring each alternative individually produces an
+> equivalent regex with zero parens, sidestepping the parser quirk.
 
 The regex is interpolated into `apim/policies/templates/global-policy.xml.tpl`,
 which uses APIM's policy expressions to:


### PR DESCRIPTION
## ⚠️ DRAFT — pending manual Portal validation before ready

This PR contains the latest Phase 1B fix for the APIM policy \`400 ValidationError\` that has persisted across PRs #135, #137, #138.

**Do NOT merge** until the rendered policy XML is manually validated in the Azure Portal policy code editor (per the in-conversation diagnostic flow that produced this fix).

## Root cause (verified via Portal)

APIM's policy expression parser does NOT respect C# verbatim string boundaries. With a \`Regex.IsMatch(origin, @"^https://(a|b|c)$")\` call, the regex's \`(\` consumes IsMatch's matching \`)\`, orphaning IsMatch and producing:

\`\`\`
An opening "(" is missing the corresponding closing ")". Line 21, position 194.
The code block is missing a closing "}" character.
\`\`\`

Position 194 is the opening paren of the \`IsMatch(\` call.

## Fix

Anchor each pattern alternative individually so the assembled regex contains zero parens. Functionally equivalent.

**Old (broken):**
\`\`\`
^https://(pcpc\.maber\.io|pcpc-git-[a-z0-9-]+-...vercel\.app|pcpc-[a-z0-9-]+-...vercel\.app)$
\`\`\`

**New (no parens):**
\`\`\`
^https://pcpc\.maber\.io$|^https://pcpc-git-[a-z0-9-]+-...vercel\.app$|^https://pcpc-[a-z0-9-]+-...vercel\.app$
\`\`\`

## Files changed

- \`apim/terraform/main.tf\` — locals add \`cors_patterns_anchored\` step
- \`apim/policies/templates/global-policy.xml.tpl\` — comment documents both APIM parser quirks (no fully-qualified \`Regex\`, no verbatim string awareness)
- \`docs/adr/ADR-013-cors-regex-policy.md\` — Mechanism section + callout explaining the parser quirk

## Validation status

- [x] \`terraform fmt\` clean
- [x] \`terraform init -backend=false\` + \`terraform validate\` green for \`apim/terraform\`
- [ ] **Manual validation in Azure Portal policy code editor** ← BLOCKER for marking ready
- [ ] PR-Validation pipeline (will run on draft)
- [ ] After mark-ready + merge: dev CD apply succeeds
- [ ] curl tests from ADR-013 verification section pass

## Handoff context for next session

See linked tracking issue. Rollback tag: \`phase-1b/pre-regex-parens-fix\`. Locally rendered debug XML at \`apim/policies/generated/global-policy-dev-RENDERED-FOR-DEBUG.xml\` (uncommitted, paste into Portal to validate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Tracking issue:** #140 (Phase 1B handoff)