### PR TITLE
docs: mark Phase 0/1A done + Phase 1B mostly-done in PORTFOLIO_PLAN

### DIFF
--- a/docs/PORTFOLIO_PLAN.md
+++ b/docs/PORTFOLIO_PLAN.md
@@ -1,9 +1,25 @@
 # PCPC Portfolio Plan: Tale of Three Architectures
 
 **Owner:** Michael Abernathy
-**Status:** Draft → Active (pending Phase 0 kickoff)
-**Last Updated:** 2026-05-05
+**Status:** Phase 0 done · Phase 1A done · Phase 1B mostly done (1 fix outstanding on PR #139, see issue #140) · Phase 2 not started
+**Last Updated:** 2026-05-07
 **Target Completion:** ~1 week (2 weeks conservative)
+
+## Phase progress (live, supersedes the per-phase status tables below)
+
+- **Phase 0:** ✅ done. Consolidation merged. Tags: `phase-0/pre-consolidation`, `phase-0/legacy-spa-archive`.
+- **Phase 1A:** ✅ done via PR #131. BackendToggle UI, abstraction layer (`frontend/src/lib/backends/`), pokedata→scrydex adapter, ADR-007 (API Architecture Spectrum), ADR-008 (APIM vs BFF), `docs/architecture-comparison.md`, README live-demo section.
+- **Phase 1B:** mostly done via PRs #132, #133, #134, #135, #136, #137, #138. Custom domain scaffolding deferred per ADR-012 (Azure cert suspension). CORS regex policy from ADR-013 has one outstanding apply-time fix (PR #139, DRAFT — see issue #140). Once #139 merges and dev CD applies cleanly, Phase 1B is done.
+- **Phase 2:** not started. Containerize Functions, Scrydex schema migration, ACA path, ADR-009.
+- **Phase 3:** not started.
+
+## ADRs accepted across Phase 1
+
+- [ADR-007](./adr/ADR-007-api-architecture-spectrum.md) — API Architecture Spectrum
+- [ADR-008](./adr/ADR-008-apim-vs-bff-gateway.md) — APIM vs SvelteKit BFF as Gateway
+- [ADR-011](./adr/ADR-011-deployment-topology-and-testing-model.md) — Deployment Topology and Testing Model
+- [ADR-012](./adr/ADR-012-apim-managed-cert-suspension.md) — APIM Managed Cert Suspension (defer custom domains)
+- [ADR-013](./adr/ADR-013-cors-regex-policy.md) — CORS Regex-Based Origin Allowlist Policy
 
 ---
 
@@ -381,9 +397,9 @@ These are deferred and tracked here for resolution at or before the relevant pha
 1. **`@maber/*` package handling during migration.** Resolved by the Phase 0 audit task: inline into `frontend/src/lib/` for minimal usage; copy as `@pcpc/*` packages for heavy usage. Audit happens before the merge step.
 2. **Whether to introduce Turbo at the PCPC repo root.** pnpm workspaces alone are sufficient for the current shape; Turbo adds task orchestration that may or may not be worth the config. Decision: defer until Phase 0 reveals whether root-level scripts feel awkward.
 3. **Portfolio site domain.** `maber.io` (root) vs `portfolio.maber.io` (subdomain)? Decision needed before Phase 3.
-4. **Custom domains for backends.** `api.pcpc.maber.io` and `aca.pcpc.maber.io` are placeholders. Final names TBD before Phase 1.
+4. ~~**Custom domains for backends.** `api.pcpc.maber.io` and `aca.pcpc.maber.io` are placeholders. Final names TBD before Phase 1.~~ **Resolved 2026-05-06:** per-env scheme `dev-api.pcpc.maber.io`, `staging-api.pcpc.maber.io`, `api.pcpc.maber.io`. **Currently DEFERRED** per ADR-012 (Azure-managed cert creation suspended Aug 15 2025 → Jun 30 2026); IaC scaffolding in place, restoration runbook in ADR-012.
 5. ~~**Legacy Svelte 4 SPA in PCPC.** Retire it during Phase 0 consolidation, archive it under a tag, or keep it as a historical reference frontend?~~ **Resolved 2026-05-06:** archived at the `phase-0/legacy-spa-archive` tag and removed from main alongside the SWA deploy stage and validate-frontend PR pipeline. The Azure Static Web App resource and its Terraform module are left intact for separate deprovisioning when convenient.
-6. **APIM custom domain SSL.** Free Azure-managed cert vs Let's Encrypt vs purchased cert? Decision needed in Phase 1.
+6. ~~**APIM custom domain SSL.** Free Azure-managed cert vs Let's Encrypt vs purchased cert? Decision needed in Phase 1.~~ **Resolved 2026-05-06:** Azure-managed cert. **Currently DEFERRED** per ADR-012 — Microsoft suspended new managed cert creation through at least June 2026. See ADR-012 for the deferral rationale and the restoration runbook.
 7. **ACA min replicas.** 0 (cold start, save $5/month) vs 1 (always warm, better demo)? Decision needed in Phase 2; current lean is 1.
 8. **`maber-web` repo fate.** After PCPC consolidation, `maber-web` becomes a 3-app monorepo (landing, blackjack, portfolio). Keep as-is, rename to reflect new scope, or eventually retire? Decision: keep as-is; revisit if/when the other apps are also reorganized.
 9. **GitHub Actions revisit in Phase 3.** Whether adding a frontend GitHub Actions workflow strengthens the comparison narrative enough to justify the duplication with Vercel's PR builds. Decision deferred to Phase 3 evaluation.


### PR DESCRIPTION
## Summary

Updates the canonical \`docs/PORTFOLIO_PLAN.md\` to reflect actual phase status:

- Header line: status updated to "Phase 0 done · Phase 1A done · Phase 1B mostly done · Phase 2 not started", last-updated date refreshed to 2026-05-07
- New **Phase progress** section near the top of the doc supersedes the per-phase status tables further down (those remain for historical context)
- New **ADRs accepted across Phase 1** section links the 5 new ADRs (007, 008, 011, 012, 013)
- Open Questions #4 (custom domain naming) and #6 (APIM SSL cert choice) marked resolved-with-deferral pointing at ADR-012

Phase 1B has one outstanding fix (regex parens) tracked in #140 / PR #139 (DRAFT). Once that merges, Phase 1B is fully done and Phase 2 can begin.

Pure docs change — no code or infra impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)