### PR TITLE
chore(infra): terraform fmt envs/{dev,prod,staging}/variables.tf

### DIFF
--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -157,8 +157,8 @@ variable "function_app_config" {
     "AZURE_STORAGE_CONTAINER_NAME" = "images"
 
     # Feature Flags
-    "ENABLE_CACHING"            = "true"
-    "ENABLE_REDIS_CACHE"        = "false"
+    "ENABLE_CACHING"     = "true"
+    "ENABLE_REDIS_CACHE" = "false"
 
     # Cache TTL Settings (in seconds)
     "CACHE_TTL_SETS"  = "604800" # 7 days

--- a/infra/envs/prod/variables.tf
+++ b/infra/envs/prod/variables.tf
@@ -152,8 +152,8 @@ variable "function_app_config" {
     "AZURE_STORAGE_CONTAINER_NAME" = "images"
 
     # Feature Flags
-    "ENABLE_CACHING"            = "true"
-    "ENABLE_REDIS_CACHE"        = "false"
+    "ENABLE_CACHING"     = "true"
+    "ENABLE_REDIS_CACHE" = "false"
 
     # Cache TTL Settings (in seconds)
     "CACHE_TTL_SETS"  = "604800" # 7 days

--- a/infra/envs/staging/variables.tf
+++ b/infra/envs/staging/variables.tf
@@ -152,8 +152,8 @@ variable "function_app_config" {
     "AZURE_STORAGE_CONTAINER_NAME" = "images"
 
     # Feature Flags
-    "ENABLE_CACHING"            = "true"
-    "ENABLE_REDIS_CACHE"        = "false"
+    "ENABLE_CACHING"     = "true"
+    "ENABLE_REDIS_CACHE" = "false"
 
     # Cache TTL Settings (in seconds)
     "CACHE_TTL_SETS"  = "604800" # 7 days


### PR DESCRIPTION
## Summary

Fixes the PR Validation pipeline's **Terraform Format Check** step, which has been failing on every PR since PR #145 with:

\`\`\`
envs/dev/variables.tf
envs/prod/variables.tf
envs/staging/variables.tf
##[error]Bash exited with code '3'.
\`\`\`

## Root cause

PR #145 (Scrydex cutover) removed the \`POKEDATA_API_KEY\` and \`POKEMON_TCG_API_KEY\` entries from each env's \`function_app_config\` map. That left \`ENABLE_CACHING\` and \`ENABLE_REDIS_CACHE\` padded out to the column width of the now-deleted longer keys — pre-2.1 \`terraform fmt\` aligned them, post-2.1 \`terraform fmt\` wants them re-tightened.

## Diff

Pure whitespace re-tightening — 3 files, 3 lines each, no semantic change:

\`\`\`hcl
-    "ENABLE_CACHING"            = "true"
-    "ENABLE_REDIS_CACHE"        = "false"
+    "ENABLE_CACHING"     = "true"
+    "ENABLE_REDIS_CACHE" = "false"
\`\`\`

Produced by \`terraform fmt -recursive infra/envs/\`. No other files touched.

## Why a separate PR

Unblocks the Format Check step across all in-flight PRs (currently [#148](https://github.com/Abernaughty/PCPC/pull/148) — Phase 2.2 ADR-009 docs). Keeps PR #148's "text-only docs" framing intact.

## Test plan

- [ ] PR Validation pipeline's Terraform Format Check step turns green on this PR
- [ ] After merge, the same step turns green on PR #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)