### PR TITLE
chore(pipelines): promote ACA image build to Build stage + skip-if-exists

### DIFF
--- a/pipelines/ado/azure-pipelines.yml
+++ b/pipelines/ado/azure-pipelines.yml
@@ -45,7 +45,7 @@ resources:
 stages:
   # ============================================================================
   # STAGE 1: BUILD
-  # Create unified artifact with all components
+  # Create unified artifact with all components + container image
   # ============================================================================
   - stage: Build
     displayName: "Build Unified Artifact"
@@ -62,6 +62,31 @@ stages:
           useApiManagement: "true"
           functionAppName: $(FUNCTION_APP_NAME)
           functionResourceGroup: $(APIM_RESOURCE_GROUP)
+
+      # Build the Path C (ACA) container image and push to PCPC's ACR. Runs
+      # in parallel with the unified-artifact build above — they're
+      # independent. Moved out of Deploy_Dev (where it used to live inside
+      # Deploy_ACA) so the image exists in ACR *before* any Deploy_* stage
+      # runs Terraform; this unblocks adding ACA jobs to staging/prod (the
+      # Container App resource needs an image to exist on first apply).
+      #
+      # The image is built once and pushed to the dev-owned ACR; downstream
+      # ACA deploy jobs (Deploy_Dev/Staging/Prod) consume the canonical
+      # SHA-tagged reference via the stageDependencies output below. How
+      # staging/prod's own ACRs get the bits (cross-env AcrPull RBAC vs
+      # `az acr import`) is a PR 3 concern — out of scope here.
+      #
+      # No `container:` directive — the job needs host Docker daemon access
+      # for `docker build` and the Trivy container-scan flow.
+      - job: Build_Container_Image
+        displayName: "Build + Push ACA Image"
+        pool:
+          vmImage: "ubuntu-latest"
+        steps:
+          - template: templates/build-and-push-image.yml
+            parameters:
+              azureSubscription: "az-pcpc-dev"
+              acrResourceGroup: "pcpc-rg-dev"
 
   # ============================================================================
   # STAGE 2: DEPLOY TO DEV
@@ -122,30 +147,35 @@ stages:
 
       # Phase 2.2 — Deploy Path C (ACA Container).
       #
-      # Parallel to Deploy_Functions (Path B). Discovers the PCPC-owned ACR
-      # provisioned by Deploy_Infrastructure, builds the Functions image,
-      # scans for HIGH+ CVEs (Trivy, blocking), pushes via `az acr login`
-      # (no Docker registry service connection — SP has AcrPush from the
-      # role assignment in dev's Terraform), and rolls a new revision on
-      # the Container App. No container: directive — the job needs the
-      # host Docker daemon for the image build.
+      # Parallel to Deploy_Functions (Path B). Consumes the canonical
+      # SHA-tagged image reference from the Build stage's
+      # `Build_Container_Image` job (cross-stage `stageDependencies` output)
+      # and rolls a new revision on the Container App. The image-build
+      # itself lives in the Build stage so that future Deploy_Staging /
+      # Deploy_Prod ACA jobs can consume the same artifact.
+      #
+      # `dependsOn: Deploy_Infrastructure` so Terraform has provisioned
+      # the Container App before we try to roll it. (Build stage already
+      # completed by the time Deploy_Dev runs — that's the stage-level
+      # dependsOn at the parent.)
       - job: Deploy_ACA
         displayName: "Deploy Path C (ACA Container)"
         dependsOn: Deploy_Infrastructure
         condition: succeeded()
         pool:
           vmImage: "ubuntu-latest"
+        variables:
+          # Map the Build stage's image-build job output to a job-scoped
+          # variable so we can pass it as a runtime parameter below.
+          containerImageReference: $[ stageDependencies.Build.Build_Container_Image.outputs['discover_image.ContainerImageReference'] ]
         steps:
-          - template: templates/build-and-push-image.yml
-            parameters:
-              azureSubscription: "az-pcpc-dev"
-              acrResourceGroup: $(APIM_RESOURCE_GROUP)
           - template: templates/deploy-aca.yml
             parameters:
               environment: dev
               azureSubscription: "az-pcpc-dev"
               containerAppName: "pcpc-aca-dev"
               resourceGroupName: $(APIM_RESOURCE_GROUP)
+              containerImageReference: $(containerImageReference)
 
       # Run Smoke Tests
       - job: Smoke_Tests

--- a/pipelines/ado/templates/build-and-push-image.yml
+++ b/pipelines/ado/templates/build-and-push-image.yml
@@ -1,7 +1,7 @@
 # Build and Push PCPC Functions ACA Image
 #
-# Phase 2.2 + polish PR. Builds the Functions container from
-# backend/functions/Dockerfile, scans for HIGH+ CVEs with Trivy (blocking),
+# Phase 2.2 + image-build-bootstrap polish PR. Builds the Functions container
+# from backend/functions/Dockerfile, scans for HIGH+ CVEs with Trivy (blocking),
 # and pushes to the PCPC-owned ACR under the pcpc/functions repository path.
 #
 # The ACR name is discovered at runtime by listing registries in the
@@ -12,11 +12,23 @@
 # a Docker registry service connection — the ADO SP has AcrPush on the
 # new ACR via a role assignment in the same Terraform state.
 #
-# Output variables (consumed by the deploy-aca.yml template that follows
-# in the same job):
+# Skip-if-exists: the discovery task checks whether the canonical git-SHA
+# tag is already present in ACR (`az acr repository show-tags`). If so,
+# build/scan/push are skipped and the existing image is reused. Mirrors
+# the content-hash skip-redeploy pattern in deploy-functions.yml.
+#
+# Output variables (job-scoped via isOutput=true; addressable from other
+# stages as `stageDependencies.<stage>.<job>.outputs['discover_image.<name>']`):
+#   AcrName                  — the discovered ACR (alphanumeric name)
+#   AcrLoginServer           — ACR login server FQDN
 #   ContainerImageReference  — full registry/repo:tag of the canonical
 #                              (git-SHA-tagged) image to deploy
-#   ContainerImageDigest     — sha256:... digest of the pushed image, for
+#   ContainerImageBuildRef   — Build ID-tagged reference (parallel tag)
+#   ContainerImageLatestRef  — latest-tagged reference (parallel tag)
+#   ShouldBuildImage         — "true" if image must be built+pushed,
+#                              "false" if the SHA tag is already in ACR
+#   ContainerImageDigest     — sha256:... digest of the pushed image
+#                              (or existing image when skipped); for
 #                              optional pin verification
 #
 # Usage:
@@ -60,12 +72,20 @@ steps:
   # breaking absolute paths that anchor on `$(Build.SourcesDirectory)`.
 
   # ---------------------------------------------------------------------------
-  # Discover the PCPC ACR in the workload RG, resolve login server, and
-  # compute image tags. The ACR name carries a random suffix from
-  # Terraform's random_string, so we filter by the stable `pcpcacr*` prefix.
+  # Discover the PCPC ACR in the workload RG, resolve login server, compute
+  # image tags, and decide whether a build is needed. The ACR name carries a
+  # random suffix from Terraform's random_string, so we filter by the stable
+  # `pcpcacr*` prefix.
+  #
+  # `name: discover_image` makes the variables addressable cross-stage as
+  # `stageDependencies.<stage>.<job>.outputs['discover_image.<varName>']`.
+  # All `task.setvariable` commands here use `isOutput=true` so they're
+  # exposed at job-output scope for consumption by downstream stages
+  # (Deploy_ACA in Deploy_Dev/Staging/Prod).
   # ---------------------------------------------------------------------------
   - task: AzureCLI@2
-    displayName: "Discover ACR + Compute Image Tags"
+    name: discover_image
+    displayName: "Discover ACR + Compute Image Tags + Check Existing"
     inputs:
       azureSubscription: ${{ parameters.azureSubscription }}
       scriptType: bash
@@ -100,11 +120,48 @@ steps:
         echo "Image build tag: $BUILD_TAG"
         echo "Canonical reference (for deploy): $FULL_REF_SHA"
 
+        # Check whether the canonical SHA tag already exists in ACR. If it
+        # does, the build/scan/push steps are skipped and downstream stages
+        # consume the existing image. Re-running the same pipeline against
+        # an unchanged commit becomes a no-op for image work.
+        echo ""
+        echo "Checking whether tag '$SHA_TAG' already exists in $ACR_NAME/$REPO..."
+        EXISTING_TAG=$(az acr repository show-tags \
+          --name "$ACR_NAME" \
+          --repository "$REPO" \
+          --query "[?@=='$SHA_TAG'] | [0]" \
+          -o tsv 2>/dev/null || true)
+
+        if [ -n "$EXISTING_TAG" ] && [ "$EXISTING_TAG" != "null" ]; then
+          echo "✓ Tag '$SHA_TAG' already in ACR. Build/scan/push will be skipped."
+          SHOULD_BUILD=false
+        else
+          echo "Tag '$SHA_TAG' not in ACR. Build/scan/push will run."
+          SHOULD_BUILD=true
+        fi
+
+        echo "##vso[task.setvariable variable=AcrName;isOutput=true]$ACR_NAME"
+        echo "##vso[task.setvariable variable=AcrLoginServer;isOutput=true]$FQDN"
+        echo "##vso[task.setvariable variable=ContainerImageReference;isOutput=true]$FULL_REF_SHA"
+        echo "##vso[task.setvariable variable=ContainerImageBuildRef;isOutput=true]$FULL_REF_BUILD"
+        echo "##vso[task.setvariable variable=ContainerImageLatestRef;isOutput=true]$FULL_REF_LATEST"
+        echo "##vso[task.setvariable variable=ShouldBuildImage;isOutput=true]$SHOULD_BUILD"
+
+        # Mirror as plain (non-output) job-scoped variables so the steps
+        # below in this same job can reference them with $(VarName) syntax.
+        # Without these mirrors, isOutput=true variables aren't available
+        # to subsequent same-job tasks via the simple $(...) macro.
         echo "##vso[task.setvariable variable=AcrName]$ACR_NAME"
         echo "##vso[task.setvariable variable=AcrLoginServer]$FQDN"
         echo "##vso[task.setvariable variable=ContainerImageReference]$FULL_REF_SHA"
         echo "##vso[task.setvariable variable=ContainerImageBuildRef]$FULL_REF_BUILD"
         echo "##vso[task.setvariable variable=ContainerImageLatestRef]$FULL_REF_LATEST"
+        echo "##vso[task.setvariable variable=ShouldBuildImage]$SHOULD_BUILD"
+
+  - script: |
+      echo "Image tag $(ContainerImageReference) already exists in ACR. Skipping build/scan/push."
+    displayName: "Skip Image Build (tag exists)"
+    condition: and(succeeded(), eq(variables['ShouldBuildImage'], 'false'))
 
   # ---------------------------------------------------------------------------
   # Build the image locally (no push yet — we scan before push)
@@ -133,6 +190,7 @@ steps:
       docker images "$(AcrLoginServer)/${{ parameters.imageRepository }}" --format "  {{.Repository}}:{{.Tag}}"
     displayName: "docker build pcpc/functions"
     workingDirectory: $(Build.SourcesDirectory)
+    condition: and(succeeded(), eq(variables['ShouldBuildImage'], 'true'))
 
   # ---------------------------------------------------------------------------
   # Scan the locally built image with Trivy (pinned), block on HIGH+ CVE.
@@ -177,6 +235,7 @@ steps:
       echo "✓ Trivy scan passed — no ${{ parameters.trivySeverity }} CVEs with available fixes"
     displayName: "Trivy CVE scan (blocking)"
     continueOnError: false
+    condition: and(succeeded(), eq(variables['ShouldBuildImage'], 'true'))
 
   # ---------------------------------------------------------------------------
   # Login to ACR via the Azure CLI (SP token / managed-identity flow) and
@@ -186,6 +245,7 @@ steps:
   # ---------------------------------------------------------------------------
   - task: AzureCLI@2
     displayName: "az acr login + push (all tags)"
+    condition: and(succeeded(), eq(variables['ShouldBuildImage'], 'true'))
     inputs:
       azureSubscription: ${{ parameters.azureSubscription }}
       scriptType: bash
@@ -203,20 +263,37 @@ steps:
         echo "✓ All tags pushed"
 
   # ---------------------------------------------------------------------------
-  # Capture the pushed digest for downstream use
+  # Capture the canonical image digest for downstream use. When the build was
+  # skipped (tag already present), fetch the existing digest from ACR via
+  # `az acr repository show`. When the build ran, prefer `docker manifest
+  # inspect` (the image is in the host daemon and ACR). Sets
+  # ContainerImageDigest as a job-output variable for cross-stage consumers.
   # ---------------------------------------------------------------------------
-  - script: |
-      set -euo pipefail
-
-      DIGEST=$(docker manifest inspect "$(ContainerImageReference)" --verbose 2>/dev/null \
-        | jq -r 'if type == "array" then .[0].Descriptor.digest else .Descriptor.digest end')
-
-      if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
-        echo "##vso[task.logissue type=warning]Could not capture image digest; deploy will use tag-based reference"
-        exit 0
-      fi
-
-      echo "Image digest: $DIGEST"
-      echo "##vso[task.setvariable variable=ContainerImageDigest]$DIGEST"
+  - task: AzureCLI@2
+    name: capture_digest
     displayName: "Capture image digest"
     continueOnError: true
+    inputs:
+      azureSubscription: ${{ parameters.azureSubscription }}
+      scriptType: bash
+      scriptLocation: inlineScript
+      inlineScript: |
+        set -euo pipefail
+
+        REPO='${{ parameters.imageRepository }}'
+        SHORT_SHA="$(echo '$(Build.SourceVersion)' | cut -c1-7)"
+        SHA_TAG="git-${SHORT_SHA}"
+
+        DIGEST=$(az acr repository show \
+          --name "$(AcrName)" \
+          --image "$REPO:$SHA_TAG" \
+          --query digest -o tsv 2>/dev/null || true)
+
+        if [ -z "$DIGEST" ] || [ "$DIGEST" = "null" ]; then
+          echo "##vso[task.logissue type=warning]Could not capture image digest from ACR; deploy will use tag-based reference"
+          echo "##vso[task.setvariable variable=ContainerImageDigest;isOutput=true]"
+          exit 0
+        fi
+
+        echo "Image digest: $DIGEST"
+        echo "##vso[task.setvariable variable=ContainerImageDigest;isOutput=true]$DIGEST"

--- a/pipelines/ado/templates/deploy-aca.yml
+++ b/pipelines/ado/templates/deploy-aca.yml
@@ -1,11 +1,12 @@
 # Deploy the PCPC Functions image to Azure Container Apps (Path C)
 #
-# Phase 2.2. Roles the new image onto the Container App and runs blocking
-# smoke tests against the ingress FQDN.
+# Phase 2.2 + image-build-bootstrap polish PR. Rolls the new image onto the
+# Container App and runs blocking smoke tests against the ingress FQDN.
 #
-# Expected pipeline variables (set by the preceding build-and-push-image.yml
-# template in the same job):
-#   ContainerImageReference  — full registry/repo:tag of the image to deploy
+# The image reference is now passed explicitly as a parameter so the
+# template no longer assumes the build-and-push-image.yml steps ran in the
+# same job. The caller (azure-pipelines.yml) wires the cross-stage output
+# from the Build stage's image-build job into `containerImageReference`.
 #
 # Usage:
 #   - template: pipelines/ado/templates/deploy-aca.yml
@@ -14,6 +15,7 @@
 #       azureSubscription: az-pcpc-dev
 #       containerAppName: pcpc-aca-dev
 #       resourceGroupName: pcpc-rg-dev
+#       containerImageReference: $(containerImageReference)  # mapped from stageDependencies
 #       runSmokeTests: true
 
 parameters:
@@ -25,6 +27,11 @@ parameters:
     type: string
   - name: resourceGroupName
     type: string
+  - name: containerImageReference
+    type: string
+    # Full registry/repo:tag reference to deploy. Typically wired from the
+    # Build stage's `Build_Container_Image` job output:
+    # $[ stageDependencies.Build.Build_Container_Image.outputs['discover_image.ContainerImageReference'] ]
   - name: runSmokeTests
     type: boolean
     default: true
@@ -50,12 +57,12 @@ steps:
       inlineScript: |
         set -euo pipefail
 
-        TARGET_REF='$(ContainerImageReference)'
+        TARGET_REF='${{ parameters.containerImageReference }}'
         APP_NAME='${{ parameters.containerAppName }}'
         RG='${{ parameters.resourceGroupName }}'
 
         if [ -z "$TARGET_REF" ]; then
-          echo "##vso[task.logissue type=error]ContainerImageReference pipeline variable is empty — the build-and-push-image template must run before this template"
+          echo "##vso[task.logissue type=error]containerImageReference parameter is empty — the Build stage's image-build job must have set the stageDependencies output that the caller maps into this parameter"
           exit 1
         fi
 
@@ -109,11 +116,11 @@ steps:
       inlineScript: |
         set -euo pipefail
 
-        echo "Rolling new revision: $(ContainerImageReference)"
+        echo "Rolling new revision: ${{ parameters.containerImageReference }}"
         az containerapp update \
           --name '${{ parameters.containerAppName }}' \
           --resource-group '${{ parameters.resourceGroupName }}' \
-          --image "$(ContainerImageReference)" \
+          --image "${{ parameters.containerImageReference }}" \
           --output none
 
         echo "✓ Container App revision update accepted"
@@ -237,7 +244,7 @@ steps:
       echo "Environment: ${{ parameters.environment }}"
       echo "Container App: ${{ parameters.containerAppName }}"
       echo "Resource Group: ${{ parameters.resourceGroupName }}"
-      echo "Image deployed: $(ContainerImageReference)"
+      echo "Image deployed: ${{ parameters.containerImageReference }}"
       echo "Ingress URL: $(acaIngressUrl)"
       echo ""
       echo "Available endpoints:"


### PR DESCRIPTION
## Summary

Moves the Path C (ACA) container image build out of `Deploy_Dev`'s `Deploy_ACA` job and into a new `Build_Container_Image` job at the top-level Build stage. The image is built once per pipeline run, pushed to PCPC's ACR with a canonical `git-<short-sha>` tag, and consumed by downstream ACA deploy jobs via cross-stage `stageDependencies` output.

**Why:** today the image build only runs inside `Deploy_Dev`. Adding ACA jobs to `Deploy_Staging` / `Deploy_Prod` in PR 3 of the polish sweep would mean either re-building per env (slow + risk of drift) or the operator manually `docker push`-ing per env before the first Terraform apply (the current workaround documented in [memory/projects/pcpc.md:103–104](https://github.com/Abernaughty/PCPC/blob/main/memory/projects/pcpc.md#L103-L104)). With the build at the Build stage, the image artifact exists in ACR before any `Deploy_*` stage runs Terraform — Terraform creates the Container App pointing at an image that's already there.

Also adds a **skip-if-SHA-tag-exists** check so re-running the pipeline on an unchanged commit is a ~10-second no-op for image work (mirrors the content-hash skip-redeploy pattern in `deploy-functions.yml`).

## Changes

| File | What |
|---|---|
| [`templates/build-and-push-image.yml`](pipelines/ado/templates/build-and-push-image.yml) | Names discovery task `discover_image`; all `task.setvariable` commands set `;isOutput=true` (with same-job mirrors for internal `$(...)` use); skip-if-tag-exists check via `az acr repository show-tags`; digest capture via `az acr repository show` so it works whether image was built or already existed |
| [`templates/deploy-aca.yml`](pipelines/ado/templates/deploy-aca.yml) | Adds `containerImageReference` template parameter; switches internal references from `$(ContainerImageReference)` to `${{ parameters.containerImageReference }}` |
| [`azure-pipelines.yml`](pipelines/ado/azure-pipelines.yml) | New `Build_Container_Image` job in Build stage (host VM, no container override, targets `pcpc-rg-dev`); Deploy_Dev's Deploy_ACA loses inline build, gains `variables:` block consuming cross-stage output, passes `$(containerImageReference)` as the new parameter |

Stats: 3 files changed, +158 / -44 lines.

## What this PR does NOT do

- **Does not add ACA jobs to Deploy_Staging or Deploy_Prod.** That's PR 3 of the polish sweep.
- **Does not decide how staging/prod ACAs receive the image bits.** Three options remain on the table (cross-env AcrPull RBAC, `az acr import` per env, or per-env rebuild) — that's a PR 3 design call. For now the image lives only in dev's ACR.
- **Does not change Deploy_Dev's end-to-end behavior** beyond moving the build's location in the pipeline graph. Same image gets built, same Trivy scan runs, same Deploy_ACA rolls a revision.

## Test plan

- [ ] CI run on this branch — Build stage gains a second parallel job (`Build + Push ACA Image`)
- [ ] First run builds the image (SHA tag isn't in ACR yet) → push succeeds → Deploy_ACA picks up the cross-stage `ContainerImageReference` and deploys
- [ ] Re-trigger pipeline on the same commit → Build_Container_Image's discovery task finds the existing tag → skip path engages → all build/scan/push steps marked Skipped → Deploy_ACA still receives the variable (set unconditionally during discovery) and runs its own skip-redeploy (current revision matches) → no-op
- [ ] No regression in Deploy_Functions, Deploy_APIM, or Smoke_Tests jobs
- [ ] Trivy still blocks on HIGH/CRITICAL CVEs (now in Build stage, not Deploy_Dev)

## Related

- Polish sweep plan: PR 1 (SWA decommission) merged as [#165](https://github.com/Abernaughty/PCPC/pull/165), Dockerfile CVE fix as [#166](https://github.com/Abernaughty/PCPC/pull/166). This is PR 2.
- PR 3 (staging/prod ACA promotion) is blocked by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)