### PR TITLE
fix(phase-2.2): BackendToggle popover swallows option clicks

### DIFF
--- a/frontend/src/lib/components/BackendToggle.svelte
+++ b/frontend/src/lib/components/BackendToggle.svelte
@@ -18,6 +18,7 @@
 
   let isOpen = $state(false);
   let buttonRef: HTMLButtonElement | null = $state(null);
+  let toggleRef: HTMLDivElement | null = $state(null);
 
   let activeId = $derived(backendStore.activeId);
   let active = $derived(backendStore.active);
@@ -67,7 +68,10 @@
   function handleClickOutside(event: MouseEvent): void {
     if (!isOpen) return;
     const target = event.target as Node;
-    if (buttonRef && !buttonRef.contains(target)) {
+    // Check the whole toggle container, not just the badge — otherwise a
+    // mousedown on an option button (a sibling of the badge inside the
+    // wrapper) closes the popover before the option's click fires.
+    if (toggleRef && !toggleRef.contains(target)) {
       isOpen = false;
     }
   }
@@ -87,7 +91,7 @@
   });
 </script>
 
-<div class="backend-toggle" data-status={activeStatus}>
+<div class="backend-toggle" bind:this={toggleRef} data-status={activeStatus}>
   <button
     bind:this={buttonRef}
     class="badge"


### PR DESCRIPTION
## Summary

- Widens `BackendToggle.svelte`'s click-outside check from the badge button to the whole `.backend-toggle` wrapper, restoring option clicks in the popover.
- Unblocks Phase 2.2 closeout: with this in, the Vercel → Azure → ACA runtime swap works on `pcpc.maber.io` and the `phase-2.2/complete` tag can be pushed.

## Root cause

The popover is a *sibling* of the badge inside `.backend-toggle`. The document-level `mousedown` outside-click handler only treated clicks inside `buttonRef` (the badge) as "inside", so a `mousedown` on an option button closed the popover before the option's own `click` could fire. Vercel-as-default disguised the bug — only the active backend appeared interactive.

Always present, just exposed now that Path C made the popover the primary way to demo the toggle. Path B was reachable via `?backend=azure` URL navigation.

## Fix

Three small edits — one new `$state` ref, one binding, one containment-check rename.

```diff
+  let toggleRef: HTMLDivElement | null = $state(null);
…
-    if (buttonRef && !buttonRef.contains(target)) {
+    if (toggleRef && !toggleRef.contains(target)) {
…
- <div class=\"backend-toggle\" data-status={activeStatus}>
+ <div class=\"backend-toggle\" bind:this={toggleRef} data-status={activeStatus}>
```

Kept `mousedown` (faster perceived close than `click`). Did **not** also flip to `click` — that alone wouldn't fix it because non-option popover regions (header, footer link, gaps) would still close.

## Test plan

- [ ] CI green (svelte-check, vite build via Vercel)
- [ ] Vercel preview deploy: open popover → click Azure → page reloads with `?backend=azure`, badge updates, card data loads
- [ ] Vercel preview deploy: click ACA → reload with `?backend=aca`, card data loads (proves the `PUBLIC_ACA_API_BASE_URL` path end-to-end)
- [ ] Click outside the badge entirely → popover closes
- [ ] Escape key → popover closes
- [ ] Click \"Compare architectures →\" footer link → opens in new tab; popover stays open (acceptable / preferable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)