### PR TITLE
fix: rename cardName→name in Functions response to match OpenAPI spec

### DIFF
--- a/backend/functions/src/functions/GetCardInfo/index.ts
+++ b/backend/functions/src/functions/GetCardInfo/index.ts
@@ -129,10 +129,12 @@ export async function getCardInfo(
         cacheAge = cachedEntry ? getCacheAge(cachedEntry.timestamp) : 0;
         monitoringService.trackEvent("cache.hit", { cardId, correlationId });
 
-        // Cache hit short-circuits to return immediately.
-        const response: ApiResponse<Card> = {
+        // Cache hit short-circuits to return immediately. Apply the
+        // same cardName→name rename as the cold-fetch path below — the
+        // initial fix missed this branch (Codex P2 review on PR #164).
+        const response: ApiResponse<ApiResponseCard> = {
           status: 200,
-          data: card,
+          data: cardToApiResponse(card),
           timestamp: new Date().toISOString(),
           cached: true,
           cacheAge,

--- a/backend/functions/src/functions/GetCardInfo/index.ts
+++ b/backend/functions/src/functions/GetCardInfo/index.ts
@@ -25,6 +25,10 @@ import {
   cardHasPricing,
   mapScrydexCardToCard,
 } from "../../utils/scrydexToCosmos";
+import {
+  cardToApiResponse,
+  type ApiResponseCard,
+} from "../../utils/cardToApiResponse";
 
 /**
  * GetCardInfo — Scrydex-powered card detail with cached pricing.
@@ -262,9 +266,11 @@ export async function getCardInfo(
       context.log(`${correlationId} Card cached (${cacheWriteTime}ms)`);
     }
 
-    const response: ApiResponse<Card> = {
+    // Apply the same cardName→name rename as GetCardsBySet (and Path A's
+    // SvelteKit BFF) so the on-wire shape matches the OpenAPI spec.
+    const response: ApiResponse<ApiResponseCard> = {
       status: 200,
-      data: card,
+      data: cardToApiResponse(card),
       timestamp: new Date().toISOString(),
       cached: false,
     };

--- a/backend/functions/src/functions/GetCardsBySet/index.ts
+++ b/backend/functions/src/functions/GetCardsBySet/index.ts
@@ -25,6 +25,10 @@ import {
   cardHasPricing,
   mapScrydexCardToCard,
 } from "../../utils/scrydexToCosmos";
+import {
+  cardToApiResponse,
+  type ApiResponseCard,
+} from "../../utils/cardToApiResponse";
 
 function cardsHavePricingData(cards: Card[]): boolean {
   if (cards.length === 0) return false;
@@ -294,8 +298,12 @@ export async function getCardsBySet(
 
     // Response shape must match the Path A SvelteKit BFF
     // (frontend/src/lib/services/api.ts:103-107 reads `result.cards`).
+    // `cardToApiResponse` renames the canonical `cardName` field to the
+    // OpenAPI-spec'd `name` (see apim/specs/pcpc-api-v1.yaml + Path A's
+    // cardToFrontend transform). Without this, browser cards display
+    // with blank names on Paths B/C.
     const response: ApiResponse<{
-      cards: Card[];
+      cards: ApiResponseCard[];
       pagination: {
         page: number;
         pageSize: number;
@@ -305,7 +313,7 @@ export async function getCardsBySet(
     }> = {
       status: 200,
       data: {
-        cards: paginatedCards,
+        cards: paginatedCards.map(cardToApiResponse),
         pagination: { page, pageSize, totalCount, totalPages },
       },
       timestamp: new Date().toISOString(),

--- a/backend/functions/src/utils/cardToApiResponse.ts
+++ b/backend/functions/src/utils/cardToApiResponse.ts
@@ -1,0 +1,48 @@
+import type { Card, CardImage, CardVariant } from "@pcpc/shared";
+
+/**
+ * Wire shape returned to API clients. The OpenAPI spec
+ * (apim/specs/pcpc-api-v1.yaml) defines the public field as `name`, but
+ * the canonical Card type in @pcpc/shared uses `cardName` for Cosmos
+ * persistence. Path A's SvelteKit BFF performs the same rename
+ * (frontend/src/routes/api/sets/[set_id]/cards/+server.ts cardToFrontend);
+ * mirroring it here keeps Paths B and C on the same on-wire contract.
+ *
+ * `number` is duplicated as `cardNumber` so frontend code that reads
+ * either field works — same as the BFF's mapping.
+ */
+export interface ApiResponseCard {
+  id: string;
+  name: string;
+  number: string;
+  cardNumber: string;
+  printedNumber?: string;
+  rarity: string;
+  rarityCode?: string;
+  artist?: string;
+  images?: CardImage[];
+  variants?: CardVariant[];
+  setCode: string;
+  setId: string;
+  setName: string;
+  pricingLastUpdated?: string;
+}
+
+export function cardToApiResponse(card: Card): ApiResponseCard {
+  return {
+    id: card.id,
+    name: card.cardName,
+    number: card.cardNumber,
+    cardNumber: card.cardNumber,
+    printedNumber: card.printedNumber,
+    rarity: card.rarity,
+    rarityCode: card.rarityCode,
+    artist: card.artist,
+    images: card.images,
+    variants: card.variants,
+    setCode: card.setCode,
+    setId: card.setId,
+    setName: card.setName,
+    pricingLastUpdated: card.pricingLastUpdated,
+  };
+}


### PR DESCRIPTION
## Summary

Card titles were displaying blank on Paths B (APIM/Functions) and C (ACA) because the Functions returned the canonical \`Card\` shape (\`{ cardName: \"Oddish\", … }\`) directly, while:

- The OpenAPI spec at [apim/specs/pcpc-api-v1.yaml](apim/specs/pcpc-api-v1.yaml#L420-L447) defines the on-wire field as \`name\`
- Path A's SvelteKit BFF performs the rename via its own [\`cardToFrontend\`](frontend/src/routes/api/sets/[set_id]/cards/+server.ts#L20-L38) transform
- The frontend reads \`card.name\`

This PR adds [backend/functions/src/utils/cardToApiResponse.ts](backend/functions/src/utils/cardToApiResponse.ts) mirroring the BFF's transform and applies it in both \`GetCardsBySet\` and \`GetCardInfo\`. The transform also duplicates \`number\` as \`cardNumber\` so frontend code that reads either form keeps working.

## Verification

- \`tsc\` clean (\`npm run build\` in \`backend/functions/\` passes)
- Wire shapes confirmed via live curls:
  - Path A: \`{ name: \"Gloom\", … }\` (unchanged)
  - Path B (current main): \`{ cardName: \"Oddish\", … }\` — broken
  - Path B (this PR, post-deploy): expected \`{ name: \"Oddish\", … }\`

## Test plan

- [ ] Dev CD's \`Deploy_Functions\` and \`Deploy_ACA\` jobs both green
- [ ] \`curl pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets/me2/cards?pageSize=2\` returns cards with \`name\` (not \`cardName\`)
- [ ] On \`pcpc.maber.io?backend=azure\` and \`?backend=aca\`: card list shows full names ("Erika's Oddish", etc.) — clear IDB cache first since old shape is cached
- [ ] Single-card detail page on both paths displays the title correctly
- [ ] Path A regression: still shows names

🤖 Generated with [Claude Code](https://claude.com/claude-code)