### PR TITLE
fix(docker): apt-get upgrade in runtime stage to clear base-image OS CVEs

### DIFF
--- a/backend/functions/Dockerfile
+++ b/backend/functions/Dockerfile
@@ -58,6 +58,15 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 FROM mcr.microsoft.com/azure-functions/node:4-node22
 
+# Pull Debian-patched OS packages. The upstream Functions base image rebuilds
+# lag CVE patches by days-to-weeks; without this layer the Trivy CVE scan in
+# build-and-push-image.yml blocks on any HIGH CVE patched in Debian since the
+# base was last rebuilt (e.g. CVE-2026-27135 in libnghttp2-14).
+RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureFunctionsJobHost__Logging__Console__IsEnabled=true \
     FUNCTIONS_WORKER_RUNTIME=node


### PR DESCRIPTION
## Summary

Trivy is blocking the dev CD pipeline on main with **HIGH** CVE-2026-27135 (`libnghttp2-14`, DoS via malformed HTTP/2 frames). The fix is in Debian at `1.52.0-1+deb12u3`, but `mcr.microsoft.com/azure-functions/node:4-node22` still ships `1.52.0-1+deb12u2` because Microsoft's base-image rebuilds lag Debian patches by days-to-weeks.

This PR adds an `apt-get update && apt-get upgrade` layer to the **runtime** stage of [backend/functions/Dockerfile](backend/functions/Dockerfile) so the final image picks up all current Debian security patches at build time. Canonical pattern for Debian-based vendor base images; mirrors the npm/pnpm override approach from PR #157 for Node-level CVEs.

Build-stage packages are **not** upgraded — that stage is discarded and only emits `dist/` + production `node_modules` to the runtime stage. No build-time cost trade-off.

## CI failure that motivated this

```
pcpcacrdevgkoka4.azurecr.io/pcpc/functions:git-2075d72 (debian 12.13)
=====================================================================
Total: 1 (HIGH: 1, CRITICAL: 0)

CVE-2026-27135  HIGH  libnghttp2-14  1.52.0-1+deb12u2 → 1.52.0-1+deb12u3
```

The scan ran against `2075d72` (the squash-merge of PR #165 onto main). Same fix was tested against the PR #165 branch before that merge; this PR is just the cherry-pick onto a clean branch.

## Test plan

- [ ] Dev CD pipeline runs cleanly with Trivy passing (0 HIGH/CRITICAL on the rebuilt image)
- [ ] Image size after upgrade layer stays in the same ballpark as before (~2.12 GB)
- [ ] No regression in Function App boot / `/api/health` 200

## Future maintenance

The upgrade layer caches against package state — when Microsoft rebuilds the base image with current packages, this layer becomes a near-no-op (apt-get reports "0 upgraded"). When Debian publishes new CVE patches, the next image rebuild picks them up automatically. No version pinning required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)