### PR TITLE
fix(phase-2.2): use ACR name (not FQDN) for shared_acr_name

### DIFF
--- a/docs/adr/ADR-009-functions-consumption-vs-container-apps.md
+++ b/docs/adr/ADR-009-functions-consumption-vs-container-apps.md
@@ -240,13 +240,16 @@ ship byte-identical application code.
 
 ### Container Registry sharing
 
-PCPC reuses the existing `maberdevcontainerregistry-ccedhvhwfndwetdp`
-ACR rather than provisioning a per-environment registry. The CI-tooling
-images (`pcpc-ci-terraform-azure`, `pcpc-ci-node22`, `pcpc-ci-node-azure`)
-already live in this ACR; Path C adds the `pcpc/functions` repository
-path for the application image. No new ACR module is added; the
-container-app module accepts the ACR resource ID and login server as
-inputs so it remains agnostic to where the registry is provisioned.
+PCPC reuses the existing `maberdevcontainerregistry` ACR (login server
+`maberdevcontainerregistry-ccedhvhwfndwetdp.azurecr.io` — the suffix on
+the FQDN is Azure's dedicated-data-endpoint mechanism, not part of the
+registry's name) rather than provisioning a per-environment registry.
+The CI-tooling images (`pcpc-ci-terraform-azure`, `pcpc-ci-node22`,
+`pcpc-ci-node-azure`) already live in this ACR; Path C adds the
+`pcpc/functions` repository path for the application image. No new ACR
+module is added; the container-app module accepts the ACR resource ID
+and login server as inputs so it remains agnostic to where the
+registry is provisioned.
 
 ### Frontend integration
 

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -363,9 +363,9 @@ variable "alert_email_address" {
 # -----------------------------------------------------------------------------
 
 variable "shared_acr_name" {
-  description = "Name of the shared Azure Container Registry that hosts the PCPC Functions image. Reused across PCPC environments rather than provisioning per-env (per ADR-009)."
+  description = "Name of the shared Azure Container Registry that hosts the PCPC Functions image. Reused across PCPC environments rather than provisioning per-env (per ADR-009). NOTE: the ACR's *name* is alphanumeric-only — `maberdevcontainerregistry`. Its login server FQDN is `maberdevcontainerregistry-ccedhvhwfndwetdp.azurecr.io` (the `-ccedhvhwfndwetdp` suffix is Azure's dedicated data endpoint mechanism, NOT part of the registry name)."
   type        = string
-  default     = "maberdevcontainerregistry-ccedhvhwfndwetdp"
+  default     = "maberdevcontainerregistry"
 }
 
 variable "shared_acr_resource_group" {

--- a/infra/modules/container-app/README.md
+++ b/infra/modules/container-app/README.md
@@ -22,8 +22,11 @@ See [`variables.tf`](./variables.tf) for the canonical descriptions; the
 non-obvious ones:
 
 - **`acr_id` / `acr_login_server`** — passed in, not provisioned. PCPC reuses
-  the shared `maberdevcontainerregistry-ccedhvhwfndwetdp` registry for both
-  CI tooling images and the application image. Per-env ACRs were not added.
+  the shared `maberdevcontainerregistry` registry (login server
+  `maberdevcontainerregistry-ccedhvhwfndwetdp.azurecr.io`) for both CI
+  tooling images and the application image. Per-env ACRs were not added.
+  The hyphenated suffix is Azure's dedicated-data-endpoint convention on
+  the FQDN, not part of the registry's `name` property.
 - **`log_analytics_workspace_id`** — pass `module.log_analytics.id` from
   the dev env so Path B (App Insights → this workspace) and Path C share
   the workspace.

--- a/infra/modules/container-app/variables.tf
+++ b/infra/modules/container-app/variables.tf
@@ -28,7 +28,7 @@ variable "log_analytics_workspace_id" {
 }
 
 variable "acr_id" {
-  description = "Resource ID of the Azure Container Registry the Container App pulls its image from. The module's user-assigned managed identity is granted the AcrPull role on this ACR. Path C reuses the shared `maberdevcontainerregistry-ccedhvhwfndwetdp` ACR rather than provisioning a per-env registry (see ADR-009)."
+  description = "Resource ID of the Azure Container Registry the Container App pulls its image from. The module's user-assigned managed identity is granted the AcrPull role on this ACR. Path C reuses the shared `maberdevcontainerregistry` ACR (login server `maberdevcontainerregistry-ccedhvhwfndwetdp.azurecr.io`) rather than provisioning a per-env registry (see ADR-009)."
   type        = string
 }
 

--- a/pipelines/ado/templates/build-and-push-image.yml
+++ b/pipelines/ado/templates/build-and-push-image.yml
@@ -16,7 +16,7 @@
 #     parameters:
 #       acrRegistryServiceConnection: pcpc-acr-service-connection
 #       azureSubscription: az-pcpc-dev
-#       acrName: maberdevcontainerregistry-ccedhvhwfndwetdp
+#       acrName: maberdevcontainerregistry
 #       imageRepository: pcpc/functions
 #       trivySeverity: HIGH,CRITICAL
 #       trivyVersion: "0.59.1"
@@ -29,7 +29,11 @@ parameters:
     type: string
   - name: acrName
     type: string
-    default: maberdevcontainerregistry-ccedhvhwfndwetdp
+    # ACR *name* is alphanumeric-only; the `-ccedhvhwfndwetdp` portion
+    # is part of the login server FQDN, not the registry name itself.
+    # `az acr show -n "$ACR_NAME" --query loginServer -o tsv` returns
+    # the FQDN at runtime, including the dedicated-data-endpoint suffix.
+    default: maberdevcontainerregistry
   - name: imageRepository
     type: string
     default: pcpc/functions


### PR DESCRIPTION
## Summary

Unblocks the dev CD pipeline from PR #150's first run. The Terraform Plan step failed on the dev environment with:

\`\`\`
Error: alpha numeric characters only are allowed in \"name\":
  \"maberdevcontainerregistry-ccedhvhwfndwetdp\"
  with data.azurerm_container_registry.shared,
  on main.tf line 389
\`\`\`

## Root cause

I conflated two distinct ACR identifiers when authoring the defaults in PR #150:

| Identifier | Value | Allowed chars |
|---|---|---|
| ACR **name** | `maberdevcontainerregistry` | Alphanumeric only |
| ACR **login server** (FQDN) | `maberdevcontainerregistry-ccedhvhwfndwetdp.azurecr.io` | Any valid hostname |

The \`-ccedhvhwfndwetdp\` suffix on the FQDN is Azure's **dedicated data endpoint** mechanism. It is NOT part of the registry's \`name\` property, which is what \`data \"azurerm_container_registry\"\` and \`az acr show -n\` expect.

Cross-checked against the live evidence in [`.devcontainer/docs/acr-authentication-guide.md`](.devcontainer/docs/acr-authentication-guide.md): \`az acr login --name maberdevcontainerregistry\` and \`az ad sp create-for-rbac --scopes .../registries/maberdevcontainerregistry\` both use the bare alphanumeric name.

## Fix

- **`infra/envs/dev/variables.tf`** — `shared_acr_name` default now `maberdevcontainerregistry`. The `data.azurerm_container_registry.shared.login_server` attribute returns the full FQDN at apply time, so the container-app module still receives the correct hostname for the `registry.server` field.
- **`pipelines/ado/templates/build-and-push-image.yml`** — `acrName` parameter default likewise corrected. `az acr show -n \"\$ACR_NAME\" --query loginServer -o tsv` returns the FQDN at runtime, including the dedicated-data-endpoint suffix.

## Doc cleanup (same root cause, same fix)

- `infra/modules/container-app/variables.tf` — `acr_id` description clarified
- `infra/modules/container-app/README.md` — ACR description clarified
- `docs/adr/ADR-009-functions-consumption-vs-container-apps.md` — *Container Registry sharing* subsection clarified, noting the name-vs-FQDN distinction so future readers don't repeat the same conflation

## Test plan

- [x] `terraform validate` in `infra/envs/dev/` succeeds locally
- [x] `terraform fmt -recursive infra/` clean
- [ ] PR Validation pipeline green
- [ ] After merge: dev CD Terraform Plan succeeds; new \`module.container_app\` resources show in the plan output; apply provisions the Container Apps Environment + UAMI + Container App; subsequent \`Deploy_ACA\` job builds + scans + pushes the image and rolls a revision

## Why a separate PR

Keeps the PR-3 frontend toggle changes (already committed locally on `feat/phase-2.2-frontend-toggle`) decoupled from the infra correction. After this lands and the next CD run goes green on main, I'll rebase the PR-3 branch and open it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)