### PR TITLE
fix: drop+recreate IndexedDB stores on version bump to clear stale legacy schema

### DIFF
--- a/frontend/src/lib/services/db.ts
+++ b/frontend/src/lib/services/db.ts
@@ -18,7 +18,11 @@ import { createContextLogger } from './logger';
 const log = createContextLogger('db');
 
 const DB_NAME = 'poke-data-db';
-const DB_VERSION = 3;
+// Bump this whenever any store's schema changes (keyPath, autoIncrement,
+// indexes). The upgrade handler drops and recreates all stores on every
+// bump — this DB is purely a cache, so a one-time rebuild on the next
+// visit is the correct tradeoff.
+const DB_VERSION = 4;
 
 // Store names
 const STORE_NAMES = {
@@ -63,11 +67,20 @@ function openDatabase(): Promise<IDBDatabase> {
       const db = (event.target as IDBOpenDBRequest).result;
       log.debug(`Upgrading database from version ${event.oldVersion} to ${DB_VERSION}`);
 
+      // Drop any existing stores first. A legacy frontend at this same
+      // origin (pre-Phase-0 Svelte 4 SPA) created stores under the same
+      // DB_NAME with a different keyPath, so additive-only upgrades left
+      // saveCardsForSet failing with "key path did not yield a value".
+      // Treating the cache as ephemeral and rebuilding on every version
+      // bump avoids any future schema-drift surprises.
+      const existingStores = Array.from(db.objectStoreNames);
+      for (const store of existingStores) {
+        db.deleteObjectStore(store);
+      }
+
       const storeNames = Object.values(STORE_NAMES);
       for (const store of storeNames) {
-        if (!db.objectStoreNames.contains(store)) {
-          db.createObjectStore(store, { keyPath: 'id', autoIncrement: true });
-        }
+        db.createObjectStore(store, { keyPath: 'id', autoIncrement: true });
       }
     };
   });


### PR DESCRIPTION
## Summary

Fixes the `[cardStore] Failed to cache cards: DataError: Failed to execute 'put' on 'IDBObjectStore': Evaluating the object store's key path did not yield a value` warning that's been silent-failing for any user with an old `poke-data-db` from the pre-Phase-0 Svelte 4 SPA at `pcpc.maber.io`.

- Bumps \`DB_VERSION\` 3 → 4 in [frontend/src/lib/services/db.ts](frontend/src/lib/services/db.ts).
- Rewrites \`onupgradeneeded\` to **drop every existing store** before recreating them with the canonical \`{ keyPath: 'id', autoIncrement: true }\` shape — instead of the previous additive-only logic that silently kept stale schemas across versions.

## Root cause

The legacy frontend (Svelte 4 SPA, retired in Phase 0) created its IndexedDB stores under the same \`poke-data-db\` name with a different keyPath. The current upgrade callback only created stores that didn't exist; existing stores from older code persisted with their original schema. When \`saveCardsForSet\` later \`put()\`'d records shaped for the new schema (\`{ setId, card, cacheTime, id: …}\`), IDB evaluated the **old** store's keyPath, found no value there, and threw \`DataError\`.

Live verification of the new card response: every card has a valid top-level \`id\` (e.g. \`me2pt5-1\`) — confirming the records being put are fine and the bug is in the store's expected shape, not the records.

## Why drop+recreate, not surgical migration

- The DB is purely a cache. No user-authored data lives there.
- Surgically inspecting each store's actual keyPath/autoIncrement against a canonical config is more code and has no upside.
- Future schema bumps benefit from the same pattern: bump the version, every client rebuilds. No drift trap.

## Cost

- One-time first-load cache miss for every user on the next visit. Re-fetches sets (~199 records) and cards on demand.
- That re-fetch is also what users who never had the legacy DB have been doing every visit anyway — the failed \`put\` meant cache writes never succeeded, so reads from cache always missed.

## Test plan

- [ ] Local: open the dev preview, clear IndexedDB in DevTools, reload — DB inspector shows version 4 with the 6 canonical stores all using \`keyPath: 'id'\`.
- [ ] Click a set → cards load → reload page → cards return from cache (no API call), no \`Failed to cache cards\` warning.
- [ ] Production after merge: visit \`pcpc.maber.io\`, open DevTools console, click any set. Expect no \`DataError\` in the console. IDB inspector shows \`poke-data-db\` at version 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)