### PR TITLE
docs(phase-2.2): ADR-009 + 3-column architecture comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A single product (Pokémon card pricing) deployed three ways from one repo to demonstrate architectural range across modern-edge, enterprise-cloud, and managed-container patterns. **One frontend, three interchangeable backends, one shared schema.**
 
-> **Status:** Phase 1 in progress — see [`docs/PORTFOLIO_PLAN.md`](docs/PORTFOLIO_PLAN.md).
-> **Live demo:** [pcpc.maber.io](https://pcpc.maber.io) — toggle backends via the corner badge or `?backend=vercel|azure`
-> **Architecture comparison:** [`docs/architecture-comparison.md`](docs/architecture-comparison.md) *(Path A & B; Path C lands in Phase 2)*
+> **Status:** Phase 2.2 in progress (containerize Functions + ACA path) — see [`docs/PORTFOLIO_PLAN.md`](docs/PORTFOLIO_PLAN.md).
+> **Live demo:** [pcpc.maber.io](https://pcpc.maber.io) — toggle backends via the corner badge or `?backend=vercel|azure` (Path C `?backend=aca` ships with Phase 2.2 PR-3)
+> **Architecture comparison:** [`docs/architecture-comparison.md`](docs/architecture-comparison.md) — all three paths described; Path C deploys via Phase 2.2.
 
 ---
 
@@ -48,15 +48,14 @@ All three paths share the same Cosmos DB account and the same TypeScript types v
 
 ## Live demo
 
-[pcpc.maber.io](https://pcpc.maber.io) — one URL, one frontend, two switchable backends today (three after Phase 2). A corner badge surfaces the active path with its latency; click to switch, or pin via `?backend=vercel|azure` in the URL. Healthcheck-driven graceful degradation hides any path whose `/health` does not respond within 2s, so partial outages never break the demo. The toggle defaults to Path A — a recruiter who never engages it gets a normal app experience.
+[pcpc.maber.io](https://pcpc.maber.io) — one URL, one frontend, two switchable backends today (three once Phase 2.2 PR-3 ships the ACA toggle). A corner badge surfaces the active path with its latency; click to switch, or pin via `?backend=vercel|azure|aca` in the URL. Healthcheck-driven graceful degradation hides any path whose `/health` does not respond within 2s, so partial outages never break the demo. The toggle defaults to Path A — a recruiter who never engages it gets a normal app experience.
 
 | URL | What it hits |
 |---|---|
 | `pcpc.maber.io` | Path A (default) |
 | `pcpc.maber.io/?backend=vercel` | Path A explicitly |
-| `pcpc.maber.io/?backend=azure` | Path B (APIM + Functions, dev environment) |
-
-> **Phase 1 caveat (resolved in Phase 2):** Path B's Functions still serve the legacy PokeData schema. The frontend bridges shapes via a temporary adapter; per-variant pricing renders as "no data" on Path B until the Phase 2 schema migration. Full context: [`docs/architecture-comparison.md`](docs/architecture-comparison.md).
+| `pcpc.maber.io/?backend=azure` | Path B (APIM + Functions, dev environment — Scrydex-native post-Phase-2.1) |
+| `pcpc.maber.io/?backend=aca` | Path C (ACA-containerized Functions) — wires up in Phase 2.2 PR-3 |
 
 ## Architecture decision records
 
@@ -64,7 +63,7 @@ Decisions live in [`docs/adr/`](docs/adr/). The existing ADRs (001–006) cover 
 
 - **[ADR-007](docs/adr/ADR-007-api-architecture-spectrum.md)** — API architecture spectrum (why three paths exist) *(Accepted, Phase 1)*
 - **[ADR-008](docs/adr/ADR-008-apim-vs-bff-gateway.md)** — APIM vs SvelteKit BFF as gateway *(Accepted, Phase 1)*
-- **ADR-009** — Functions Consumption vs Container Apps *(Phase 2)*
+- **[ADR-009](docs/adr/ADR-009-functions-consumption-vs-container-apps.md)** — Functions Consumption vs Container Apps *(Accepted, Phase 2.2)*
 - **ADR-010** *(optional)* — Path to AKS *(Phase 3)*
 
 ## Repository layout
@@ -108,9 +107,10 @@ Backend (Path B) and infrastructure are run via `pipelines/ado/` and Terraform m
 | Phase | Goal | Status |
 |---|---|---|
 | **0** | Consolidate maber-web/apps/pcpc into this repo, set up workspace, add portfolio surface | done |
-| **1** | Live two-path toggle (Vercel BFF + APIM/Functions), ADR-007 & ADR-008, comparison doc | in progress |
-| **2** | Containerize Functions, ship ACA path, Scrydex schema migration, ADR-009 | after Phase 1 |
-| **3** | Polish: portfolio site, LinkedIn distribution, ADR-010 | final |
+| **1** | Live two-path toggle (Vercel BFF + APIM/Functions), ADR-007 & ADR-008, comparison doc | done |
+| **2.1** | Cut backend over from PokeData to Scrydex; `@pcpc/shared` canonical types; smoke tests re-promoted to blocking | done (PRs #145, #146) |
+| **2.2** | Containerize Functions, ship ACA path, ADR-009 | in progress |
+| **3** | Polish: portfolio site, LinkedIn distribution, ADR-010 | after Phase 2.2 |
 
 Full plan with risks, success metrics, and open questions: [`docs/PORTFOLIO_PLAN.md`](docs/PORTFOLIO_PLAN.md).
 

--- a/docs/PORTFOLIO_PLAN.md
+++ b/docs/PORTFOLIO_PLAN.md
@@ -9,14 +9,16 @@
 
 - **Phase 0:** ✅ done. Consolidation merged. Tags: `phase-0/pre-consolidation`, `phase-0/legacy-spa-archive`.
 - **Phase 1A:** ✅ done via PR #131. BackendToggle UI, abstraction layer (`frontend/src/lib/backends/`), pokedata→scrydex adapter, ADR-007 (API Architecture Spectrum), ADR-008 (APIM vs BFF), `docs/architecture-comparison.md`, README live-demo section.
-- **Phase 1B:** mostly done via PRs #132, #133, #134, #135, #136, #137, #138. Custom domain scaffolding deferred per ADR-012 (Azure cert suspension). CORS regex policy from ADR-013 has one outstanding apply-time fix (PR #139, DRAFT — see issue #140). Once #139 merges and dev CD applies cleanly, Phase 1B is done.
-- **Phase 2:** not started. Containerize Functions, Scrydex schema migration, ACA path, ADR-009.
+- **Phase 1B:** ✅ done via PRs #132–#138 (+ #139/#141/#142/#143/#144 closing out the apply-time fix path). Custom domains deferred per ADR-012; CORS regex policy live per ADR-013.
+- **Phase 2.1:** ✅ done via PRs #145, #146 (2026-05-12). Backend cut over from PokeData to Scrydex. `@pcpc/shared` canonical types, `ScrydexApiService.ts`, smoke tests re-promoted to blocking. Tags: `phase-2/pre-scrydex-cutover`, `phase-2/post-scrydex-cutover`.
+- **Phase 2.2:** in progress. Containerize Functions + ACA path. PR-1 (this work): ADR-009 + 3-column comparison doc. PR-2: Dockerfile + container-app Terraform module + ADO pipeline stage (dev only). PR-3: frontend toggle + Vercel env var.
 - **Phase 3:** not started.
 
-## ADRs accepted across Phase 1
+## ADRs accepted across Phases 1 and 2
 
 - [ADR-007](./adr/ADR-007-api-architecture-spectrum.md) — API Architecture Spectrum
 - [ADR-008](./adr/ADR-008-apim-vs-bff-gateway.md) — APIM vs SvelteKit BFF as Gateway
+- [ADR-009](./adr/ADR-009-functions-consumption-vs-container-apps.md) — Functions Consumption vs Container Apps
 - [ADR-011](./adr/ADR-011-deployment-topology-and-testing-model.md) — Deployment Topology and Testing Model
 - [ADR-012](./adr/ADR-012-apim-managed-cert-suspension.md) — APIM Managed Cert Suspension (defer custom domains)
 - [ADR-013](./adr/ADR-013-cors-regex-policy.md) — CORS Regex-Based Origin Allowlist Policy
@@ -400,7 +402,7 @@ These are deferred and tracked here for resolution at or before the relevant pha
 4. ~~**Custom domains for backends.** `api.pcpc.maber.io` and `aca.pcpc.maber.io` are placeholders. Final names TBD before Phase 1.~~ **Resolved 2026-05-06:** per-env scheme `dev-api.pcpc.maber.io`, `staging-api.pcpc.maber.io`, `api.pcpc.maber.io`. **Currently DEFERRED** per ADR-012 (Azure-managed cert creation suspended Aug 15 2025 → Jun 30 2026); IaC scaffolding in place, restoration runbook in ADR-012.
 5. ~~**Legacy Svelte 4 SPA in PCPC.** Retire it during Phase 0 consolidation, archive it under a tag, or keep it as a historical reference frontend?~~ **Resolved 2026-05-06:** archived at the `phase-0/legacy-spa-archive` tag and removed from main alongside the SWA deploy stage and validate-frontend PR pipeline. The Azure Static Web App resource and its Terraform module are left intact for separate deprovisioning when convenient.
 6. ~~**APIM custom domain SSL.** Free Azure-managed cert vs Let's Encrypt vs purchased cert? Decision needed in Phase 1.~~ **Resolved 2026-05-06:** Azure-managed cert. **Currently DEFERRED** per ADR-012 — Microsoft suspended new managed cert creation through at least June 2026. See ADR-012 for the deferral rationale and the restoration runbook.
-7. **ACA min replicas.** 0 (cold start, save $5/month) vs 1 (always warm, better demo)? Decision needed in Phase 2; current lean is 1.
+7. ~~**ACA min replicas.** 0 (cold start, save $5/month) vs 1 (always warm, better demo)?~~ **Resolved 2026-05-12 (Phase 2.2 PR-1):** min_replicas = 1 in dev. Rationale: the frontend's 2-second `probeHealth` timeout at [`frontend/src/lib/backends/health.ts`](../frontend/src/lib/backends/health.ts) is shorter than ACA's 1–3s cold-start at min=0, so min=0 would falsely degrade Path C after every idle period and hide it from the toggle. Cost envelope ~$5–15/mo per env documented in [ADR-009](./adr/ADR-009-functions-consumption-vs-container-apps.md).
 8. **`maber-web` repo fate.** After PCPC consolidation, `maber-web` becomes a 3-app monorepo (landing, blackjack, portfolio). Keep as-is, rename to reflect new scope, or eventually retire? Decision: keep as-is; revisit if/when the other apps are also reorganized.
 9. **GitHub Actions revisit in Phase 3.** Whether adding a frontend GitHub Actions workflow strengthens the comparison narrative enough to justify the duplication with Vercel's PR builds. Decision deferred to Phase 3 evaluation.
 

--- a/docs/adr/ADR-009-functions-consumption-vs-container-apps.md
+++ b/docs/adr/ADR-009-functions-consumption-vs-container-apps.md
@@ -1,0 +1,254 @@
+# ADR-009: Functions Consumption vs Container Apps
+
+## Status
+
+Accepted
+
+Date: 2026-05-12
+
+## Context
+
+After Phase 2.1, Path B (APIM → Azure Functions v4 on a Consumption plan) is
+Scrydex-native end-to-end. The Functions code is stable, the schema is
+canonical, and the deployment pipeline is mature. Path B alone already
+satisfies the enterprise/regulated-industry audience the portfolio plan
+([`PORTFOLIO_PLAN.md`](../PORTFOLIO_PLAN.md)) targets with Azure depth.
+
+Phase 2.2 adds a **third path** by taking the *same* Functions code,
+packaging it as an OCI image, and running it on **Azure Container Apps**
+with the Functions custom-container base image. Path C is not a rewrite
+and not a separate codebase — it is a different runtime envelope around
+identical application code, deployed to the same Cosmos DB and observed
+through the same Application Insights workspace.
+
+The question this ADR answers is **why both runtimes exist in the same
+project, and when each one is the right call.** As with
+[ADR-008](./ADR-008-apim-vs-bff-gateway.md), the answer is not "one is
+better"; the answer is a decision rule that a senior+ engineer would
+write down. The portfolio's job is to show that decision rule explicitly.
+
+This ADR is intentionally narrower than [ADR-007](./ADR-007-api-architecture-spectrum.md).
+ADR-007 explains why three deployment paths exist at all. This ADR
+explains the runtime-shaped tradeoff between two of them.
+
+## Decision
+
+**Keep both runtimes. Run Functions on Consumption when the workload
+matches Consumption's grain (event-driven, bursty, scale-to-zero
+acceptable, vendor lock-in tolerable). Run Functions in a container on
+ACA when the workload needs portable image immutability, richer scaling
+triggers, or a deployment story that an auditor will sign.** Both
+runtimes execute byte-identical application code and serve byte-identical
+responses to the frontend.
+
+The decision rule, written for future selves and for portfolio readers:
+
+| Choose Functions Consumption when… | Choose Functions on ACA when… |
+|---|---|
+| Workload is request/response with low or unpredictable RPS | Workload benefits from richer scaling triggers (HTTP, queue depth, Cosmos change feed, custom KEDA scalers) |
+| Cold start of ~500–1500ms is acceptable at the cold tail | Cold start must be predictable (min replicas ≥ 1 keeps it ~0ms; configurable per env) |
+| Cost at idle must be exactly $0 | Cost at idle is acceptable at ~$5–15/mo per replica-environment for guaranteed warmth |
+| Runtime lock-in to Azure Functions host is tolerable | Image must be portable (same OCI image runs on AKS, ECS, GKE, local Docker) |
+| Deploy artifact is a ZIP attached to a managed host | Deploy artifact is a digest-pinned image scanned and stored in a registry |
+| Operator team accepts "publish and forget" runtime opacity | Auditor needs to attest *exactly* what's running (image SHA, base image provenance, CVE scan results) |
+| KEDA primitives are not needed | KEDA primitives (event-source-driven autoscale) are part of the design |
+
+## Consequences
+
+### Positive
+
+- **Same code, two runtimes, observable difference.** The portfolio
+  artifact is no longer "we describe a tradeoff" but "we ran the same
+  code two ways and the latency badge tells you which one you're on."
+  This is the most legible possible demonstration of runtime fluency.
+- **Container immutability is real, not aspirational.** Every Path C
+  deploy is a digest-pinned image (`pcpc/functions@sha256:…`), scanned
+  for CVEs in CI before push, and rolled to ACA as an atomic revision.
+  Path B's ZIP-and-deploy model is operationally lighter but offers no
+  comparable supply-chain story.
+- **KEDA is the natural next step.** ACA's scale rules expose Cosmos
+  change feed, Service Bus queue depth, Event Hubs, and custom HTTP
+  metrics as autoscale triggers. The first revision of Path C uses the
+  default HTTP scale rule for simplicity, but the door is open to
+  meaningful demonstrations of event-driven autoscale in Phase 3 without
+  re-architecting.
+- **Observability parity, free.** Both runtimes set the same
+  `APPLICATIONINSIGHTS_CONNECTION_STRING` and the same `cloud_RoleName`
+  convention, so Path B and Path C traces land in the same Log Analytics
+  workspace, queryable side by side. The portfolio can demonstrate
+  end-to-end traces across runtimes without bolting on anything new.
+- **Auditor-friendly artifact lineage.** Image build → CVE scan → ACR
+  push → revision pin in Terraform → ACA revision rollout is a chain a
+  FedRAMP/ATO assessor can follow. Path B's "deploy a ZIP via az
+  functionapp deployment" is harder to attest.
+
+### Negative
+
+- **Two pipelines for the same code.** Path B has its
+  `deploy-functions.yml` template; Path C adds a parallel `deploy-aca.yml`
+  with its own image build, CVE scan, push, and revision update steps.
+  Maintaining both costs operational attention that a real product would
+  amortize over more meaningful divergence.
+- **Higher idle cost.** Functions Consumption is exactly $0 at idle.
+  ACA at min_replicas=1 is ~$5–15/mo per replica-environment. The
+  portfolio justifies this because warm-start makes the live demo feel
+  snappy, but for a real product without a recruiter-demo constraint,
+  min_replicas=0 (or Consumption) would often be the right call.
+- **Health-probe timing coupling.** ACA's cold-start at min_replicas=0
+  exceeds the frontend's 2-second `probeHealth` timeout, which would
+  cause the toggle to falsely mark Path C unhealthy after every idle
+  period. The portfolio resolves this by defaulting to min_replicas=1.
+  A real workload with bursty traffic and tolerant clients could ship
+  min=0 cleanly; the constraint is the *demo*, not the runtime.
+- **Larger deployment artifact.** A Functions ZIP is megabytes; a
+  Functions container image is hundreds of megabytes (base image +
+  Node + node_modules). Pull time at cold start is non-trivial. The
+  base image (`mcr.microsoft.com/azure-functions/node:4-node22`) is
+  cached on the ACA node, but the first pull after a node hop is
+  visible in cold-start latency.
+- **Two scale models to reason about.** Functions Consumption scales
+  by request rate, opaquely. ACA scales by an explicit rule (HTTP
+  concurrency by default), which is more legible *and* more rope. A
+  misconfigured `max_replicas` could exhaust Cosmos RU/s in a way the
+  Functions host would have throttled gracefully.
+
+## Alternatives Considered
+
+### Option 1: Functions on Consumption only (skip Path C entirely)
+
+- **Pros**: Lower operational surface; lower cost; Path B already
+  demonstrates the enterprise Azure story end-to-end.
+- **Cons**: Forecloses the container/KEDA/image-immutability narrative
+  entirely; weakens the portfolio's FedRAMP/ATO posture talking point;
+  the three-path comparison collapses to two and the architectural
+  *spectrum* (the framing of [ADR-007](./ADR-007-api-architecture-spectrum.md))
+  becomes a binary.
+- **Reason for rejection**: The portfolio's job is to demonstrate range.
+  Path C is what differentiates the project from "yet another Azure
+  Functions example."
+
+### Option 2: Functions on a dedicated App Service plan (Premium or Elastic Premium)
+
+- **Pros**: Always-warm without containerization; richer feature surface
+  than Consumption (VNet integration, larger instances, pre-warmed
+  instances).
+- **Cons**: No portable image; same Functions host lock-in as
+  Consumption; substantially higher cost (~$150+/mo for the smallest
+  Premium plan); loses the entire container/immutability/KEDA story.
+- **Reason for rejection**: All the cost of "stay warm" with none of
+  the portfolio value Path C is designed to deliver. If the only goal
+  were "Path B but always warm," Premium would be reasonable. The goal
+  is broader.
+
+### Option 3: Functions on AKS (kubectl Functions runtime + KEDA)
+
+- **Pros**: Most expressive scaling model; native Kubernetes operational
+  surface; strongest cloud-portability story.
+- **Cons**: AKS node-pool operational cost (~$70+/mo before any
+  workload); the entire Kubernetes operational surface (RBAC, CNI,
+  upgrades, etcd, ingress controllers) added to a portfolio project for
+  a workload that does not need it.
+- **Reason for rejection**: PORTFOLIO_PLAN.md:64 explicitly scopes AKS
+  out. [ADR-010](./ADR-010-path-to-aks.md) *(planned, Phase 3)*
+  documents the path-to-AKS thinking without paying the AKS cost.
+
+### Option 4: App Service for Containers (instead of ACA)
+
+- **Pros**: Container hosting under the same App Service umbrella as
+  Functions Consumption/Premium; lower operational complexity than ACA;
+  shares some IaC patterns with the existing function-app module.
+- **Cons**: No KEDA; less interesting scaling story; no scale-to-zero
+  on the consumption-tier equivalent; weaker FedRAMP/ATO narrative
+  because the runtime envelope is still App Service rather than a
+  generic container runtime.
+- **Reason for rejection**: ACA is the more interesting demonstration.
+  The point of Path C is to escape the App Service runtime, not to
+  swap App Service flavors.
+
+## Implementation Notes
+
+### Shared application code
+
+The Functions source under [`backend/functions/src/`](../../backend/functions/src/)
+is *unchanged* by Phase 2.2. The Dockerfile at
+[`backend/functions/Dockerfile`](../../backend/functions/Dockerfile) is a
+multi-stage build whose first stage runs `npm ci && npm run build` and
+whose second stage copies the `dist/` output onto
+`mcr.microsoft.com/azure-functions/node:4-node22`. Build context is
+`backend/` (not `backend/functions/`) so the `@pcpc/shared` workspace
+package — referenced as `"@pcpc/shared": "file:../shared"` in
+[`backend/functions/package.json`](../../backend/functions/package.json) —
+resolves correctly. `npm ci --omit=dev` at the runtime stage strips
+`@pcpc/shared` cleanly because it is types-only.
+
+### Infrastructure boundary
+
+A new Terraform module at [`infra/modules/container-app/`](../../infra/modules/)
+composes:
+
+- `azurerm_container_app_environment` consuming the existing
+  `module.log_analytics` outputs (no new workspace)
+- A `UserAssignedIdentity` granted `AcrPull` on the shared ACR
+- `azurerm_container_app` with HTTP ingress (`target_port = 80`,
+  `external_enabled = true`), `min_replicas = 1` (default), and a
+  secret-backed `env` block carrying the same Scrydex/Cosmos
+  credentials Path B already consumes
+
+The module is wired into [`infra/envs/dev/main.tf`](../../infra/envs/dev/main.tf)
+alongside the function-app module. The two runtimes share Cosmos,
+Application Insights, Key Vault, and the storage account — they differ
+only in *how* the code runs.
+
+### Pipeline boundary
+
+A new Azure DevOps template at
+[`pipelines/ado/templates/deploy-aca.yml`](../../pipelines/ado/templates/deploy-aca.yml)
+runs in the `Deploy_Dev` stage in parallel with `Deploy_Functions`.
+The companion template
+[`pipelines/ado/templates/build-and-push-image.yml`](../../pipelines/ado/templates/build-and-push-image.yml)
+builds the image, scans for HIGH+ CVEs with Trivy (blocking), and
+pushes to the shared `maberdevcontainerregistry` ACR under the
+`pcpc/functions` repository path. ACA pulls via the user-assigned
+managed identity, not the ADO service connection (different identities
+for different purposes).
+
+### Container Registry sharing
+
+PCPC reuses the existing `maberdevcontainerregistry-ccedhvhwfndwetdp`
+ACR rather than provisioning a per-environment registry. The CI-tooling
+images (`pcpc-ci-terraform-azure`, `pcpc-ci-node22`, `pcpc-ci-node-azure`)
+already live in this ACR; Path C adds the `pcpc/functions` repository
+path for the application image. No new ACR module is added; the
+container-app module accepts the ACR resource ID and login server as
+inputs so it remains agnostic to where the registry is provisioned.
+
+### Frontend integration
+
+Path C registers as a `BackendDefinition` at
+[`frontend/src/lib/backends/path-c-aca.ts`](../../frontend/src/lib/backends/),
+mirroring [`path-b-azure.ts`](../../frontend/src/lib/backends/path-b-azure.ts).
+The 2-second healthcheck timeout at
+[`frontend/src/lib/backends/health.ts`](../../frontend/src/lib/backends/health.ts)
+is unchanged; the `min_replicas = 1` decision exists precisely so this
+timeout does not falsely degrade Path C. The base URL is configured via
+the `PUBLIC_ACA_API_BASE_URL` env var (per-scope on Vercel).
+
+### Cost envelope
+
+At portfolio traffic levels with `min_replicas = 1` and the default
+0.5 vCPU / 1 GiB memory:
+
+- Path B (Functions Consumption): ~$0/mo at idle, scales to ~$1–3/mo
+  under recruiter traffic
+- Path C (ACA min=1): ~$5–15/mo at idle (vCPU + memory accruing
+  continuously), marginal cost per request negligible
+
+This delta is the price of the architectural demonstration and is
+flagged honestly in [`docs/architecture-comparison.md`](../architecture-comparison.md).
+
+## Related Decisions
+
+- [ADR-007: API Architecture Spectrum](./ADR-007-api-architecture-spectrum.md)
+- [ADR-008: APIM vs SvelteKit BFF as Gateway](./ADR-008-apim-vs-bff-gateway.md)
+- ADR-010: Path to AKS *(planned, Phase 3)*
+- [ADR-006: API Integration Strategy](./ADR-006-api-integration-strategy.md)

--- a/docs/adr/ADR-009-functions-consumption-vs-container-apps.md
+++ b/docs/adr/ADR-009-functions-consumption-vs-container-apps.md
@@ -212,6 +212,32 @@ pushes to the shared `maberdevcontainerregistry` ACR under the
 managed identity, not the ADO service connection (different identities
 for different purposes).
 
+### CORS handling (gateway-layer parity with Path B)
+
+Path B's CORS allowlist lives entirely in the APIM regex policy
+([ADR-013](./ADR-013-cors-regex-policy.md)); the Functions code under
+[`backend/functions/src/`](../../backend/functions/src/) emits no
+`Access-Control-Allow-*` headers and the APIM policy is the only
+allowlist gate. Path C cannot inherit that gate because it deliberately
+bypasses APIM (direct ACA ingress is the architectural point of the
+path — see [ADR-007](./ADR-007-api-architecture-spectrum.md)).
+
+The decision is to **keep CORS at the gateway layer for Path C too**,
+configured on the ACA ingress (`cors` block on
+`azurerm_container_app.ingress`) with the same allowlist the APIM regex
+policy uses. Both paths source the allowlist from the same
+`APIM_CORS_ORIGINS` ADO variable group entry, so adding or removing a
+domain updates both gateways atomically.
+
+The alternative — emit CORS headers from Functions code — was rejected
+because it would (a) require the same code to behave differently depending
+on whether it's running behind APIM or behind ACA ingress (APIM strips
+and re-adds CORS, which would conflict with app-emitted headers), and
+(b) move policy concerns out of the gateway, weakening the
+"gateway is the allowlist" model. Keeping CORS gateway-layer in both
+envelopes preserves the comparison doc's claim that Path B and Path C
+ship byte-identical application code.
+
 ### Container Registry sharing
 
 PCPC reuses the existing `maberdevcontainerregistry-ccedhvhwfndwetdp`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,7 @@ Each ADR follows a standardized format:
 | [ADR-006](./ADR-006-api-integration-strategy.md) | API Integration Strategy | Accepted | 2025-09-22 |
 | [ADR-007](./ADR-007-api-architecture-spectrum.md) | API Architecture Spectrum (three paths) | Accepted | 2026-05-06 |
 | [ADR-008](./ADR-008-apim-vs-bff-gateway.md) | APIM vs SvelteKit BFF as Gateway | Accepted | 2026-05-06 |
+| [ADR-009](./ADR-009-functions-consumption-vs-container-apps.md) | Functions Consumption vs Container Apps | Accepted | 2026-05-12 |
 | [ADR-011](./ADR-011-deployment-topology-and-testing-model.md) | Deployment Topology and Testing Model | Accepted | 2026-05-06 |
 | [ADR-012](./ADR-012-apim-managed-cert-suspension.md) | APIM Managed Cert Suspension — Defer Custom Hostnames | Accepted | 2026-05-07 |
 | [ADR-013](./ADR-013-cors-regex-policy.md) | CORS Regex-Based Origin Allowlist Policy | Accepted | 2026-05-07 |
@@ -40,7 +41,6 @@ These ADRs document the architectural reasoning behind PCPC's three-path deploym
 
 | ADR | Title | Phase | Status |
 |-----|-------|-------|--------|
-| [ADR-009](./ADR-009-functions-vs-container-apps.md) | Functions Consumption vs Container Apps | 2 | Planned |
 | [ADR-010](./ADR-010-path-to-aks.md) | Path to AKS (speculative) | 3 (optional) | Planned |
 
 ## Decision Process

--- a/docs/architecture-comparison.md
+++ b/docs/architecture-comparison.md
@@ -1,8 +1,9 @@
 # Architecture Comparison
 
-> **Phase 1 (current).** Two of three paths are live: Path A (Vercel BFF)
-> and Path B (APIM + Functions). Path C (ACA Container) ships in Phase 2;
-> a third column will be added to every table here when it lands.
+> **Phase 2.2 (current).** All three paths are described here. Path A
+> (Vercel BFF) and Path B (APIM + Functions, Scrydex-native post-Phase-2.1)
+> are live. Path C (ACA Container) ships in Phase 2.2 — the infra and
+> pipeline land first, then the frontend toggle wires `?backend=aca`.
 
 This document is the marquee artifact of the PCPC portfolio. The plan
 (see [`PORTFOLIO_PLAN.md`](./PORTFOLIO_PLAN.md)) is to ship one product
@@ -16,28 +17,29 @@ The decision narrative behind the comparison lives in the ADRs:
   why three paths exist at all
 - [ADR-008 — APIM vs SvelteKit BFF as Gateway](./adr/ADR-008-apim-vs-bff-gateway.md):
   the gateway-shaped tradeoff between Path A and Path B
-- ADR-009 *(Phase 2)*: Functions Consumption vs Container Apps
+- [ADR-009 — Functions Consumption vs Container Apps](./adr/ADR-009-functions-consumption-vs-container-apps.md):
+  the runtime-shaped tradeoff between Path B and Path C
 
 ---
 
 ## Headline architecture
 
 ```
-                          pcpc.maber.io
-                       (Vercel · SvelteKit)
-                                │
-                  ┌─────────────┴─────────────┐
-          ?backend=vercel              ?backend=azure          (?backend=aca, Phase 2)
-                  │                            │                            │
-        SvelteKit BFF                  APIM (Consumption)          ACA + KEDA (planned)
-        (+server.ts on                         │                            │
-         Vercel serverless)            Azure Functions v4         Azure Functions v4
-                  │                    (Node.js 22)               (containerized)
-                  │                            │                            │
-                  └────────────────────────────┴────────────────────────────┘
-                                               │
-                                  Cosmos DB (Scrydex schema)
-                                  Redis (optional)
+                              pcpc.maber.io
+                           (Vercel · SvelteKit)
+                                    │
+                ┌───────────────────┼───────────────────┐
+        ?backend=vercel       ?backend=azure       ?backend=aca
+                │                   │                   │
+         SvelteKit BFF       APIM (Consumption)   ACA Ingress
+        (+server.ts on               │                   │
+         Vercel serverless)  Azure Functions v4   Azure Functions v4
+                │            (Node.js 22, ZIP)   (Node.js 22, container)
+                │                   │                   │
+                └───────────────────┴───────────────────┘
+                                    │
+                       Cosmos DB (Scrydex schema)
+                       Redis (optional)
 ```
 
 A single SvelteKit frontend serves all three paths. The active path is
@@ -45,7 +47,7 @@ selected by the `?backend=` URL parameter and surfaced in the corner badge.
 All paths share the same Cosmos DB account and the same TypeScript types
 via `@pcpc/shared`.
 
-## Data flow (Path A and Path B; Phase 2 adds Path C as a parallel branch)
+## Data flow (all three paths converge on the same Cosmos + Scrydex upstream)
 
 ```
 Browser ──▶ pcpc.maber.io (Vercel)
@@ -59,10 +61,22 @@ Browser ──▶ pcpc.maber.io (Vercel)
                 │                              ▼
                 │                        Scrydex API
                 │
-                └── ?backend=azure  ──▶ APIM (api.pcpc.maber.io, Consumption)
+                ├── ?backend=azure  ──▶ APIM (dev-api.pcpc.maber.io, Consumption)
+                │                              │
+                │                              ▼
+                │                       Azure Functions v4 (Node 22, ZIP)
+                │                              │
+                │                              ▼
+                │                       Cosmos DB (Scrydex schema)
+                │                              ▲
+                │                              │ (cache miss)
+                │                              ▼
+                │                       Scrydex API
+                │
+                └── ?backend=aca    ──▶ ACA Ingress (FQDN)
                                                │
                                                ▼
-                                       Azure Functions v4 (Node 22)
+                                       Azure Functions v4 (Node 22, container)
                                                │
                                                ▼
                                        Cosmos DB (Scrydex schema)
@@ -72,10 +86,20 @@ Browser ──▶ pcpc.maber.io (Vercel)
                                        Scrydex API
 ```
 
-The Scrydex upstream is the same for both paths — when neither Cosmos nor
-Redis has the data, both paths fetch from `api.scrydex.com` and write back
-through the same cache hierarchy. That hierarchy (Redis → Cosmos → upstream)
-is described in [ADR-003](./adr/ADR-003-caching-architecture-design.md).
+The Scrydex upstream is the same for all three paths — when neither Cosmos
+nor Redis has the data, every path fetches from `api.scrydex.com` and
+writes back through the same cache hierarchy. That hierarchy (Redis →
+Cosmos → upstream) is described in
+[ADR-003](./adr/ADR-003-caching-architecture-design.md).
+
+Path B and Path C run the *same application code* — the difference is the
+runtime envelope (Functions host on Consumption vs containerized
+Functions on Azure Container Apps) and the network ingress (APIM vs ACA
+ingress). The Functions source under
+[`backend/functions/src/`](../backend/functions/src/) is unchanged
+between them. See
+[ADR-009](./adr/ADR-009-functions-consumption-vs-container-apps.md) for
+the full runtime tradeoff.
 
 ---
 
@@ -83,57 +107,78 @@ is described in [ADR-003](./adr/ADR-003-caching-architecture-design.md).
 
 ### Request flow
 
-| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
-|---|---|---|
-| User-facing URL | `pcpc.maber.io` | `pcpc.maber.io` (toggle to `?backend=azure`) |
-| Frontend → API hop | Same Vercel deployment, no separate gateway | Browser → APIM → Functions → Cosmos |
-| Network hops added by the gateway | 0 | 1 (APIM → Functions) |
-| Cold-start surface | Vercel serverless (~50–150ms) | APIM cold (~80–150ms) + Functions cold (~500–1500ms on Consumption) |
-| Where business logic runs | SvelteKit `+server.ts` in same process as page rendering | Azure Functions v4 (separate process, separate runtime) |
-| Direct backend access without the gateway | N/A — same process | Functions HTTP trigger is `function`-auth (key required); APIM holds the key |
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions | Path C — ACA Container |
+|---|---|---|---|
+| User-facing URL | `pcpc.maber.io` | `pcpc.maber.io` (toggle to `?backend=azure`) | `pcpc.maber.io` (toggle to `?backend=aca`) |
+| Frontend → API hop | Same Vercel deployment, no separate gateway | Browser → APIM → Functions → Cosmos | Browser → ACA ingress → Functions container → Cosmos |
+| Network hops added by the gateway | 0 | 1 (APIM → Functions) | 0 (ACA ingress is L7 routing in the same node) |
+| Cold-start surface | Vercel serverless (~50–150ms) | APIM cold (~80–150ms) + Functions cold (~500–1500ms on Consumption) | ACA ingress (~10–30ms) + Functions container cold (~0ms at min_replicas=1; ~1–3s at min=0) |
+| Where business logic runs | SvelteKit `+server.ts` in same process as page rendering | Azure Functions v4 (separate process, separate runtime) | Azure Functions v4 in container (byte-identical to Path B's code) |
+| Direct backend access without the gateway | N/A — same process | Functions HTTP trigger is `function`-auth (key required); APIM holds the key | ACA ingress is the only path; anonymous public ingress |
 
 ### Operational characteristics
 
-| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
-|---|---|---|
-| IaC scope | None (Vercel project settings only) | 9 Terraform modules (`infra/modules/`) + APIM-as-code (`apim/`) |
-| CI/CD | Vercel auto-deploy on push to `main`; PR previews | Azure DevOps multi-stage pipeline; ACR-backed CI containers |
-| Deployment time | ~30–90s | ~3–8min (Terraform plan/apply + Functions deploy + APIM sync) |
-| Observability | Vercel logs + browser dev tools | Application Insights + Log Analytics + APIM Analytics |
-| Secret management | Vercel env vars | Azure Key Vault → Function App app-settings |
-| Identity model | Vercel deployment owner | Azure managed identity |
-| Custom domain (Phase 1) | `pcpc.maber.io` (Vercel + Cloudflare) | Per-env: `dev-api.pcpc.maber.io`, `staging-api.pcpc.maber.io`, `api.pcpc.maber.io` (APIM hostname binding + Azure-managed cert; CNAMEs in Cloudflare) |
-| TLS cert | Vercel-managed | Azure-managed (free) |
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions | Path C — ACA Container |
+|---|---|---|---|
+| IaC scope | None (Vercel project settings only) | 9 Terraform modules (`infra/modules/`) + APIM-as-code (`apim/`) | New `container-app` module (`infra/modules/container-app/`) reusing existing log-analytics, cosmos, app-insights, storage outputs |
+| CI/CD | Vercel auto-deploy on push to `main`; PR previews | Azure DevOps multi-stage pipeline; Functions ZIP deploy with content-hash skip | Azure DevOps stage parallel to Path B's; Docker build → Trivy scan → ACR push → `az containerapp update` |
+| Deployment time | ~30–90s | ~3–8min (Terraform plan/apply + Functions deploy + APIM sync) | ~5–10min (Terraform plan/apply + image build + CVE scan + ACR push + revision activation) |
+| Observability | Vercel logs + browser dev tools | Application Insights + Log Analytics + APIM Analytics | Same App Insights + Log Analytics workspace as Path B; ACA-native revision/replica logs additionally |
+| Secret management | Vercel env vars | Azure Key Vault → Function App app-settings | ACA `secret` blocks (managed identity-resolved at runtime); same Key Vault as Path B |
+| Identity model | Vercel deployment owner | Azure managed identity (SystemAssigned) | Azure user-assigned managed identity (UAMI) — first UAMI in the repo, used for ACR pull |
+| Custom domain (current) | `pcpc.maber.io` (Vercel + Cloudflare) | Deferred per [ADR-012](./adr/ADR-012-apim-managed-cert-suspension.md); using `*.azure-api.net` until Azure-managed cert creation resumes Jun 2026 | Deferred (mirrors Path B); using ACA-issued `*.azurecontainerapps.io` until the managed-cert window opens |
+| TLS cert | Vercel-managed | Currently `*.azure-api.net` default; future Azure-managed (free) per ADR-012 | Currently ACA-issued; future Azure-managed per same window |
 
 ### Scaling and cost
 
-| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
-|---|---|---|
-| Scaling model | Per-request serverless (Vercel) | APIM Consumption: per-call, no min instances; Functions Consumption: per-execution |
-| Scale-to-zero | Yes | Yes |
-| Concurrency limit per instance | Vercel default (high) | Functions Consumption: 200 concurrent per instance |
-| Estimated monthly cost (recruiter-traffic levels) | $0 (Vercel free tier) | ~$2–8 (APIM Consumption + Functions Consumption + Cosmos serverless) |
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions | Path C — ACA Container |
+|---|---|---|---|
+| Scaling model | Per-request serverless (Vercel) | APIM Consumption: per-call, no min instances; Functions Consumption: per-execution | ACA scale rule (HTTP concurrency by default); KEDA-ready for Cosmos change feed / queue depth / custom scalers |
+| Scale-to-zero | Yes | Yes | Configurable; **min_replicas=1** in PCPC to keep healthcheck under 2s probe timeout (min=0 supported but trades cold-start for cost) |
+| Concurrency limit per instance | Vercel default (high) | Functions Consumption: 200 concurrent per instance | Tunable via scale rule (default 10 HTTP requests/replica before scale-out) |
+| Estimated monthly cost (recruiter-traffic levels) | $0 (Vercel free tier) | ~$2–8 (APIM Consumption + Functions Consumption + Cosmos serverless) | ~$5–15 at min_replicas=1 (continuous vCPU + memory accrual on 0.5 vCPU / 1 GiB); ~$0–3 at min_replicas=0 |
 
 ### Security posture
 
-| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
-|---|---|---|
-| TLS termination | Vercel edge | APIM gateway |
-| Authn/authz | App-level (none required for read endpoints) | APIM subscription model available; currently `subscription_required = false` for the demo |
-| Secret access | Vercel env vars at build/runtime | Key Vault references in app-settings; Functions read at runtime |
-| Rate limiting | None (Vercel edge limits only) | Available via APIM policy; not currently configured |
-| CORS | SvelteKit handles same-origin natively | Configured at APIM to accept `pcpc.maber.io` (Phase 1B) |
-| Audit | Vercel deployment log | App Insights request log + APIM Analytics |
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions | Path C — ACA Container |
+|---|---|---|---|
+| TLS termination | Vercel edge | APIM gateway | ACA ingress (managed) |
+| Authn/authz | App-level (none required for read endpoints) | APIM subscription model available; currently `subscription_required = false` for the demo | Anonymous public ingress; app-level (none required for read endpoints) |
+| Secret access | Vercel env vars at build/runtime | Key Vault references in app-settings; Functions read at runtime | ACA `secret` blocks resolved via managed identity at revision-start time |
+| Rate limiting | None (Vercel edge limits only) | Available via APIM policy; not currently configured | Available via ACA ingress rules; not currently configured |
+| CORS | SvelteKit handles same-origin natively | Configured at APIM via the regex policy (see [ADR-013](./adr/ADR-013-cors-regex-policy.md)) | Handled at the Functions layer (same code as Path B) — `pcpc.maber.io` allowed by the same allowlist |
+| Audit | Vercel deployment log | App Insights request log + APIM Analytics | App Insights request log + ACA revision/replica logs; image SHA pinned per revision for supply-chain attestation |
+| Image / runtime provenance | N/A | ZIP deploy; runtime opacity inside the Functions host | Digest-pinned image (`pcpc/functions@sha256:…`) scanned for HIGH+ CVEs (Trivy) in CI before push; revision-pinned in Terraform |
 
 ### Schema and data
 
-| Aspect | Path A — Vercel BFF | Path B — APIM + Functions |
-|---|---|---|
-| Backend schema (Phase 1) | Scrydex | PokeData *(legacy; migrates to Scrydex in Phase 2)* |
-| Frontend-facing shape | Scrydex (canonical) | Scrydex via `pokedata-to-scrydex` adapter |
-| Type sharing | `@pcpc/shared` (Scrydex types) | `@pcpc/shared` (Scrydex types) |
-| Per-variant pricing supported | Yes | No *(empty `variants[]` until Phase 2)* |
-| Cosmos DB | Same account, same Scrydex containers | Same account; will use Scrydex containers post-migration |
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions | Path C — ACA Container |
+|---|---|---|---|
+| Backend schema | Scrydex (canonical) | Scrydex (canonical, Phase 2.1) | Scrydex (canonical — same code as Path B) |
+| Frontend-facing shape | Scrydex envelopes from [`@pcpc/shared`](../backend/shared) | Scrydex envelopes from [`@pcpc/shared`](../backend/shared) | Scrydex envelopes from [`@pcpc/shared`](../backend/shared) |
+| Type sharing | `@pcpc/shared` (types-only, interfaces erase) | `@pcpc/shared` (npm `file:../shared`; ZIP deploy excludes it via `--omit=dev`) | `@pcpc/shared` (npm `file:../shared`; container build copies `shared/` into context, runtime image excludes it via `--omit=dev`) |
+| Per-variant pricing supported | Yes | Yes (post-Phase-2.1 Scrydex cutover) | Yes (identical code) |
+| Cosmos DB | Same account, same Scrydex containers | Same account, same Scrydex containers | Same account, same Scrydex containers |
+
+### Runtime model (the marquee row for Phase 2.2)
+
+| Aspect | Path A — Vercel BFF | Path B — APIM + Functions | Path C — ACA Container |
+|---|---|---|---|
+| Runtime envelope | Vercel serverless (Node.js) | Functions host on Consumption plan (managed by Azure) | Functions host inside an OCI container on ACA |
+| Deploy artifact | Build output uploaded to Vercel | ZIP attached to Function App | Digest-pinned OCI image in ACR (`pcpc/functions@sha256:…`) |
+| Image immutability | N/A | Mutable host; runtime patched by Microsoft | Immutable image; base image upgrades are explicit, scanned, and rollable |
+| Scaling primitive | Vercel request router | Functions host autoscale (opaque) | ACA scale rules (HTTP concurrency; KEDA-ready) |
+| Portability | Vercel-specific | Functions host-specific (Azure lock-in) | OCI image (same artifact runs on AKS, ECS, GKE, local Docker) |
+| Supply-chain attestability | Build provenance (Vercel) | Lower (ZIP + managed runtime) | High (image SHA + base image SHA + CVE scan results in CI logs) |
+| FedRAMP / ATO posture | N/A (not the target audience) | Moderate (managed Azure service, but runtime is opaque) | Strong (explicit image lineage, digest pinning, CVE attestation, no managed-runtime opacity) |
+| What the code knows about its runtime | Vercel adapter (SvelteKit) | Pure Functions code; no Vercel awareness | Pure Functions code; no ACA awareness (the container is environment-agnostic) |
+
+Path B and Path C ship **byte-identical application code** and serve
+**byte-identical responses** to the frontend. The differences in this
+table are entirely about the runtime envelope and the operational
+properties that flow from it. The full decision rule for choosing
+between Consumption and ACA is in
+[ADR-009](./adr/ADR-009-functions-consumption-vs-container-apps.md).
 
 ---
 
@@ -157,45 +202,54 @@ is described in [ADR-003](./adr/ADR-003-caching-architecture-design.md).
 - Managed identity, Key Vault references, audit log integration
 - Defense/regulated-industry-friendly deployment patterns
 
+### Path C — ACA Container (container fluency / supply-chain vocabulary)
+
+- Same Functions code as Path B, packaged as an OCI image
+- Multi-stage Dockerfile against `mcr.microsoft.com/azure-functions/node:4-node22`
+- Digest-pinned image with HIGH+ CVE scanning (Trivy) blocking in CI
+- Azure Container Apps with KEDA-ready scaling (HTTP rule today, event-source-driven scalers available)
+- User-assigned managed identity for ACR pull (no admin user on the registry)
+- Image revision history in ACR; ACA revision rollouts are atomic and rollable
+- FedRAMP / ATO-friendly: explicit image lineage, runtime not opaque
+- Demonstrates the *next* architectural step (container portability) without paying the AKS cost (see [ADR-010, planned](./adr/ADR-010-path-to-aks.md))
+
 ---
 
-## Phase 1 known limitations (resolved in Phase 2)
+## Current known limitations
 
 These are surfaced explicitly because the portfolio rewards honesty about
 in-progress work more than it rewards hiding it.
 
-- **Path B serves PokeData-shape data.** The Functions code has not yet
-  been migrated to the Scrydex schema. A frontend adapter
-  (`frontend/src/lib/backends/adapters/pokedata-to-scrydex.ts`) bridges
-  the request/response shape so the toggle works end-to-end, but the
-  adapter cannot synthesize per-variant pricing that PokeData never had.
-  Path B card detail therefore renders as "no pricing available" until
-  Phase 2 migrates the Functions to Scrydex.
-- **Set metadata on Path B is sparse.** Series, total, printedTotal,
-  isOnlineOnly, logo, and symbol come back undefined on Path B because
-  PokeData does not expose them. Path A returns full metadata.
-- **Custom domains land in Phase 1B.** Phase 1A ships the toggle pointed
-  at the dev APIM's `*.azure-api.net` hostname. Phase 1B provisions the
-  per-environment custom domains (`dev-api`, `staging-api`, `api`) with
-  Azure-managed certs and adds the validation + CNAME records in
-  Cloudflare manually.
+- **Custom domains are deferred** per
+  [ADR-012](./adr/ADR-012-apim-managed-cert-suspension.md). Until Azure
+  resumes managed-cert creation (window: Aug 2025 → Jun 2026), Path B uses
+  the dev APIM's `*.azure-api.net` hostname and Path C uses the ACA-issued
+  `*.azurecontainerapps.io` ingress hostname. Restoration runbook is in
+  the ADR.
+- **APIM-in-front-of-ACA is intentionally *not* used.** Path C is designed
+  to demonstrate "skip the gateway, see what the runtime alone gives you"
+  — routing Path C through APIM would blur the architectural comparison.
+  CORS, observability, and rate-limiting parity with Path B are
+  implemented in the Functions code itself (same code runs in both
+  envelopes).
 
 The toggle's healthcheck-driven graceful degradation guarantees the user
 experience never regresses below "Path A works." A reader who never
 engages the toggle gets a normal Scrydex-backed experience identical to
-the pre-Phase-1 deployment.
+the pre-portfolio deployment.
 
 ---
 
 ## How to try it
 
-1. Open [pcpc.maber.io](https://pcpc.maber.io) *(wired in Phase 1B)*.
+1. Open [pcpc.maber.io](https://pcpc.maber.io).
 2. Notice the badge in the bottom-right corner. It shows the active backend
    and the latency of its last healthcheck.
 3. Click the badge. Pick a different path from the popover. The page
    reloads and the same UI is now talking to the other backend.
 4. The latency badge updates with the new backend's response time.
-5. To pin a path via URL, append `?backend=vercel` or `?backend=azure`.
+5. To pin a path via URL, append `?backend=vercel`, `?backend=azure`, or
+   `?backend=aca` (the last is live once Phase 2.2 PR-3 merges).
 6. To return to default behavior, remove the parameter (or pick Vercel).
 
 The toggle is opt-in. A visitor who never opens the popover sees Path A
@@ -203,15 +257,13 @@ behavior throughout — fast, normal, unbroken.
 
 ---
 
-## What changes in Phase 2
+## What's next
 
-This document gets a third column (Path C — ACA Container) and ADR-009
-gets published. The headline diagram gains a third descending arrow, the
-data-flow diagram gains a third parallel branch, and the comparison tables
-above gain rows for KEDA scaling characteristics, container image
-provenance, and the cold-start delta between Functions Consumption and
-ACA min-replicas-1 deployments.
-
-Once Path C is live, the Phase 1 known-limitations section above
-collapses to a single line: "schema migrated; Path B and Path C now serve
-canonical Scrydex data."
+With Phase 2.2 shipping the ACA path, the three-column comparison is
+complete and the marquee artifact is operational. Phase 3 covers
+distribution — portfolio site deploy, LinkedIn post with the headline
+diagram, the planned
+[ADR-010 — Path to AKS](./adr/ADR-010-path-to-aks.md) as the
+speculative "what would change if this needed Kubernetes" document, and
+optional polish items like KEDA event-driven scale rules on Path C (e.g.
+scaling on Cosmos change feed instead of HTTP concurrency).

--- a/docs/architecture-comparison.md
+++ b/docs/architecture-comparison.md
@@ -146,7 +146,7 @@ the full runtime tradeoff.
 | Authn/authz | App-level (none required for read endpoints) | APIM subscription model available; currently `subscription_required = false` for the demo | Anonymous public ingress; app-level (none required for read endpoints) |
 | Secret access | Vercel env vars at build/runtime | Key Vault references in app-settings; Functions read at runtime | ACA `secret` blocks resolved via managed identity at revision-start time |
 | Rate limiting | None (Vercel edge limits only) | Available via APIM policy; not currently configured | Available via ACA ingress rules; not currently configured |
-| CORS | SvelteKit handles same-origin natively | Configured at APIM via the regex policy (see [ADR-013](./adr/ADR-013-cors-regex-policy.md)) | Handled at the Functions layer (same code as Path B) — `pcpc.maber.io` allowed by the same allowlist |
+| CORS | SvelteKit handles same-origin natively | Configured at APIM via the regex policy (see [ADR-013](./adr/ADR-013-cors-regex-policy.md)) — Functions code emits no CORS headers; APIM is the only allowlist gate | Configured at the ACA ingress `cors` block; same allowlist as APIM (mirrors [ADR-013](./adr/ADR-013-cors-regex-policy.md) at a different gateway). Keeps Functions code envelope-agnostic — Path B and Path C ship byte-identical code; only the gateway differs. |
 | Audit | Vercel deployment log | App Insights request log + APIM Analytics | App Insights request log + ACA revision/replica logs; image SHA pinned per revision for supply-chain attestation |
 | Image / runtime provenance | N/A | ZIP deploy; runtime opacity inside the Functions host | Digest-pinned image (`pcpc/functions@sha256:…`) scanned for HIGH+ CVEs (Trivy) in CI before push; revision-pinned in Terraform |
 
@@ -229,9 +229,18 @@ in-progress work more than it rewards hiding it.
 - **APIM-in-front-of-ACA is intentionally *not* used.** Path C is designed
   to demonstrate "skip the gateway, see what the runtime alone gives you"
   — routing Path C through APIM would blur the architectural comparison.
-  CORS, observability, and rate-limiting parity with Path B are
-  implemented in the Functions code itself (same code runs in both
-  envelopes).
+  Path C therefore needs its own gateway-layer configuration for
+  cross-cutting concerns that APIM provides on Path B:
+  - **CORS** — implemented as an ACA ingress `cors` rule with the same
+    allowlist as the APIM regex policy ([ADR-013](./adr/ADR-013-cors-regex-policy.md)),
+    sourced from the same `APIM_CORS_ORIGINS` variable group entry. The
+    Functions code itself emits no CORS headers in either envelope; the
+    gateway is the single allowlist gate (APIM on Path B, ACA ingress on
+    Path C). This keeps the application code byte-identical across the
+    two paths — only the runtime envelope differs.
+  - **Rate limiting and observability** — same App Insights connection
+    string covers both paths' telemetry; rate limiting is not configured
+    on either path today.
 
 The toggle's healthcheck-driven graceful degradation guarantees the user
 experience never regresses below "Path A works." A reader who never


### PR DESCRIPTION
## Summary

PR-1 of three for **Phase 2.2** (containerize Functions + ship the ACA path). Text-only landing — ADR + comparison-doc updates with no infra or code changes. Lands first so the runtime tradeoff is argued before the implementation arrives, mirroring the ADR-013 → PR #139 pattern from Phase 1B.

Follow-up PRs (already planned, not yet opened):
- **PR-2** — `backend/functions/Dockerfile`, `infra/modules/container-app/`, ADO pipeline stage (dev only). Touches Azure; will stop for review before merge.
- **PR-3** — frontend `path-c-aca.ts` registration + Vercel `PUBLIC_ACA_API_BASE_URL` env var.

## What's in this PR

- **New ADR-009** — *Functions Consumption vs Container Apps.* The runtime-shaped tradeoff between Path B and Path C: decision rule, cost envelopes ($0 vs ~$5–15/mo), portability (Functions host lock-in vs OCI image), scaling primitives, FedRAMP/ATO posture, image immutability. Alternatives considered: Functions-only, App Service Premium, AKS, App Service for Containers.
- **`docs/architecture-comparison.md`** — every comparison table expands from 2 to 3 columns. New **Runtime model** section is the marquee row for Phase 2.2 (image immutability, supply-chain attestability, portability). Refreshes the now-stale *Phase 1 known limitations* section (Phase 2.1's Scrydex cutover resolved the PokeData caveat) and replaces the closing *What changes in Phase 2* paragraph with a Phase 3 outlook.
- **`docs/PORTFOLIO_PLAN.md`** — phase status block updated (1B done, 2.1 done, 2.2 in progress); ADR-009 appended to the accepted list; open question #7 resolved (ACA \`min_replicas = 1\`). Rationale on the resolution: the frontend's 2-second \`probeHealth\` timeout in [\`frontend/src/lib/backends/health.ts\`](https://github.com/Abernaughty/PCPC/blob/main/frontend/src/lib/backends/health.ts) is shorter than ACA's 1–3s cold-start at \`min=0\`, so \`min=0\` would falsely degrade Path C and hide it from the toggle.
- **`README.md`** — Status line flipped to Phase 2.2; \`?backend=aca\` row added to the live-demo table (called out as wired-up post-PR-3); stale PokeData caveat removed (Path B is Scrydex-native post-Phase-2.1); by-phase status table refreshed.
- **`docs/adr/README.md`** — ADR-009 moved from *Planned* to *Accepted* with date 2026-05-12 and the correct filename.

## Test plan

Text-only, no CD impact.

- [ ] Visual diff against ADR-008 for tone/length consistency
- [ ] Every in-doc ADR cross-link resolves (ADR-007, ADR-008, ADR-012, ADR-013 — the broken ADR-002/003/005/006/010 refs are pre-existing inconsistencies in the index, not introduced by this PR)
- [ ] `docs/architecture-comparison.md` renders cleanly on GitHub (tables, code-block diagrams)
- [ ] README live-demo table reads sensibly in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)