### PR TITLE
fix(phase-2.2): drop explicit checkout: self from inlined ACA templates

### DIFF
--- a/pipelines/ado/templates/build-and-push-image.yml
+++ b/pipelines/ado/templates/build-and-push-image.yml
@@ -52,7 +52,12 @@ parameters:
     default: "0.59.1"
 
 steps:
-  - checkout: self
+  # No explicit `- checkout: self` — the parent job's implicit checkout
+  # handles it. Including `- checkout: self` here (and in deploy-aca.yml,
+  # which also gets inlined into the same job) triggers ADO's "multiple
+  # repositories" layout, where source lands at
+  # `$(Build.SourcesDirectory)/<repo>/` instead of `$(Build.SourcesDirectory)/`,
+  # breaking absolute paths that anchor on `$(Build.SourcesDirectory)`.
 
   # ---------------------------------------------------------------------------
   # Discover the PCPC ACR in the workload RG, resolve login server, and

--- a/pipelines/ado/templates/deploy-aca.yml
+++ b/pipelines/ado/templates/deploy-aca.yml
@@ -30,7 +30,10 @@ parameters:
     default: true
 
 steps:
-  - checkout: self
+  # No explicit `- checkout: self` — the parent job's implicit checkout
+  # handles it. See the note in build-and-push-image.yml: having multiple
+  # explicit checkouts in one job changes ADO's source-layout convention
+  # and breaks `$(Build.SourcesDirectory)`-anchored paths.
 
   # ---------------------------------------------------------------------------
   # Skip-redeploy check: compare incoming image reference to the currently


### PR DESCRIPTION
## Summary

Follow-up to #154. The first fix anchored `docker build` to `$(Build.SourcesDirectory)` (absolute paths) — necessary but not sufficient. The dev CD's next run failed with:

\`\`\`
ERROR: failed to build: unable to prepare context: 
  path \"/home/vsts/work/1/s/backend\" not found
\`\`\`

So `$(Build.SourcesDirectory)` resolved correctly but the directory genuinely doesn't exist on the agent — **source wasn't checked out to the expected location**.

## Root cause

Both `build-and-push-image.yml` and `deploy-aca.yml` start with `- checkout: self`. ADO inlines both templates into the `Deploy_ACA` job, so the job ends up with **two explicit checkouts**.

When a job has multiple `checkout` steps, ADO switches to the \"multiple repositories\" source-layout convention — source lands at `$(Pipeline.Workspace)/s/<repo-name>/` instead of `$(Pipeline.Workspace)/s/`. That breaks anything that anchors on `$(Build.SourcesDirectory)`.

## Fix

Remove the explicit `- checkout: self` from both templates. Let the parent job's implicit single checkout drop source at `$(Build.SourcesDirectory)` the way the rest of the templates (`deploy-functions.yml`, `deploy-apim.yml`) already expect.

10-line diff, two files (`build-and-push-image.yml`, `deploy-aca.yml`), with explanatory comments at each removal site so future readers understand why explicit checkouts in these templates are deliberately omitted.

## Test plan

- [ ] Re-run dev CD after merge
- [ ] `docker build pcpc/functions` finds `/home/vsts/work/1/s/backend/` and builds successfully
- [ ] Trivy scan + ACR push + `az containerapp update --image <sha>` + smoke tests all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)