### PR TITLE
feat(phase-2.2): move auth to gateway layer (authLevel: anonymous on read endpoints)

### DIFF
--- a/backend/functions/src/functions/GetCardInfo/index.ts
+++ b/backend/functions/src/functions/GetCardInfo/index.ts
@@ -85,7 +85,15 @@ export async function getCardInfo(
       `${correlationId} Processing request for card ${cardId} in set ${setId}`
     );
 
-    const forceRefresh = request.query.get("forceRefresh") === "true";
+    // SECURITY: see GetSetList for the rationale. `forceRefresh` is
+    // intentionally ignored on anonymous-auth public endpoints to
+    // prevent unbounded Scrydex API credit burn (this endpoint can also
+    // re-fetch pricing on demand, which is a separate Scrydex cost vector).
+    // Card data still re-fetches from Scrydex on legitimate cache misses
+    // (bounded by card cardinality) and on stale-pricing detection via
+    // `needsPricing` — only the forceRefresh override is removed.
+    // Addresses Codex P1 review on PR #159.
+    const forceRefresh = false;
     const cardsTtl = parseInt(process.env.CACHE_TTL_CARDS || "3600");
 
     monitoringService.trackEvent("request.parameters", {

--- a/backend/functions/src/functions/GetCardsBySet/index.ts
+++ b/backend/functions/src/functions/GetCardsBySet/index.ts
@@ -67,7 +67,11 @@ export async function getCardsBySet(
 
     context.log(`${correlationId} Processing Scrydex request for setId: ${setId}`);
 
-    const forceRefresh = request.query.get("forceRefresh") === "true";
+    // SECURITY: see GetSetList for the rationale. `forceRefresh` is
+    // intentionally ignored on anonymous-auth public endpoints to
+    // prevent unbounded Scrydex API credit burn. Addresses Codex P1
+    // review on PR #159.
+    const forceRefresh = false;
     const page = parseInt(request.query.get("page") || "1");
     const pageSize = Math.min(
       parseInt(request.query.get("pageSize") || "500"),

--- a/backend/functions/src/functions/GetSetList/index.ts
+++ b/backend/functions/src/functions/GetSetList/index.ts
@@ -36,7 +36,14 @@ export async function getSetList(
     context.log(`${correlationId} Processing Scrydex request for set list`);
 
     const language = (request.query.get("language") || "en").toLowerCase();
-    const forceRefresh = request.query.get("forceRefresh") === "true";
+    // SECURITY: the `forceRefresh` query param is intentionally ignored on
+    // this anonymous-auth public endpoint. Honoring it from untrusted
+    // callers would bypass Redis + Cosmos and hit Scrydex on every
+    // request, burning paid API credits with no upper bound. The
+    // RefreshData timer trigger keeps caches current on a 12h cadence;
+    // manual refresh is an admin path via that trigger, not the public
+    // surface. Addresses Codex P1 review on PR #159.
+    const forceRefresh = false;
     const returnAll = request.query.get("all") === "true";
     const page = parseInt(request.query.get("page") || "1");
     const pageSize = parseInt(request.query.get("pageSize") || "100");

--- a/backend/functions/src/index.ts
+++ b/backend/functions/src/index.ts
@@ -84,23 +84,37 @@ import { monitorScrydexUsage } from "./functions/MonitorScrydexUsage";
 import { refreshData } from "./functions/RefreshData";
 
 // HTTP triggers
+//
+// authLevel: "anonymous" on the read endpoints. Auth lives at the gateway
+// layer (APIM regex policy on Path B, ACA ingress CORS on Path C) per
+// ADR-009's intent. With Path C bypassing APIM, function-key auth on
+// the Functions host would 401 every browser request to /api/sets,
+// /api/sets/{setId}/cards, and /api/cards/{cardId}. Moving auth to the
+// gateway means the same code path serves both gateways without
+// per-runtime branching.
+//
+// Side effect: Path B's Function App URL is now anonymously callable
+// too. APIM still provides rate limiting, the developer portal, and
+// observability — those are its value-add, not "the only ingress that
+// can call this." See ADR-009's "ACR ownership" subsection nearby for
+// the parallel reasoning on shared-infrastructure ownership.
 app.http("getSetList", {
   methods: ["GET"],
-  authLevel: "function",
+  authLevel: "anonymous",
   route: "sets",
   handler: getSetList,
 });
 
 app.http("getCardInfo", {
   methods: ["GET"],
-  authLevel: "function",
+  authLevel: "anonymous",
   route: "sets/{setId}/cards/{cardId}",
   handler: getCardInfo,
 });
 
 app.http("getCardsBySet", {
   methods: ["GET"],
-  authLevel: "function",
+  authLevel: "anonymous",
   route: "sets/{setId}/cards",
   handler: getCardsBySet,
 });


### PR DESCRIPTION
## Summary

Path C exposes the Functions container's ACA ingress directly to the browser — no APIM to inject function keys. But the three read endpoints (\`getSetList\`, \`getCardInfo\`, \`getCardsBySet\`) declared \`authLevel: function\` in [\`backend/functions/src/index.ts\`](https://github.com/Abernaughty/PCPC/blob/main/backend/functions/src/index.ts), so the Functions host required a function key even when reached through ACA ingress. Result: every browser request to \`/api/sets\` on Path C returned **401**.

Verified live on dev (post #158 unblocking the smoke test):

\`\`\`bash
$ curl https://pcpc-aca-dev.gentlesmoke-60971ffc.centralus.azurecontainerapps.io/api/sets
HTTP 401
\`\`\`

## Fix

Change \`authLevel\` from \`function\` to \`anonymous\` on the three read endpoints. \`healthCheck\` was already anonymous and is unchanged.

| Endpoint | Before | After |
|---|---|---|
| \`GET /api/health\` | anonymous | anonymous (unchanged) |
| \`GET /api/sets\` | function (401) | anonymous (200) |
| \`GET /api/sets/{setId}/cards\` | function (401) | anonymous (200) |
| \`GET /api/sets/{setId}/cards/{cardId}\` | function (401) | anonymous (200) |

Inline comment documents the gateway-layer-auth intent and references ADR-009.

## Path B implication (deliberate, documented inline)

This change makes Path B's Function App URL anonymously callable too — APIM is no longer the only ingress that can hit \`/api/sets\`.

**APIM's continued value-add for Path B:**
- Rate limiting (per-IP)
- Subscription model + developer portal (currently \`subscription_required=false\` but mechanism in place)
- Observability via APIM Analytics
- The architectural pivot point ADR-008 frames

That value-add doesn't depend on APIM being the *only* ingress — analogous to PR #153's framing of shared infrastructure (gateways do gateway things; the application doesn't enforce its own auth in parallel).

This is the architectural intent ADR-009 articulates: *\"CORS, secrets, and observability parity with Path B are configured at the ACA ingress and in app_settings — same code runs in both envelopes; only the gateway differs.\"* Until this PR, that intent was aspirational; the Functions code was still enforcing function-key auth, which defeated the gateway-layer-only model.

## Test plan

- [x] \`npm run build\` (tsc) succeeds locally
- [ ] Lands after #158 (the smoke-test fix); #158 doesn't block this PR, but the CD will be smoother in order
- [ ] Dev CD: image rebuilds, pushes, revision rolls
- [ ] \`curl https://<aca-fqdn>/api/sets\` returns 200 with Scrydex data
- [ ] \`curl https://<aca-fqdn>/api/sets/sv8/cards\` returns 200
- [ ] Browser toggle on \`pcpc.maber.io ?backend=aca\` loads card data end-to-end (requires the Vercel \`PUBLIC_ACA_API_BASE_URL\` env var to include \`/api\` — already mentioned in #158 follow-up notes)
- [ ] \`curl https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets\` still returns 200 — Path B unchanged from the recruiter-toggle perspective

## Smoke test follow-up (not in this PR)

With auth removed, the smoke test could actually call \`/api/sets\` on Path C end-to-end. PR #158 currently skips that test with \`EXPECT_FUNCTION_KEY=false\`. A future enhancement could make the script exercise the real data path when no key is expected — but staying focused on the authLevel change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)