### PR TITLE
fix(phase-2.2): use absolute build context paths for docker build step

### DIFF
--- a/pipelines/ado/templates/build-and-push-image.yml
+++ b/pipelines/ado/templates/build-and-push-image.yml
@@ -107,21 +107,27 @@ steps:
   # Build context is backend/ so the file:../shared reference in
   # backend/functions/package.json resolves. Dockerfile path is relative to
   # that context.
+  #
+  # Use absolute paths anchored at $(Build.SourcesDirectory) so cwd quirks
+  # in the inlined-template step context don't break the build (the
+  # default `script:` cwd resolved to `_temp/` in practice, not the source
+  # directory).
   # ---------------------------------------------------------------------------
   - script: |
       set -euo pipefail
 
       echo "Building Functions container image..."
       docker build \
-        -f backend/functions/Dockerfile \
+        -f "$(Build.SourcesDirectory)/backend/functions/Dockerfile" \
         -t "$(ContainerImageReference)" \
         -t "$(ContainerImageBuildRef)" \
         -t "$(ContainerImageLatestRef)" \
-        backend/
+        "$(Build.SourcesDirectory)/backend"
 
       echo "Built tags:"
       docker images "$(AcrLoginServer)/${{ parameters.imageRepository }}" --format "  {{.Repository}}:{{.Tag}}"
     displayName: "docker build pcpc/functions"
+    workingDirectory: $(Build.SourcesDirectory)
 
   # ---------------------------------------------------------------------------
   # Install Trivy (pinned), scan the locally built image, block on HIGH+ CVE


### PR DESCRIPTION
## Summary

The dev CD's `Deploy_ACA` job failed at the `docker build pcpc/functions` step with:

\`\`\`
Building Functions container image...
ERROR: failed to build: unable to prepare context: path \"backend/\" not found
##[error]Bash exited with code '1'.
\`\`\`

## Root cause

The inlined-template `script:` step ran with cwd = `_temp/` (where ADO writes the generated script file), not `\$(Build.SourcesDirectory)`. The relative `backend/` build context reference didn't resolve from there.

The sibling `build-ci-images.yml` template doesn't hit this because it uses `Docker@2` with `buildContext: \$(Build.SourcesDirectory)` (absolute). My new template used a raw `script:` block with a relative path.

## Fix

Anchor both the Dockerfile path and the build context to `\$(Build.SourcesDirectory)`, and set `workingDirectory` on the step explicitly:

\`\`\`yaml
- script: |
    docker build \
      -f \"\$(Build.SourcesDirectory)/backend/functions/Dockerfile\" \
      -t \"\$(ContainerImageReference)\" \
      ... \
      \"\$(Build.SourcesDirectory)/backend\"
  displayName: \"docker build pcpc/functions\"
  workingDirectory: \$(Build.SourcesDirectory)
\`\`\`

8-line diff, single file (`pipelines/ado/templates/build-and-push-image.yml`).

## Verification

- [ ] Re-run dev CD after merge; `docker build pcpc/functions` should succeed
- [ ] Trivy scan runs against the local image
- [ ] `az acr login` + push all three tags
- [ ] `Deploy_ACA` job's `az containerapp update --image` step rolls the new revision
- [ ] Smoke tests blocking-green against the ACA ingress FQDN

🤖 Generated with [Claude Code](https://claude.com/claude-code)