### PR TITLE
feat(phase-2.2): containerize Functions + ACA infrastructure (dev only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,9 +125,13 @@ temp/
 *.tmp
 *.temp
 
-# Docker
+# Docker — broadly ignore developer-local .dockerignore + Dockerfile.local
+# (these are scratch / per-developer overrides). The Phase 2.2 ACA image
+# build has an intentional, source-controlled dockerignore at
+# backend/.dockerignore — unignored below.
 .dockerignore
 Dockerfile.local
+!backend/.dockerignore
 
 # Secrets and sensitive files
 *.pem

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,50 @@
+# -----------------------------------------------------------------------------
+# Docker ignore for the PCPC Functions ACA image build.
+#
+# Build context is `backend/` (set in the ADO pipeline and in any local
+# `docker build -f backend/functions/Dockerfile backend/` invocation), so
+# this file applies to everything under backend/ for image builds.
+#
+# Why context = backend/: the @pcpc/shared workspace is at backend/shared/
+# and is referenced as `file:../shared` from backend/functions/package.json.
+# Anything outside backend/ is invisible to the build, so we don't need to
+# ignore frontend/, infra/, pipelines/, docs/, etc. — they're not in scope.
+# -----------------------------------------------------------------------------
+
+# Build / dev artifacts that should never reach a container image
+**/node_modules
+**/dist
+**/.tsbuildinfo
+**/*.tsbuildinfo
+
+# Local-only / developer-machine artifacts
+**/local.settings.json
+**/.env
+**/.env.*
+
+# Test output and developer scripts inside backend/functions/
+functions/test
+functions/scripts
+functions/test-endpoints.sh
+functions/*.bat
+functions/deploy.zip
+functions/deployment.zip
+
+# Editor / VCS noise
+**/.vscode
+**/.idea
+**/.git
+**/.gitignore
+
+# Documentation that shouldn't bloat the build context
+**/*.md
+
+# IMPORTANT exceptions: keep the lockfiles and the shared package's source
+# (Dockerfile copies them explicitly). Without these unignores, `**/*.md`
+# would already have skipped package.json's adjacent README — but the COPY
+# instructions are explicit about what enters the image, so the unignores
+# below are defense in depth rather than load-bearing.
+!functions/package-lock.json
+!functions/package.json
+!shared/package.json
+!shared/src/**

--- a/backend/functions/Dockerfile
+++ b/backend/functions/Dockerfile
@@ -1,0 +1,82 @@
+# -----------------------------------------------------------------------------
+# PCPC Functions — ACA container image
+#
+# Phase 2.2 (ACA path). Packages the SAME Functions code that Path B's
+# Consumption-plan Function App runs (no app-level differences), inside the
+# official Azure Functions Node.js 22 base image, for deployment to
+# Azure Container Apps.
+#
+# Build context: backend/   (NOT backend/functions/)
+# Dockerfile path: backend/functions/Dockerfile
+#
+# The context-root setting is required so the `file:../shared` reference in
+# backend/functions/package.json (the @pcpc/shared workspace package) resolves
+# during `npm ci`. Build command from the repo root:
+#
+#   docker build -f backend/functions/Dockerfile backend/
+#
+# The image is published to ACR as pcpc/functions:<tag>. See ADR-009 for the
+# decision to keep CORS, secrets, and observability gateway-layer rather than
+# baking environment-specific behavior into the image (the same image is
+# deployed to dev/staging/prod with only env-var differences).
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# Stage 1: build
+#
+# Installs all dependencies (including @pcpc/shared via the file:../shared
+# reference) and runs `tsc` to emit dist/. The build stage is discarded in
+# the final image so devDependencies and TypeScript sources never reach
+# the runtime image.
+# -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/azure-functions/node:4-node22 AS build
+
+WORKDIR /build
+
+# Copy the @pcpc/shared workspace first so the file:../shared dependency
+# resolves when we run `npm ci` in the functions directory.
+COPY shared/ ./shared/
+
+# Copy lockfile + manifest only, install with `npm ci` to fetch deps using
+# Docker layer caching: the deps layer is rebuilt only when package-lock.json
+# changes, not when source files change.
+COPY functions/package.json functions/package-lock.json ./functions/
+WORKDIR /build/functions
+RUN npm ci --no-audit --no-fund
+
+# Now copy source and compile.
+COPY functions/ ./
+RUN npm run build
+
+# -----------------------------------------------------------------------------
+# Stage 2: runtime
+#
+# Copies only the compiled output and a clean production-only node_modules
+# tree onto the official Functions image. @pcpc/shared is a devDependency
+# (types-only — interfaces erase at compile time, no runtime references),
+# so `npm ci --omit=dev` correctly excludes it from the final image.
+# -----------------------------------------------------------------------------
+FROM mcr.microsoft.com/azure-functions/node:4-node22
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
+    FUNCTIONS_WORKER_RUNTIME=node
+
+WORKDIR /home/site/wwwroot
+
+COPY --from=build /build/functions/dist ./dist
+COPY --from=build /build/functions/host.json ./host.json
+COPY --from=build /build/functions/package.json ./package.json
+COPY --from=build /build/functions/package-lock.json ./package-lock.json
+
+RUN npm ci --omit=dev --no-audit --no-fund
+
+# No HEALTHCHECK directive here. ACA's `ingress.health_probes` block in the
+# container-app Terraform module is the canonical liveness/readiness signal;
+# adding HEALTHCHECK here would create a redundant probe surface that
+# confuses debugging. See ADR-009 Implementation Notes for the rationale.
+
+# No ENTRYPOINT / CMD either — the Functions base image's entrypoint
+# (`/opt/startup/start_nonappservice.sh`) launches the Functions host with
+# the right environment. Overriding it would require reimplementing host
+# startup, which defeats the purpose of using the official base image.

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -375,3 +375,79 @@ module "api_management" {
 
   depends_on = [module.resource_group]
 }
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container)
+#
+# The shared ACR (maberdevcontainerregistry-ccedhvhwfndwetdp) lives in dev-rg
+# under the same subscription as PCPC dev (see .ci/versions.yaml and the
+# ACR-DATA-PLANE-AUTH-ISSUE.md notes). We look it up via data source rather
+# than provisioning a new registry per ADR-009.
+# -----------------------------------------------------------------------------
+
+data "azurerm_container_registry" "shared" {
+  name                = var.shared_acr_name
+  resource_group_name = var.shared_acr_resource_group
+}
+
+module "container_app" {
+  source = "../../modules/container-app"
+
+  name                = "pcpc-aca-${local.environment}"
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  environment         = var.environment
+
+  log_analytics_workspace_id = module.log_analytics.id
+
+  acr_id           = data.azurerm_container_registry.shared.id
+  acr_login_server = data.azurerm_container_registry.shared.login_server
+  image_repository = var.container_app_image_repository
+  image_tag        = var.container_app_image_tag
+
+  min_replicas     = var.container_app_min_replicas
+  max_replicas     = var.container_app_max_replicas
+  cpu              = var.container_app_cpu
+  memory           = var.container_app_memory
+  http_concurrency = var.container_app_http_concurrency
+
+  cors_allowed_origins = var.container_app_cors_allowed_origins
+
+  # Non-secret env vars: same shape Path B uses (cosmos config, runtime
+  # flags, App Insights endpoint references). Container-runtime additions:
+  # FUNCTIONS_WORKER_RUNTIME (required) and AzureWebJobsStorage (set via
+  # secret_settings below).
+  app_settings = merge(
+    var.function_app_config, # non-secret config shared with Path B
+    {
+      "COSMOS_DB_ENDPOINT"                    = module.cosmos_db.endpoint
+      "FUNCTIONS_WORKER_RUNTIME"              = "node"
+      "APPINSIGHTS_INSTRUMENTATIONKEY"        = module.application_insights.instrumentation_key
+      "APPLICATIONINSIGHTS_CONNECTION_STRING" = module.application_insights.connection_string
+      "AZURE_FUNCTIONS_ENVIRONMENT"           = var.environment
+    }
+  )
+
+  # Secret env vars. Note we DO NOT carry over the Consumption-only
+  # WEBSITE_CONTENTAZUREFILECONNECTIONSTRING / WEBSITE_CONTENTSHARE
+  # settings here — those are file-share settings for the Functions
+  # Consumption plan, irrelevant in a container runtime.
+  secret_settings = merge(
+    local.function_app_secrets_filtered, # Scrydex creds (same map Path B uses)
+    {
+      "COSMOS_DB_CONNECTION_STRING" = module.cosmos_db.primary_sql_connection_string
+      "COSMOS_DB_KEY"               = module.cosmos_db.primary_key
+      "AzureWebJobsStorage"         = module.storage_account.primary_connection_string
+    }
+  )
+
+  tags = local.common_tags
+
+  depends_on = [
+    module.resource_group,
+    module.storage_account,
+    module.cosmos_db,
+    module.application_insights,
+    module.log_analytics,
+  ]
+}

--- a/infra/envs/dev/outputs.tf
+++ b/infra/envs/dev/outputs.tf
@@ -265,5 +265,25 @@ output "deployment_summary" {
     log_analytics        = module.log_analytics.name
     application_insights = module.application_insights.name
     api_management       = var.enable_api_management ? module.api_management[0].name : "Not deployed"
+    container_app        = module.container_app.name
   }
+}
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container) outputs
+# -----------------------------------------------------------------------------
+
+output "container_app_name" {
+  description = "Name of the Path C Container App. Used by the deploy-aca.yml pipeline template to target `az containerapp update`."
+  value       = module.container_app.name
+}
+
+output "container_app_fqdn" {
+  description = "Public ingress FQDN for the Path C Container App. Set the Vercel project's PUBLIC_ACA_API_BASE_URL env var to `https://<this>` for the Phase 2.2 PR-3 frontend wiring."
+  value       = module.container_app.ingress_fqdn
+}
+
+output "container_app_resource_group" {
+  description = "Resource group containing the Container App. Convenience output for pipeline `az containerapp` invocations (same as the env-wide resource group)."
+  value       = module.resource_group.name
 }

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -357,3 +357,67 @@ variable "alert_email_address" {
   type        = string
   default     = "devops@maber.io"
 }
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container) variables
+# -----------------------------------------------------------------------------
+
+variable "shared_acr_name" {
+  description = "Name of the shared Azure Container Registry that hosts the PCPC Functions image. Reused across PCPC environments rather than provisioning per-env (per ADR-009)."
+  type        = string
+  default     = "maberdevcontainerregistry-ccedhvhwfndwetdp"
+}
+
+variable "shared_acr_resource_group" {
+  description = "Resource group that contains the shared ACR. The registry is in the same Azure subscription as PCPC dev."
+  type        = string
+  default     = "dev-rg"
+}
+
+variable "container_app_image_repository" {
+  description = "Repository path within the shared ACR for the Functions image (e.g. `pcpc/functions`). Distinct from the `pcpc-ci/*` CI tooling image repos."
+  type        = string
+  default     = "pcpc/functions"
+}
+
+variable "container_app_image_tag" {
+  description = "Initial image tag at terraform-apply time. Subsequent CD runs use `az containerapp update --image <new_sha>` to roll new revisions; the container-app module ignores image changes via lifecycle.ignore_changes."
+  type        = string
+  default     = "latest"
+}
+
+variable "container_app_min_replicas" {
+  description = "Minimum ACA replicas. Default 1 keeps the frontend's 2-second probeHealth timeout from falsely degrading Path C after idle periods (resolved as PORTFOLIO_PLAN.md open question #7)."
+  type        = number
+  default     = 1
+}
+
+variable "container_app_max_replicas" {
+  description = "Maximum ACA replicas the HTTP scale rule can scale out to."
+  type        = number
+  default     = 3
+}
+
+variable "container_app_cpu" {
+  description = "vCPU per replica."
+  type        = number
+  default     = 0.5
+}
+
+variable "container_app_memory" {
+  description = "Memory per replica (e.g. 1Gi, 2Gi)."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "container_app_http_concurrency" {
+  description = "Concurrent HTTP requests per replica before the HTTP scale rule scales out."
+  type        = number
+  default     = 10
+}
+
+variable "container_app_cors_allowed_origins" {
+  description = "Origins allowed by the ACA ingress CORS rule. Path C bypasses APIM, so this is the only allowlist gate. Keep in sync with the APIM regex policy (ADR-013) — both should be driven from the same canonical source. ACA CORS does not support regex; pass literal origins. Vercel preview origins can be added explicitly here when needed."
+  type        = list(string)
+  default     = ["https://pcpc.maber.io"]
+}

--- a/infra/modules/container-app/README.md
+++ b/infra/modules/container-app/README.md
@@ -1,0 +1,82 @@
+# container-app
+
+Terraform module that deploys the PCPC Functions image to Azure Container
+Apps (Path C of the three-path portfolio architecture). Added in Phase 2.2.
+
+See [`docs/adr/ADR-009-functions-consumption-vs-container-apps.md`](../../../docs/adr/ADR-009-functions-consumption-vs-container-apps.md)
+for the runtime tradeoff between Path B (Functions on Consumption) and
+Path C (Functions in container on ACA).
+
+## What this module composes
+
+| Resource | Purpose |
+|---|---|
+| `azurerm_user_assigned_identity` | ACR pull identity. **First UAMI in the PCPC repo** — the sibling `function-app` module uses SystemAssigned; ACR pull is the production-correct UAMI use case. |
+| `azurerm_role_assignment` | Grants the UAMI `AcrPull` on the caller-supplied ACR. |
+| `azurerm_container_app_environment` | Container Apps Environment. Consumes the caller-supplied Log Analytics workspace so Path B and Path C traces land in the same workspace. |
+| `azurerm_container_app` | The application itself. Single revision mode, HTTP scale rule, ingress CORS configured, secret/env wiring identical to Path B's Function App app_settings. |
+
+## Inputs
+
+See [`variables.tf`](./variables.tf) for the canonical descriptions; the
+non-obvious ones:
+
+- **`acr_id` / `acr_login_server`** — passed in, not provisioned. PCPC reuses
+  the shared `maberdevcontainerregistry-ccedhvhwfndwetdp` registry for both
+  CI tooling images and the application image. Per-env ACRs were not added.
+- **`log_analytics_workspace_id`** — pass `module.log_analytics.id` from
+  the dev env so Path B (App Insights → this workspace) and Path C share
+  the workspace.
+- **`min_replicas` (default `1`)** — keeps the frontend's 2-second
+  `probeHealth` timeout from falsely degrading Path C after idle periods.
+  Resolved as PORTFOLIO_PLAN open question #7. `min=0` is supported (the
+  variable validation allows it) but the toggle will hide Path C after
+  every idle window unless the probe timeout is also raised.
+- **`cors_allowed_origins`** — Path C bypasses APIM, so this is the only
+  CORS allowlist gate. Keep in sync with the APIM regex policy
+  (see ADR-013) — both should be driven from the `APIM_CORS_ORIGINS`
+  variable group entry.
+- **`app_settings` / `secret_settings`** — pass the Scrydex creds,
+  Cosmos connection string, and App Insights connection string the same
+  way the function-app module receives them. The module performs the
+  same hyphen-to-underscore transform as `function-app` so callers can
+  pass either form. `secret_settings` materialize as Container App
+  `secret` blocks referenced from env via `secret_name` — values never
+  appear in `az containerapp env` dumps or revision describes.
+
+## Container image tag handling
+
+`image_tag` is the **baseline** the resource records at `terraform apply`
+time. The ADO pipeline (`pipelines/ado/templates/deploy-aca.yml`) runs
+`az containerapp update --image <new_sha>` post-Terraform-apply to roll
+new revisions. The module's `lifecycle.ignore_changes` block ignores
+`template[0].container[0].image` to prevent Terraform from flapping the
+image back to the baseline on every CD run.
+
+This split — **Terraform owns the resource shape, the pipeline owns the
+image tag** — mirrors how Path B handles its `DEPLOY_PACKAGE_HASH`
+app-setting (also pipeline-managed, also ignored by Terraform).
+
+## Outputs
+
+| Output | Used by |
+|---|---|
+| `ingress_fqdn` | Vercel env var `PUBLIC_ACA_API_BASE_URL` (see PR-3 of Phase 2.2) |
+| `id`, `name` | Pipeline `az containerapp update` calls |
+| `principal_id` | If a caller later grants the UAMI extra roles (e.g. Cosmos data reader) |
+
+## Why no HEALTHCHECK in the Dockerfile
+
+Health probes are configured on the ACA ingress itself (revision-level
+liveness, readiness, startup probes). Adding a Dockerfile `HEALTHCHECK`
+would create a redundant probe surface that complicates debugging.
+ACA's signal is canonical.
+
+## Why no APIM in front
+
+Path C is the "skip the gateway, see what the runtime alone gives you"
+demonstration. Routing through APIM would blur the architectural
+comparison the portfolio is designed to expose. CORS, secrets, and
+observability parity with Path B are configured at the ACA ingress and
+in app_settings — same code runs in both envelopes; only the gateway
+differs. See ADR-009 Implementation Notes for the rationale.

--- a/infra/modules/container-app/main.tf
+++ b/infra/modules/container-app/main.tf
@@ -1,0 +1,184 @@
+# -----------------------------------------------------------------------------
+# LOCALS
+# -----------------------------------------------------------------------------
+
+locals {
+  common_tags = merge(
+    {
+      Environment = var.environment
+      ManagedBy   = "Terraform"
+      Module      = "container-app"
+    },
+    var.tags
+  )
+
+  # Mirror function-app's hyphen-to-underscore transform for app_settings keys.
+  # Azure Key Vault secret names use hyphens, but Node.js process.env.* lookups
+  # use underscores; the transform happens at the gateway so callers can pass
+  # either form.
+  transformed_app_settings = {
+    for key, value in var.app_settings :
+    replace(key, "-", "_") => value
+  }
+
+  # Same transform for secret keys.
+  transformed_secret_settings = {
+    for key, value in var.secret_settings :
+    replace(key, "-", "_") => value
+  }
+
+  # Secret names in the Container App resource must be lowercase + hyphens.
+  # The env var name keeps the transformed (underscore) form; the secret
+  # ref name is a lowercased-hyphen form so it satisfies the resource's
+  # name validation. We build both views here.
+  secret_refs = {
+    for key, value in local.transformed_secret_settings :
+    key => {
+      env_name    = key
+      secret_name = lower(replace(key, "_", "-"))
+      value       = value
+    }
+  }
+
+  full_image_reference = "${var.acr_login_server}/${var.image_repository}:${var.image_tag}"
+}
+
+# -----------------------------------------------------------------------------
+# USER-ASSIGNED MANAGED IDENTITY
+#
+# Used by the Container App to pull from ACR. Separate from the System
+# identity Path B's Function App uses — UAMI is the production-correct
+# pattern for ACR pulls (admin-enabled ACR would be a scanner finding).
+# -----------------------------------------------------------------------------
+
+resource "azurerm_user_assigned_identity" "this" {
+  name                = "${var.name}-uami"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tags                = local.common_tags
+}
+
+resource "azurerm_role_assignment" "acr_pull" {
+  scope                = var.acr_id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_user_assigned_identity.this.principal_id
+}
+
+# -----------------------------------------------------------------------------
+# CONTAINER APPS ENVIRONMENT
+#
+# Consumes the caller-supplied Log Analytics workspace so Path B (Function
+# App / App Insights) and Path C (this Container App) write traces to the
+# same workspace and are queryable side-by-side.
+# -----------------------------------------------------------------------------
+
+resource "azurerm_container_app_environment" "this" {
+  name                       = "${var.name}-env"
+  location                   = var.location
+  resource_group_name        = var.resource_group_name
+  log_analytics_workspace_id = var.log_analytics_workspace_id
+
+  tags = local.common_tags
+}
+
+# -----------------------------------------------------------------------------
+# CONTAINER APP
+# -----------------------------------------------------------------------------
+
+resource "azurerm_container_app" "this" {
+  name                         = var.name
+  resource_group_name          = var.resource_group_name
+  container_app_environment_id = azurerm_container_app_environment.this.id
+  revision_mode                = "Single"
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.this.id]
+  }
+
+  registry {
+    server   = var.acr_login_server
+    identity = azurerm_user_assigned_identity.this.id
+  }
+
+  # Each secret_settings entry becomes one `secret` block here AND one
+  # `env { name=..., secret_name=... }` block in the template below.
+  dynamic "secret" {
+    for_each = local.secret_refs
+    content {
+      name  = secret.value.secret_name
+      value = secret.value.value
+    }
+  }
+
+  template {
+    min_replicas = var.min_replicas
+    max_replicas = var.max_replicas
+
+    http_scale_rule {
+      name                = "http-scale"
+      concurrent_requests = var.http_concurrency
+    }
+
+    container {
+      name   = "functions"
+      image  = local.full_image_reference
+      cpu    = var.cpu
+      memory = var.memory
+
+      # Non-secret env vars (plain value)
+      dynamic "env" {
+        for_each = local.transformed_app_settings
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      # Secret env vars (referenced by secret_name from the secret blocks above)
+      dynamic "env" {
+        for_each = local.secret_refs
+        content {
+          name        = env.value.env_name
+          secret_name = env.value.secret_name
+        }
+      }
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = var.target_port
+    transport        = "auto"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+
+    cors {
+      allowed_origins    = var.cors_allowed_origins
+      allowed_methods    = var.cors_allowed_methods
+      allowed_headers    = var.cors_allowed_headers
+      exposed_headers    = []
+      max_age_in_seconds = var.cors_max_age_in_seconds
+    }
+  }
+
+  tags = local.common_tags
+
+  depends_on = [
+    azurerm_role_assignment.acr_pull,
+  ]
+
+  lifecycle {
+    # Pipeline-managed: ADO's deploy-aca.yml runs `az containerapp update
+    # --image <new_sha>` post-Terraform-apply to roll new revisions. Terraform
+    # owns the resource shape; the pipeline owns the image tag pin. Without
+    # this ignore, every CD run would either flap the image back to the
+    # `image_tag` variable's default or force re-runs to bump the variable.
+    ignore_changes = [
+      template[0].container[0].image,
+    ]
+  }
+}

--- a/infra/modules/container-app/outputs.tf
+++ b/infra/modules/container-app/outputs.tf
@@ -1,0 +1,38 @@
+# -----------------------------------------------------------------------------
+# OUTPUTS
+# -----------------------------------------------------------------------------
+
+output "id" {
+  description = "Resource ID of the Container App."
+  value       = azurerm_container_app.this.id
+}
+
+output "name" {
+  description = "Name of the Container App."
+  value       = azurerm_container_app.this.name
+}
+
+output "ingress_fqdn" {
+  description = "Public FQDN exposed by the Container App's ingress. The frontend's PUBLIC_ACA_API_BASE_URL Vercel env var should point at https://<this>."
+  value       = azurerm_container_app.this.latest_revision_fqdn
+}
+
+output "environment_id" {
+  description = "Resource ID of the Container Apps Environment."
+  value       = azurerm_container_app_environment.this.id
+}
+
+output "principal_id" {
+  description = "Principal ID of the user-assigned managed identity (used for ACR pull). Exposed so the caller can grant additional roles (e.g. Cosmos data reader) if it later moves off connection-string auth."
+  value       = azurerm_user_assigned_identity.this.principal_id
+}
+
+output "identity_id" {
+  description = "Resource ID of the user-assigned managed identity."
+  value       = azurerm_user_assigned_identity.this.id
+}
+
+output "latest_revision_name" {
+  description = "Name of the most recently deployed revision. Useful for pipeline post-deploy verification (poll until Active)."
+  value       = azurerm_container_app.this.latest_revision_name
+}

--- a/infra/modules/container-app/variables.tf
+++ b/infra/modules/container-app/variables.tf
@@ -1,0 +1,170 @@
+# -----------------------------------------------------------------------------
+# REQUIRED VARIABLES
+# -----------------------------------------------------------------------------
+
+variable "name" {
+  description = "Base name for the Container App resources. Used for the Container App itself, the Container Apps Environment (`<name>-env`), and the user-assigned managed identity (`<name>-uami`)."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]{2,32}$", var.name))
+    error_message = "Name must be 2-32 characters, lowercase letters, numbers, and hyphens only (Container App names have a 32-char limit)."
+  }
+}
+
+variable "resource_group_name" {
+  description = "Name of the resource group that hosts the Container App resources."
+  type        = string
+}
+
+variable "location" {
+  description = "Azure region where the Container App resources will be created. Must match the region of the Log Analytics workspace passed in via log_analytics_workspace_id."
+  type        = string
+}
+
+variable "log_analytics_workspace_id" {
+  description = "Resource ID of an existing Log Analytics workspace that the Container Apps Environment writes its system + container logs to. Path C reuses Path B's workspace so traces from both runtimes are queryable side-by-side (see ADR-009)."
+  type        = string
+}
+
+variable "acr_id" {
+  description = "Resource ID of the Azure Container Registry the Container App pulls its image from. The module's user-assigned managed identity is granted the AcrPull role on this ACR. Path C reuses the shared `maberdevcontainerregistry-ccedhvhwfndwetdp` ACR rather than provisioning a per-env registry (see ADR-009)."
+  type        = string
+}
+
+variable "acr_login_server" {
+  description = "Login server hostname for the ACR (e.g. `maberdevcontainerregistry-ccedhvhwfndwetdp.azurecr.io`). Used in the `registry.server` field on the Container App."
+  type        = string
+}
+
+variable "image_repository" {
+  description = "Image repository path within the ACR (e.g. `pcpc/functions`). Combined with `image_tag` to form the full image reference."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9._/-]*$", var.image_repository))
+    error_message = "Image repository must be a valid ACR repository path (lowercase, slashes, dots, hyphens, underscores)."
+  }
+}
+
+variable "image_tag" {
+  description = "Image tag to deploy at module-apply time. The ADO pipeline updates this via `az containerapp update --image` post-apply, so the value here is the initial / baseline tag (`latest` is fine for first apply)."
+  type        = string
+  default     = "latest"
+}
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — environment + naming
+# -----------------------------------------------------------------------------
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod). Used in default tagging and to derive environment-specific defaults."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod."
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to apply to resources. Merged with module defaults (Environment, ManagedBy=Terraform, Module=container-app)."
+  type        = map(string)
+  default     = {}
+}
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — scaling + resources
+# -----------------------------------------------------------------------------
+
+variable "min_replicas" {
+  description = "Minimum number of replicas. PCPC defaults to 1 in dev so the frontend's 2-second probeHealth timeout never falsely degrades Path C after an idle period (see ADR-009 and the open-question resolution in PORTFOLIO_PLAN.md)."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.min_replicas >= 0 && var.min_replicas <= 25
+    error_message = "min_replicas must be between 0 and 25."
+  }
+}
+
+variable "max_replicas" {
+  description = "Maximum number of replicas the HTTP scale rule can scale out to."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.max_replicas >= 1 && var.max_replicas <= 300
+    error_message = "max_replicas must be between 1 and 300."
+  }
+}
+
+variable "cpu" {
+  description = "vCPU cores per replica. Combined with `memory`, must match a valid ACA Consumption profile (e.g. 0.5 vCPU + 1Gi memory, 1.0 vCPU + 2Gi memory)."
+  type        = number
+  default     = 0.5
+}
+
+variable "memory" {
+  description = "Memory per replica (e.g. `1Gi`, `2Gi`, `4Gi`). Must pair with `cpu` against a valid ACA Consumption profile."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "http_concurrency" {
+  description = "Concurrent HTTP requests per replica before the HTTP scale rule scales out. Defaults to 10 (ACA default)."
+  type        = number
+  default     = 10
+}
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — ingress + CORS
+# -----------------------------------------------------------------------------
+
+variable "target_port" {
+  description = "Port the container listens on. The Functions base image listens on 80 by default."
+  type        = number
+  default     = 80
+}
+
+variable "cors_allowed_origins" {
+  description = "List of origins allowed by the ACA ingress CORS rule. Path C bypasses APIM, so this is the only allowlist gate for browser requests to Path C — keep in sync with the APIM regex policy origins (see ADR-013) or source both from the same variable group entry."
+  type        = list(string)
+  default     = []
+}
+
+variable "cors_allowed_methods" {
+  description = "HTTP methods permitted by the ingress CORS rule."
+  type        = list(string)
+  default     = ["GET", "POST", "OPTIONS"]
+}
+
+variable "cors_allowed_headers" {
+  description = "Request headers permitted by the ingress CORS rule."
+  type        = list(string)
+  default     = ["content-type", "x-functions-key"]
+}
+
+variable "cors_max_age_in_seconds" {
+  description = "Max age the browser can cache CORS preflight responses, in seconds."
+  type        = number
+  default     = 3600
+}
+
+# -----------------------------------------------------------------------------
+# OPTIONAL — application settings + secrets
+# -----------------------------------------------------------------------------
+
+variable "app_settings" {
+  description = "Non-secret application settings (env vars) for the container. Keys are emitted to the container with the original casing. Hyphenated keys are converted to underscores (parity with the function-app module's transform) so Node.js can read them as `process.env.*`."
+  type        = map(string)
+  default     = {}
+}
+
+variable "secret_settings" {
+  description = "Secret application settings. Map of env-var name → secret value. Each entry materializes as both a Container App `secret` block and an `env` block that references it via `secret_name`, so the value never appears in env-var dumps or revision describe output."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}

--- a/infra/modules/container-app/versions.tf
+++ b/infra/modules/container-app/versions.tf
@@ -1,0 +1,18 @@
+# -----------------------------------------------------------------------------
+# Provider version pin for the container-app module.
+#
+# Pinned to the same range as the rest of the modules in infra/modules/.
+# azurerm 4.47.0+ supports azurerm_container_app and
+# azurerm_container_app_environment with the ingress.cors block we use.
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.47.0, < 5.0.0"
+    }
+  }
+}

--- a/pipelines/ado/azure-pipelines.yml
+++ b/pipelines/ado/azure-pipelines.yml
@@ -120,6 +120,30 @@ stages:
               environment: dev
               azureSubscription: "az-pcpc-dev"
 
+      # Phase 2.2 — Deploy Path C (ACA Container).
+      #
+      # Parallel to Deploy_Functions (Path B). Builds the Functions image,
+      # scans for HIGH+ CVEs (Trivy, blocking), pushes to ACR, and rolls a
+      # new revision on the Container App. No container: directive — the
+      # job needs the host Docker daemon for the image build.
+      - job: Deploy_ACA
+        displayName: "Deploy Path C (ACA Container)"
+        dependsOn: Deploy_Infrastructure
+        condition: succeeded()
+        pool:
+          vmImage: "ubuntu-latest"
+        steps:
+          - template: templates/build-and-push-image.yml
+            parameters:
+              acrRegistryServiceConnection: pcpc-acr-service-connection
+              azureSubscription: "az-pcpc-dev"
+          - template: templates/deploy-aca.yml
+            parameters:
+              environment: dev
+              azureSubscription: "az-pcpc-dev"
+              containerAppName: "pcpc-aca-dev"
+              resourceGroupName: $(APIM_RESOURCE_GROUP)
+
       # Run Smoke Tests
       - job: Smoke_Tests
         displayName: "Run Smoke Tests"

--- a/pipelines/ado/templates/build-and-push-image.yml
+++ b/pipelines/ado/templates/build-and-push-image.yml
@@ -1,0 +1,174 @@
+# Build and Push PCPC Functions ACA Image
+#
+# Phase 2.2. Builds the Functions container from backend/functions/Dockerfile,
+# scans for HIGH+ CVEs with Trivy (blocking), and pushes to the shared ACR
+# under the pcpc/functions repository path.
+#
+# Output variables (consumed by the deploy-aca.yml template that follows
+# in the same job):
+#   ContainerImageReference  — full registry/repo:tag of the canonical
+#                              (git-SHA-tagged) image to deploy
+#   ContainerImageDigest     — sha256:... digest of the pushed image, for
+#                              optional pin verification
+#
+# Usage:
+#   - template: pipelines/ado/templates/build-and-push-image.yml
+#     parameters:
+#       acrRegistryServiceConnection: pcpc-acr-service-connection
+#       azureSubscription: az-pcpc-dev
+#       acrName: maberdevcontainerregistry-ccedhvhwfndwetdp
+#       imageRepository: pcpc/functions
+#       trivySeverity: HIGH,CRITICAL
+#       trivyVersion: "0.59.1"
+
+parameters:
+  - name: acrRegistryServiceConnection
+    type: string
+    default: pcpc-acr-service-connection
+  - name: azureSubscription
+    type: string
+  - name: acrName
+    type: string
+    default: maberdevcontainerregistry-ccedhvhwfndwetdp
+  - name: imageRepository
+    type: string
+    default: pcpc/functions
+  - name: trivySeverity
+    type: string
+    default: "HIGH,CRITICAL"
+  - name: trivyVersion
+    type: string
+    default: "0.59.1"
+
+steps:
+  - checkout: self
+
+  # ---------------------------------------------------------------------------
+  # Resolve ACR login server and compute image tags
+  # ---------------------------------------------------------------------------
+  - task: AzureCLI@2
+    displayName: "Resolve ACR + Compute Image Tags"
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+
+        ACR_NAME='${{ parameters.acrName }}'
+        REPO='${{ parameters.imageRepository }}'
+
+        FQDN=$(az acr show -n "$ACR_NAME" --query loginServer -o tsv)
+        SHORT_SHA="$(echo '$(Build.SourceVersion)' | cut -c1-7)"
+        BUILD_TAG="$(Build.BuildId)"
+        SHA_TAG="git-${SHORT_SHA}"
+
+        FULL_REF_SHA="${FQDN}/${REPO}:${SHA_TAG}"
+        FULL_REF_BUILD="${FQDN}/${REPO}:${BUILD_TAG}"
+        FULL_REF_LATEST="${FQDN}/${REPO}:latest"
+
+        echo "ACR login server: $FQDN"
+        echo "Image SHA tag: $SHA_TAG"
+        echo "Image build tag: $BUILD_TAG"
+        echo "Canonical reference (for deploy): $FULL_REF_SHA"
+
+        echo "##vso[task.setvariable variable=AcrLoginServer]$FQDN"
+        echo "##vso[task.setvariable variable=ContainerImageReference]$FULL_REF_SHA"
+        echo "##vso[task.setvariable variable=ContainerImageBuildRef]$FULL_REF_BUILD"
+        echo "##vso[task.setvariable variable=ContainerImageLatestRef]$FULL_REF_LATEST"
+
+  # ---------------------------------------------------------------------------
+  # Build the image locally (no push yet — we scan before push)
+  #
+  # Build context is backend/ so the file:../shared reference in
+  # backend/functions/package.json resolves. Dockerfile path is relative to
+  # that context.
+  # ---------------------------------------------------------------------------
+  - script: |
+      set -euo pipefail
+
+      echo "Building Functions container image..."
+      docker build \
+        -f backend/functions/Dockerfile \
+        -t "$(ContainerImageReference)" \
+        -t "$(ContainerImageBuildRef)" \
+        -t "$(ContainerImageLatestRef)" \
+        backend/
+
+      echo "Built tags:"
+      docker images "$(AcrLoginServer)/${{ parameters.imageRepository }}" --format "  {{.Repository}}:{{.Tag}}"
+    displayName: "docker build pcpc/functions"
+
+  # ---------------------------------------------------------------------------
+  # Install Trivy (pinned), scan the locally built image, block on HIGH+ CVE
+  # ---------------------------------------------------------------------------
+  - script: |
+      set -euo pipefail
+
+      TRIVY_VERSION='${{ parameters.trivyVersion }}'
+      echo "Installing Trivy ${TRIVY_VERSION}..."
+      curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
+        | sh -s -- -b /tmp v${TRIVY_VERSION}
+      /tmp/trivy --version
+    displayName: "Install Trivy ${{ parameters.trivyVersion }}"
+
+  - script: |
+      set -euo pipefail
+
+      echo "=========================================="
+      echo "TRIVY CVE SCAN"
+      echo "=========================================="
+      echo "Image:    $(ContainerImageReference)"
+      echo "Severity: ${{ parameters.trivySeverity }} (blocking)"
+      echo ""
+
+      /tmp/trivy image \
+        --severity '${{ parameters.trivySeverity }}' \
+        --exit-code 1 \
+        --no-progress \
+        --ignore-unfixed \
+        --scanners vuln \
+        "$(ContainerImageReference)"
+
+      echo ""
+      echo "✓ Trivy scan passed — no ${{ parameters.trivySeverity }} CVEs with available fixes"
+    displayName: "Trivy CVE scan (blocking)"
+    continueOnError: false
+
+  # ---------------------------------------------------------------------------
+  # Login to ACR and push all three tags
+  # ---------------------------------------------------------------------------
+  - task: Docker@2
+    displayName: "Login to ACR"
+    inputs:
+      command: login
+      containerRegistry: ${{ parameters.acrRegistryServiceConnection }}
+
+  - script: |
+      set -euo pipefail
+
+      echo "Pushing image tags..."
+      docker push "$(ContainerImageReference)"
+      docker push "$(ContainerImageBuildRef)"
+      docker push "$(ContainerImageLatestRef)"
+      echo "✓ All tags pushed"
+    displayName: "docker push (all tags)"
+
+  # ---------------------------------------------------------------------------
+  # Capture the pushed digest for downstream use
+  # ---------------------------------------------------------------------------
+  - script: |
+      set -euo pipefail
+
+      DIGEST=$(docker manifest inspect "$(ContainerImageReference)" --verbose 2>/dev/null \
+        | jq -r 'if type == "array" then .[0].Descriptor.digest else .Descriptor.digest end')
+
+      if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+        echo "##vso[task.logissue type=warning]Could not capture image digest; deploy will use tag-based reference"
+        exit 0
+      fi
+
+      echo "Image digest: $DIGEST"
+      echo "##vso[task.setvariable variable=ContainerImageDigest]$DIGEST"
+    displayName: "Capture image digest"
+    continueOnError: true

--- a/pipelines/ado/templates/deploy-aca.yml
+++ b/pipelines/ado/templates/deploy-aca.yml
@@ -1,0 +1,241 @@
+# Deploy the PCPC Functions image to Azure Container Apps (Path C)
+#
+# Phase 2.2. Roles the new image onto the Container App and runs blocking
+# smoke tests against the ingress FQDN.
+#
+# Expected pipeline variables (set by the preceding build-and-push-image.yml
+# template in the same job):
+#   ContainerImageReference  — full registry/repo:tag of the image to deploy
+#
+# Usage:
+#   - template: pipelines/ado/templates/deploy-aca.yml
+#     parameters:
+#       environment: dev
+#       azureSubscription: az-pcpc-dev
+#       containerAppName: pcpc-aca-dev
+#       resourceGroupName: pcpc-rg-dev
+#       runSmokeTests: true
+
+parameters:
+  - name: environment
+    type: string
+  - name: azureSubscription
+    type: string
+  - name: containerAppName
+    type: string
+  - name: resourceGroupName
+    type: string
+  - name: runSmokeTests
+    type: boolean
+    default: true
+
+steps:
+  - checkout: self
+
+  # ---------------------------------------------------------------------------
+  # Skip-redeploy check: compare incoming image reference to the currently
+  # active revision's image. Mirrors deploy-functions.yml's content-hash skip
+  # pattern (which keys off DEPLOY_PACKAGE_HASH); here we key off the
+  # registry/repo:tag tuple instead.
+  # ---------------------------------------------------------------------------
+  - task: AzureCLI@2
+    displayName: "Evaluate ACA Deployment"
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+
+        TARGET_REF='$(ContainerImageReference)'
+        APP_NAME='${{ parameters.containerAppName }}'
+        RG='${{ parameters.resourceGroupName }}'
+
+        if [ -z "$TARGET_REF" ]; then
+          echo "##vso[task.logissue type=error]ContainerImageReference pipeline variable is empty — the build-and-push-image template must run before this template"
+          exit 1
+        fi
+
+        echo "Target image: $TARGET_REF"
+        echo "Container App: $APP_NAME (rg=$RG)"
+
+        set +e
+        CURRENT_REF=$(az containerapp show \
+          --name "$APP_NAME" \
+          --resource-group "$RG" \
+          --query 'properties.template.containers[0].image' \
+          -o tsv 2>/dev/null)
+        CLI_EXIT=$?
+        set -e
+
+        if [ $CLI_EXIT -ne 0 ]; then
+          echo "Could not read current Container App image (CLI exit $CLI_EXIT). Defaulting to deploy."
+          SHOULD_DEPLOY=true
+          CURRENT_REF=""
+        elif [ -z "$CURRENT_REF" ]; then
+          echo "Container App has no current image set. Will deploy."
+          SHOULD_DEPLOY=true
+        elif [ "$CURRENT_REF" = "$TARGET_REF" ]; then
+          echo "Current image matches target. Skipping ACA revision update."
+          SHOULD_DEPLOY=false
+        else
+          echo "Current image differs from target. Will deploy."
+          SHOULD_DEPLOY=true
+        fi
+
+        echo "Current image: ${CURRENT_REF:-<none>}"
+        echo "##vso[task.setvariable variable=ShouldDeployACA]$SHOULD_DEPLOY"
+
+  - script: |
+      echo "ACA image unchanged from last deployment. Skipping revision update."
+    displayName: "Skip ACA Deployment"
+    condition: and(succeeded(), eq(variables['ShouldDeployACA'], 'false'))
+
+  # ---------------------------------------------------------------------------
+  # Roll the new image onto the Container App. revision_mode = "Single"
+  # (set by the Terraform module) means this replaces the active revision
+  # atomically.
+  # ---------------------------------------------------------------------------
+  - task: AzureCLI@2
+    displayName: "Update Container App Image"
+    condition: and(succeeded(), eq(variables['ShouldDeployACA'], 'true'))
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+
+        echo "Rolling new revision: $(ContainerImageReference)"
+        az containerapp update \
+          --name '${{ parameters.containerAppName }}' \
+          --resource-group '${{ parameters.resourceGroupName }}' \
+          --image "$(ContainerImageReference)" \
+          --output none
+
+        echo "✓ Container App revision update accepted"
+
+  # ---------------------------------------------------------------------------
+  # Wait for the new revision to reach Running/Healthy state. Mirrors the
+  # 30-second sleep + healthcheck pattern in deploy-functions.yml, but with
+  # an explicit poll because ACA's revision provisioning is more visible
+  # than the Function App ZIP deploy.
+  # ---------------------------------------------------------------------------
+  - task: AzureCLI@2
+    displayName: "Wait for New Revision Active"
+    condition: and(succeeded(), eq(variables['ShouldDeployACA'], 'true'))
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+
+        APP_NAME='${{ parameters.containerAppName }}'
+        RG='${{ parameters.resourceGroupName }}'
+        MAX_WAIT_SECONDS=300
+        POLL_INTERVAL=10
+        elapsed=0
+
+        echo "Waiting up to ${MAX_WAIT_SECONDS}s for new revision to become active..."
+
+        while [ $elapsed -lt $MAX_WAIT_SECONDS ]; do
+          LATEST_REV=$(az containerapp revision list \
+            --name "$APP_NAME" \
+            --resource-group "$RG" \
+            --query '[?properties.active==`true`] | [0]' \
+            -o json 2>/dev/null || echo '{}')
+
+          STATE=$(echo "$LATEST_REV" | jq -r '.properties.runningState // "Unknown"')
+          REV_NAME=$(echo "$LATEST_REV" | jq -r '.name // "unknown"')
+
+          echo "  [${elapsed}s] Revision $REV_NAME state=$STATE"
+
+          if [ "$STATE" = "Running" ] || [ "$STATE" = "RunningAtMaxScale" ]; then
+            echo "✓ Revision is Running"
+            exit 0
+          fi
+
+          if [ "$STATE" = "Failed" ]; then
+            echo "##vso[task.logissue type=error]Revision $REV_NAME entered Failed state"
+            exit 1
+          fi
+
+          sleep $POLL_INTERVAL
+          elapsed=$((elapsed + POLL_INTERVAL))
+        done
+
+        echo "##vso[task.logissue type=error]Revision did not reach Running state within ${MAX_WAIT_SECONDS}s"
+        exit 1
+
+  # ---------------------------------------------------------------------------
+  # Capture ingress FQDN for the smoke test stage and the deployment summary.
+  # ---------------------------------------------------------------------------
+  - task: AzureCLI@2
+    displayName: "Get Container App Ingress FQDN"
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+
+        FQDN=$(az containerapp show \
+          --name '${{ parameters.containerAppName }}' \
+          --resource-group '${{ parameters.resourceGroupName }}' \
+          --query 'properties.configuration.ingress.fqdn' \
+          -o tsv)
+
+        if [ -z "$FQDN" ]; then
+          echo "##vso[task.logissue type=error]Failed to read Container App ingress FQDN"
+          exit 1
+        fi
+
+        ACA_URL="https://${FQDN}"
+        echo "ACA ingress URL: $ACA_URL"
+        echo "##vso[task.setvariable variable=acaIngressUrl]$ACA_URL"
+
+  # ---------------------------------------------------------------------------
+  # Blocking smoke tests. Reuses the existing health-check-functions.sh
+  # script — it's URL-agnostic and accepts an optional function key (ACA
+  # ingress is anonymous so we don't pass one).
+  # ---------------------------------------------------------------------------
+  - ${{ if eq(parameters.runSmokeTests, true) }}:
+      - script: |
+          set -euo pipefail
+
+          chmod +x pipelines/ado/scripts/health-check-functions.sh
+
+          echo "=========================================="
+          echo "ACA SMOKE TESTS"
+          echo "=========================================="
+          echo "URL: $(acaIngressUrl)"
+          echo "Environment: ${{ parameters.environment }}"
+          echo ""
+
+          bash pipelines/ado/scripts/health-check-functions.sh "$(acaIngressUrl)"
+        displayName: "Run ACA Smoke Tests (blocking)"
+        continueOnError: false
+
+  # ---------------------------------------------------------------------------
+  # Deployment summary
+  # ---------------------------------------------------------------------------
+  - script: |
+      echo "=========================================="
+      echo "ACA DEPLOYMENT SUMMARY"
+      echo "=========================================="
+      echo ""
+      echo "Environment: ${{ parameters.environment }}"
+      echo "Container App: ${{ parameters.containerAppName }}"
+      echo "Resource Group: ${{ parameters.resourceGroupName }}"
+      echo "Image deployed: $(ContainerImageReference)"
+      echo "Ingress URL: $(acaIngressUrl)"
+      echo ""
+      echo "Available endpoints:"
+      echo "  - Health: $(acaIngressUrl)/api/health"
+      echo "  - Sets:   $(acaIngressUrl)/api/sets"
+      echo "  - Cards:  $(acaIngressUrl)/api/sets/{setId}/cards"
+      echo "  - Card:   $(acaIngressUrl)/api/cards/{cardId}"
+      echo ""
+      echo "=========================================="
+    displayName: "Display ACA Deployment Summary"


### PR DESCRIPTION
## Summary

PR-2 of three for **Phase 2.2** (containerize the existing Azure Functions and ship the ACA path). This PR lands the Dockerfile, the new `container-app` Terraform module, and the ADO pipeline stage that builds → scans → pushes → deploys the image. **Dev environment only.** Staging/prod promotion is a follow-up PR after dev is verified.

Rollback tag `phase-2.2/pre-aca` on `main` pinned before this branch was opened.

Successor:
- **PR-3** (frontend toggle + Vercel `PUBLIC_ACA_API_BASE_URL`) — opens after this lands and dev CD turns green.

Addresses [@codex's review on PR #148](https://github.com/Abernaughty/PCPC/pull/148): the new container-app module includes the `ingress.cors` block with the allowlist as a typed input, so Path C is CORS-safe out of the box without depending on app-level header emission.

## What's in this PR

### Dockerfile + dockerignore

- **`backend/functions/Dockerfile`** — multi-stage build against `mcr.microsoft.com/azure-functions/node:4-node22`. Build context is `backend/` (not `backend/functions/`) so the `file:../shared` reference for `@pcpc/shared` resolves at install time. Build stage runs `tsc`; runtime stage copies `dist/` + `host.json` + manifests and runs `npm ci --omit=dev` for a lean prod image. No HEALTHCHECK — ACA's ingress probes are the canonical signal. Verified locally: image is 2.12 GB, `host.json` + `dist/` + 261-pkg `node_modules` present at `/home/site/wwwroot`.
- **`backend/.dockerignore`** — at the context root (Docker only honors dockerignore at the context root, not in subdirs). Excludes `node_modules`, `dist`, `local.settings.json`, test scripts, developer artifacts.
- **`.gitignore`** — adds `!backend/.dockerignore` exception. The repo's blanket `.dockerignore` rule (line 129) was masking the intentional one; the negation makes the source-controlled dockerignore trackable while keeping per-developer scratch dockerignores ignored.

### `container-app` Terraform module (new)

`infra/modules/container-app/{main,variables,outputs,versions}.tf` + README.

Composes:
- `azurerm_container_app_environment` consuming caller-supplied `log_analytics_workspace_id` (same workspace as Path B's App Insights — see ADR-009)
- `azurerm_user_assigned_identity` — **first UAMI in the repo**; granted `AcrPull` on the caller-supplied ACR
- `azurerm_container_app` with HTTP ingress (port 80), the **CORS rule** addressing PR #148's review, HTTP scale rule, secret + env blocks parity with Path B's `app_settings`

Key design choices:
- `revision_mode = "Single"` (simpler for portfolio; canary via `Multiple` is a future move noted in ADR-009)
- `lifecycle.ignore_changes = [template[0].container[0].image]` so Terraform owns the resource shape while the pipeline owns the image tag — mirrors how function-app handles `DEPLOY_PACKAGE_HASH`
- `allow_credentials` removed from the `cors` block during validation — azurerm 4.x dropped it and we don't need credentials anyway

### Dev env wiring

- `infra/envs/dev/main.tf` — adds `data "azurerm_container_registry" "shared"` (looks up `maberdevcontainerregistry-ccedhvhwfndwetdp` in `dev-rg`) and a `module "container_app"` block that consumes existing module outputs (cosmos, storage, app insights, log analytics). **Container-runtime-only settings:** `AzureWebJobsStorage` (from storage module's connection string), `FUNCTIONS_WORKER_RUNTIME=node`. **Consumption-only settings intentionally NOT carried over:** `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`, `WEBSITE_CONTENTSHARE`.
- `infra/envs/dev/variables.tf` — 8 new variables. Defaults match `PORTFOLIO_PLAN.md` guidance — `min_replicas=1` resolves open question #7 (the frontend's 2s `probeHealth` timeout would falsely degrade Path C at `min=0`).
- `infra/envs/dev/outputs.tf` — exposes `container_app_fqdn` for the pipeline to capture and for PR-3's Vercel env var.

Validated locally:
- `terraform fmt -recursive infra/` clean
- `terraform validate` in `envs/dev/` succeeds (caught an azurerm 4.x cors schema mismatch on first try; fixed pre-commit)

### ADO pipeline templates

- **`pipelines/ado/templates/build-and-push-image.yml`** — resolves ACR login server, computes 3 tags (`latest`, `$(Build.BuildId)`, `git-<short-sha>`), `docker build` locally, installs Trivy (pinned `v0.59.1`), scans for `HIGH,CRITICAL` CVEs **blocking** (per the plan's image-scanning decision), pushes all 3 tags to ACR.
- **`pipelines/ado/templates/deploy-aca.yml`** — skip-redeploy check (mirrors `deploy-functions.yml`'s content-hash skip at lines 130-180), `az containerapp update --image`, polls revision until `runningState=Running` (5min timeout, 10s interval; fails fast on `Failed`), captures ingress FQDN, runs `health-check-functions.sh` against the FQDN. **No wrapper script needed** — the existing health-check script is URL-agnostic and accepts no function key (ACA ingress is anonymous).
- **`pipelines/ado/azure-pipelines.yml`** — adds `Deploy_ACA` job to `Deploy_Dev` stage, parallel to `Deploy_Functions`. No `container:` override — the job needs the host Docker daemon for the image build. Staging/prod stages unchanged (promoted in a follow-up PR).

## What dev CD will do on first run

1. Terraform plan/apply provisions the Container App with `image=latest` (resource exists but pulls a not-yet-pushed image; the revision will error until step 2 lands)
2. Docker build → Trivy passes → ACR push tags the image at `pcpc/functions:git-<sha>`
3. `az containerapp update --image` rolls the new revision
4. Smoke test hits `/api/health` and `/api/sets` through the ACA FQDN — **blocking**
5. `terraform output container_app_fqdn` is available for PR-3

## Test plan

- [x] `docker build -f backend/functions/Dockerfile backend/` succeeds locally
- [x] `terraform fmt -recursive infra/` clean
- [x] `terraform validate` in `envs/dev/` succeeds
- [ ] PR Validation pipeline (Terraform fmt, validate, tflint, checkov) turns green
- [ ] Dev CD pipeline turns green end-to-end (the moment of truth)
- [ ] After dev CD: `curl https://<aca-fqdn>/api/health` returns 200, `curl https://<aca-fqdn>/api/sets` returns real Scrydex data
- [ ] App Insights confirms Path C traces tagged with `cloud_RoleName=pcpc-aca-dev` in the shared workspace
- [ ] Tag `phase-2.2/post-aca-infra` after dev CD is green

## Things to watch on first CD run

- **ACA scale-to-zero edge case** — addressed by defaulting `min_replicas=1` (ADR-009 + PORTFOLIO_PLAN open question #7)
- **`AzureWebJobsStorage` required by base image** — wired via storage module's `primary_connection_string` output
- **`WEBSITE_RUN_FROM_PACKAGE` / `WEBSITE_CONTENTSHARE`** do NOT apply to containers — intentionally absent from ACA env vars
- **UAMI for ACR pull**, not admin user — production-correct pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)