### PR TITLE
fix(phase-2.2): add OPTIONS operations to APIM spec so CORS preflight reaches inbound policy

### DIFF
--- a/apim/specs/pcpc-api-v1.yaml
+++ b/apim/specs/pcpc-api-v1.yaml
@@ -122,6 +122,24 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: CORS preflight
+      description: |
+        Route hook for the API-level CORS policy (see ADR-013). The custom
+        regex-based preflight handler in the inbound policy returns 204
+        with Access-Control-Allow-* headers when the Origin matches the
+        configured allowlist, 403 otherwise. APIM requires an OPTIONS
+        operation in the spec so unmatched requests don't 404 before
+        policies run (per learn.microsoft.com/azure/api-management/cors-policy).
+      operationId: options-sets
+      tags:
+        - System
+      security: []
+      responses:
+        "204":
+          description: Preflight accepted; CORS headers returned
+        "403":
+          description: Origin not in allowlist
 
   /health:
     get:
@@ -154,6 +172,19 @@ paths:
             application/json:
               schema:
                 type: object
+    options:
+      summary: CORS preflight
+      description: |
+        Route hook for the API-level CORS policy. See /sets options for details.
+      operationId: options-health
+      tags:
+        - System
+      security: []
+      responses:
+        "204":
+          description: Preflight accepted; CORS headers returned
+        "403":
+          description: Origin not in allowlist
 
   "/sets/{setCode}/cards":
     get:
@@ -219,6 +250,28 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: CORS preflight
+      description: |
+        Route hook for the API-level CORS policy. See /sets options for details.
+      operationId: options-cards-by-set
+      tags:
+        - System
+      security: []
+      parameters:
+        - name: setCode
+          in: path
+          required: true
+          description: The set code (e.g., 'sv8', 'base1')
+          schema:
+            type: string
+            pattern: "^[a-zA-Z0-9-_]+$"
+            example: "sv8"
+      responses:
+        "204":
+          description: Preflight accepted; CORS headers returned
+        "403":
+          description: Origin not in allowlist
 
   "/sets/{setId}/cards/{cardId}":
     get:
@@ -277,6 +330,36 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+    options:
+      summary: CORS preflight
+      description: |
+        Route hook for the API-level CORS policy. See /sets options for details.
+      operationId: options-card-info
+      tags:
+        - System
+      security: []
+      parameters:
+        - name: setId
+          in: path
+          required: true
+          description: The set identifier
+          schema:
+            type: string
+            pattern: "^[a-zA-Z0-9-_]+$"
+            example: "sv8"
+        - name: cardId
+          in: path
+          required: true
+          description: The card identifier within the set
+          schema:
+            type: string
+            pattern: "^[a-zA-Z0-9-_]+$"
+            example: "001"
+      responses:
+        "204":
+          description: Preflight accepted; CORS headers returned
+        "403":
+          description: Origin not in allowlist
 
 components:
   securitySchemes:
@@ -601,3 +684,5 @@ tags:
     description: Pokemon card set operations
   - name: Cards
     description: Pokemon card operations
+  - name: System
+    description: System operations (health, CORS preflight)


### PR DESCRIPTION
## Summary

- Adds `options:` peers to all 4 paths in [apim/specs/pcpc-api-v1.yaml](apim/specs/pcpc-api-v1.yaml) — `/sets`, `/health`, `/sets/{setCode}/cards`, `/sets/{setId}/cards/{cardId}`.
- Unblocks Path B (Azure backend) in the production browser, finally closing the last Phase 2.2 gap. Path B has been latently broken since Phase 1B; only emerged now that PR #160 made the popover toggle Azure reachable from `pcpc.maber.io`.
- Also adds the `System` tag to global tags to silence a pre-existing Spectral `operation-tag-defined` warning on `/health` GET.

## Root cause (verified live)

```
$ curl -X OPTIONS https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets/me1/cards \
    -H 'Origin: https://pcpc.maber.io'
HTTP/1.1 404 Resource Not Found   ← APIM 404s before policy can run
```

APIM matches operations by path+method. The spec only defined `get:` operations, so `OPTIONS /sets/me1/cards` had no match and APIM 404'd out of the routing layer — before the global inbound policy's `<choose method='OPTIONS'>` preflight handler ([apim/policies/templates/global-policy.xml.tpl:31-61](apim/policies/templates/global-policy.xml.tpl)) had any chance to respond. GET `/sets` worked from `curl` because it's a "simple" CORS request, but the frontend always sends `Content-Type: application/json` ([frontend/src/lib/backends/path-b-azure.ts:55](frontend/src/lib/backends/path-b-azure.ts)) which forces preflight on all GETs, so browsers were uniformly blocked. Only `/sets` *appeared* to work because IndexedDB cache shielded the user from fresh calls.

Path A (BFF, same-origin) and Path C (ACA, ingress handles OPTIONS natively — verified `200` + full ACAO from `curl -X OPTIONS`) are unaffected.

## Approach (Microsoft-canonical)

[Microsoft Learn APIM CORS reference](https://learn.microsoft.com/azure/api-management/cors-policy) documents this exact pattern:

> *"If a request matches an operation with an OPTIONS method defined in the API, preflight request processing logic associated with the `cors` policy will not be executed. Therefore, such operations can be used to implement custom preflight processing logic."*

Adding `options:` to the spec gives APIM a route to dispatch preflight into the existing custom inbound handler, which returns `204` + ACAO for allowed origins or `403` otherwise via `<return-response>` — short-circuiting before rate-limit and any backend call.

**Why not switch to built-in `<cors>` policy?** `<allowed-origins>` still doesn't support wildcard subdomains (same Microsoft doc) — each `<origin>` must be `*` or a literal URI. We need `pcpc-git-*-abernaughtys-projects.vercel.app` for Vercel per-PR preview URLs (per ADR-013). The custom regex-based design holds; only the route hook was missing.

**Why spec-only, no explicit Terraform `api_operation` resources?** Same pattern as `get_health` ([apim/terraform/apis.tf:64-80](apim/terraform/apis.tf)) — operations that don't need a per-operation policy stay spec-managed only, avoiding the spec-import-vs-explicit-resource race that bit #137. OPTIONS operations don't need per-op policies.

## Pre-merge verification

- Spectral (with the same ruleset CI uses, `apim/specs/.spectral.yaml`): **0 errors, 0 warnings**.
- `js-yaml` parse: all 4 paths now have both `get` and `options` keys.

## Post-merge verification

After dev CD applies:
- [ ] `OPTIONS /pcpc-api/v1/sets/me1/cards` with `Origin: https://pcpc.maber.io` returns `204` + `Access-Control-Allow-Origin: https://pcpc.maber.io`
- [ ] Same with `Origin: https://evil.example.com` returns `403`
- [ ] On `pcpc.maber.io?backend=azure`: click a set → cards load with no CORS error (clear IndexedDB first to force fresh `/sets` call)
- [ ] Click a card → detail page loads
- [ ] Regression: Path A and Path C still work via popover toggle

On success: tag `phase-2.2/complete` and clear the BLOCKED note from memory.

## Follow-ups (separate, not urgent)

- Clean up `APIM_CORS_ORIGINS` legacy URL format in `vg-pcpc-dev-config` (silences deploy warning, doesn't affect this bug).
- Document the spec→APIM→preflight contract in ADR-013.

🤖 Generated with [Claude Code](https://claude.com/claude-code)