### PR TITLE
fix(phase-2.2): run Trivy via official Docker image, not install.sh

### DIFF
--- a/pipelines/ado/templates/build-and-push-image.yml
+++ b/pipelines/ado/templates/build-and-push-image.yml
@@ -135,18 +135,21 @@ steps:
     workingDirectory: $(Build.SourcesDirectory)
 
   # ---------------------------------------------------------------------------
-  # Install Trivy (pinned), scan the locally built image, block on HIGH+ CVE
+  # Scan the locally built image with Trivy (pinned), block on HIGH+ CVE.
+  #
+  # Uses the official `aquasec/trivy` Docker image instead of the install.sh
+  # script: install.sh has had repeated issues with asset-naming changes
+  # across Trivy releases (it failed silently after "found version" on
+  # v0.59.1 in the first attempt). The container approach also lets us
+  # scan the locally-built image by mounting the Docker socket — at this
+  # point in the pipeline the image exists only in the host daemon (not
+  # yet pushed to ACR), so a registry-based scan wouldn't work.
+  #
+  # Mounting `/root/.cache/trivy` as a working-directory cache keeps the
+  # vulnerability database between runs (within a single agent VM); on
+  # Microsoft-hosted agents each job is a fresh VM so the cache is empty
+  # — that's fine, it just means the first download per job.
   # ---------------------------------------------------------------------------
-  - script: |
-      set -euo pipefail
-
-      TRIVY_VERSION='${{ parameters.trivyVersion }}'
-      echo "Installing Trivy ${TRIVY_VERSION}..."
-      curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh \
-        | sh -s -- -b /tmp v${TRIVY_VERSION}
-      /tmp/trivy --version
-    displayName: "Install Trivy ${{ parameters.trivyVersion }}"
-
   - script: |
       set -euo pipefail
 
@@ -155,15 +158,20 @@ steps:
       echo "=========================================="
       echo "Image:    $(ContainerImageReference)"
       echo "Severity: ${{ parameters.trivySeverity }} (blocking)"
+      echo "Trivy:    aquasec/trivy:${{ parameters.trivyVersion }}"
       echo ""
 
-      /tmp/trivy image \
-        --severity '${{ parameters.trivySeverity }}' \
-        --exit-code 1 \
-        --no-progress \
-        --ignore-unfixed \
-        --scanners vuln \
-        "$(ContainerImageReference)"
+      docker run --rm \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v "$(Pipeline.Workspace)/.trivy-cache:/root/.cache/trivy" \
+        aquasec/trivy:${{ parameters.trivyVersion }} \
+        image \
+          --severity '${{ parameters.trivySeverity }}' \
+          --exit-code 1 \
+          --no-progress \
+          --ignore-unfixed \
+          --scanners vuln \
+          "$(ContainerImageReference)"
 
       echo ""
       echo "✓ Trivy scan passed — no ${{ parameters.trivySeverity }} CVEs with available fixes"


### PR DESCRIPTION
## Summary

The dev CD's \`Install Trivy 0.59.1\` step failed silently:

\`\`\`
Installing Trivy 0.59.1...
aquasecurity/trivy info checking GitHub for tag 'v0.59.1'
aquasecurity/trivy info found version: 0.59.1 for v0.59.1/Linux/64bit
##[error]Bash exited with code '1'.
\`\`\`

The install.sh script logged \"found version\" — meaning it resolved the GitHub release — then exited 1 with no error message. This is a known class of failure with Trivy's install.sh; asset-naming changes across releases break the download step opaquely.

## Fix

Skip the install.sh entirely. Use the official \`aquasec/trivy\` Docker image and mount the Docker socket so it can scan the locally-built image without needing trivy installed on the agent. Three wins:

1. **No bootstrap script.** Docker pulls the image on first use, caches it. No URL/asset-naming brittleness.
2. **Same version pin** — \`aquasec/trivy:0.59.1\` matches what the install.sh was attempting.
3. **Scans the *local* image.** At this point in the pipeline the image exists only in the host Docker daemon (we scan *before* push). The socket-mount pattern is the canonical way to give a containerized scanner visibility into local images — couldn't do this with the install.sh path without writing a registry first.

\`/root/.cache/trivy\` is mounted to \`\$(Pipeline.Workspace)/.trivy-cache\` so the vulnerability DB persists between steps in the same job (Microsoft-hosted agents are fresh VMs per job, so the cache is empty on first run — that's fine, it's a one-time DB download).

26-line diff, one file (\`pipelines/ado/templates/build-and-push-image.yml\`).

## Test plan

- [ ] Re-run dev CD; Trivy step pulls \`aquasec/trivy:0.59.1\` and scans \`pcpcacrdevgkoka4.azurecr.io/pcpc/functions:git-<sha>\` against the local Docker daemon
- [ ] Scan completes with \"no HIGH/CRITICAL CVEs with available fixes\"
- [ ] ACR push + \`az containerapp update --image <sha>\` + smoke tests follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)