### PR TITLE
feat(infra): migrate ACR to dedicated shared resource group

### DIFF
--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -326,39 +326,23 @@ module "api_management" {
 # -----------------------------------------------------------------------------
 # Phase 2.2 — Path C (ACA Container)
 #
-# Polish PR: PCPC owns its own ACR. The previous design consumed the shared
-# `maberdevcontainerregistry` in `dev-rg` via data source, which forced
-# cross-RG RBAC grants on the ADO SP. Now the ACR lives in pcpc-rg-dev and
-# every role assignment against it works inside the SP's existing scope.
-# See ADR-009's "ACR ownership" subsection.
+# The ACR consumed by this Container App lives in `pcpc-rg-shared` (PR 2.5),
+# not in `pcpc-rg-dev`. Each env's TF reads the shared ACR via
+# `data.terraform_remote_state.shared` and scopes its own UAMI's AcrPull
+# role assignment to that ACR. Dev/staging/prod all consume symmetrically.
+# See ADR-009's "ACR ownership" subsection for the rationale.
 # -----------------------------------------------------------------------------
 
-module "container_registry" {
-  source = "../../modules/container-registry"
-
-  name                = "pcpcacr${local.environment}${random_string.suffix.result}"
-  resource_group_name = module.resource_group.name
-  location            = var.location
-  environment         = var.environment
-
-  sku           = var.container_registry_sku
-  admin_enabled = false
-
-  tags = local.common_tags
-
-  depends_on = [module.resource_group]
-}
-
-# Grant the ADO service principal AcrPush on the new ACR. Without this, the
-# pipeline cannot push application images via `az acr login` + `docker push`.
-# `data.azurerm_client_config.current.object_id` is the SP that's applying
-# this Terraform — i.e., the same identity the pipeline runs as.
-resource "azurerm_role_assignment" "ado_sp_acr_push" {
-  scope                = module.container_registry.id
-  role_definition_name = "AcrPush"
-  principal_id         = data.azurerm_client_config.current.object_id
-
-  depends_on = [module.container_registry]
+data "terraform_remote_state" "shared" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "pcpc-terraform-state-rg"
+    storage_account_name = "pcpctfstatedacc29c2"
+    container_name       = "tfstate"
+    key                  = "shared.terraform.tfstate"
+    tenant_id            = "5f445a68-ec75-42cf-a50f-6ec158ee675c"
+    subscription_id      = "555b4cfa-ad2e-4c71-9433-620a59cf7616"
+  }
 }
 
 module "container_app" {
@@ -371,8 +355,8 @@ module "container_app" {
 
   log_analytics_workspace_id = module.log_analytics.id
 
-  acr_id           = module.container_registry.id
-  acr_login_server = module.container_registry.login_server
+  acr_id           = data.terraform_remote_state.shared.outputs.acr_id
+  acr_login_server = data.terraform_remote_state.shared.outputs.acr_login_server
   image_repository = var.container_app_image_repository
   image_tag        = var.container_app_image_tag
 
@@ -420,6 +404,5 @@ module "container_app" {
     module.cosmos_db,
     module.application_insights,
     module.log_analytics,
-    module.container_registry,
   ]
 }

--- a/infra/envs/dev/outputs.tf
+++ b/infra/envs/dev/outputs.tf
@@ -249,21 +249,3 @@ output "container_app_resource_group" {
   value       = module.resource_group.name
 }
 
-# -----------------------------------------------------------------------------
-# PCPC-owned Container Registry (polish PR — Phase 2.2)
-# -----------------------------------------------------------------------------
-
-output "container_registry_name" {
-  description = "Name of the PCPC-owned ACR that hosts application container images. The ADO pipeline reads this via `terraform output` for `az acr login --name <name>` invocations."
-  value       = module.container_registry.name
-}
-
-output "container_registry_login_server" {
-  description = "Login server hostname of the PCPC-owned ACR (e.g. `pcpcacrdev<suffix>.azurecr.io`). Prefix for image references — `<login_server>/pcpc/functions:<tag>`."
-  value       = module.container_registry.login_server
-}
-
-output "container_registry_id" {
-  description = "Resource ID of the PCPC-owned ACR. Exposed for staging/prod envs to consume via `data.azurerm_container_registry` against this state."
-  value       = module.container_registry.id
-}

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -294,18 +294,11 @@ variable "alert_email_address" {
 
 # -----------------------------------------------------------------------------
 # Phase 2.2 — Path C (ACA Container) variables
+#
+# Note: container_registry_sku moved to infra/shared/variables.tf in PR 2.5.
+# The shared ACR is provisioned once in `infra/shared/` and consumed here via
+# terraform_remote_state. Env TFs only own the Container App itself.
 # -----------------------------------------------------------------------------
-
-variable "container_registry_sku" {
-  description = "SKU for the PCPC-owned Container Registry. Defaults to `Basic` (~$5/mo, 10 GiB storage). Bump to `Premium` only when private endpoints / geo-replication / content trust are needed."
-  type        = string
-  default     = "Basic"
-
-  validation {
-    condition     = contains(["Basic", "Standard", "Premium"], var.container_registry_sku)
-    error_message = "container_registry_sku must be Basic, Standard, or Premium."
-  }
-}
 
 variable "container_app_image_repository" {
   description = "Repository path within the shared ACR for the Functions image (e.g. `pcpc/functions`). Distinct from the `pcpc-ci/*` CI tooling image repos."

--- a/infra/modules/container-registry/variables.tf
+++ b/infra/modules/container-registry/variables.tf
@@ -27,13 +27,13 @@ variable "location" {
 # -----------------------------------------------------------------------------
 
 variable "environment" {
-  description = "Environment name (dev, staging, prod). Used in default tagging."
+  description = "Environment name (dev, staging, prod, shared). Used in default tagging. `shared` is the platform-infra value used by the `infra/shared/` TF root that hosts the single PCPC ACR consumed by all envs."
   type        = string
   default     = "dev"
 
   validation {
-    condition     = contains(["dev", "staging", "prod"], var.environment)
-    error_message = "Environment must be dev, staging, or prod."
+    condition     = contains(["dev", "staging", "prod", "shared"], var.environment)
+    error_message = "Environment must be dev, staging, prod, or shared."
   }
 }
 

--- a/infra/shared/main.tf
+++ b/infra/shared/main.tf
@@ -1,0 +1,132 @@
+# -----------------------------------------------------------------------------
+# PCPC Shared Platform Infrastructure
+#
+# Hosts shared resources that span environments — currently just the single
+# Container Registry that all envs (dev/staging/prod) pull from. Lives in its
+# own resource group (`pcpc-rg-shared`) and its own Terraform state file
+# (`shared.terraform.tfstate`) so the ACR's lifecycle is decoupled from any
+# single env's lifecycle.
+#
+# Originally the ACR lived in `pcpc-rg-dev` (PR #153). That worked while only
+# dev had ACA, but it implicitly treated dev as the "platform owner" — any
+# staging/prod ACA promotion would have needed cross-RG AcrPull grants
+# reaching back into `pcpc-rg-dev`, the same coupling Phase 2.2 explicitly
+# moved away from. Moving the ACR here lets dev/staging/prod each manage only
+# their own RG while the platform RG holds the shared piece.
+#
+# Apply procedure (one-time bootstrap):
+#   1. Operator manually creates `pcpc-rg-shared` and grants the ADO SP
+#      `Contributor` + `Role Based Access Control Administrator` on it
+#      (ABAC condition: AcrPull + AcrPush role-definition GUIDs).
+#   2. Operator runs `terraform init && terraform apply` from this directory.
+#   3. Env TFs (dev/staging/prod) consume the ACR via
+#      `data.terraform_remote_state.shared` against this state file.
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_version = ">= 1.0.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 4.47.0, < 5.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+
+  # Remote backend for state management — same storage account as env states,
+  # different key. The state container already exists (provisioned out-of-band
+  # before any env's first apply).
+  backend "azurerm" {
+    resource_group_name  = "pcpc-terraform-state-rg"
+    storage_account_name = "pcpctfstatedacc29c2"
+    container_name       = "tfstate"
+    key                  = "shared.terraform.tfstate"
+    tenant_id            = "5f445a68-ec75-42cf-a50f-6ec158ee675c"
+    subscription_id      = "555b4cfa-ad2e-4c71-9433-620a59cf7616"
+  }
+}
+
+provider "azurerm" {
+  features {
+    resource_group {
+      # Shared RG holds platform infra consumed by all envs — deletion should
+      # only happen via deliberate `terraform destroy`. Set to true to prevent
+      # accidental destroy when child resources are present.
+      prevent_deletion_if_contains_resources = true
+    }
+  }
+  subscription_id = "555b4cfa-ad2e-4c71-9433-620a59cf7616"
+}
+
+provider "random" {}
+
+data "azurerm_client_config" "current" {}
+
+# Random suffix to satisfy ACR's global-uniqueness requirement. ACR names
+# are alphanumeric only (no hyphens), so we concatenate without separator.
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+locals {
+  common_tags = {
+    Environment = "shared"
+    Project     = var.project_name
+    ManagedBy   = "Terraform"
+    Repository  = "PCPC"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Shared Resource Group
+# -----------------------------------------------------------------------------
+module "resource_group" {
+  source = "../modules/resource-group"
+
+  name         = "pcpc-rg-shared"
+  location     = var.location
+  environment  = "shared"
+  project_name = var.project_name
+  tags         = local.common_tags
+}
+
+# -----------------------------------------------------------------------------
+# Shared Container Registry
+#
+# Single ACR consumed by all envs. Each env's container_app module's UAMI
+# gets AcrPull on this registry via the env's own TF (cross-RG role
+# assignment, scoped to this ACR's id).
+# -----------------------------------------------------------------------------
+module "container_registry" {
+  source = "../modules/container-registry"
+
+  name                = "pcpcacr${random_string.suffix.result}"
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  environment         = "shared"
+
+  sku           = var.container_registry_sku
+  admin_enabled = false
+
+  tags = local.common_tags
+
+  depends_on = [module.resource_group]
+}
+
+# Grant the ADO service principal AcrPush on the shared ACR so the pipeline's
+# `Build_Container_Image` job can `az acr login && docker push`. Same pattern
+# as the role assignment previously in `infra/envs/dev/main.tf` (which is
+# being removed in the dev rewire half of this PR).
+resource "azurerm_role_assignment" "ado_sp_acr_push" {
+  scope                = module.container_registry.id
+  role_definition_name = "AcrPush"
+  principal_id         = data.azurerm_client_config.current.object_id
+
+  depends_on = [module.container_registry]
+}

--- a/infra/shared/main.tf
+++ b/infra/shared/main.tf
@@ -85,15 +85,21 @@ locals {
 
 # -----------------------------------------------------------------------------
 # Shared Resource Group
+#
+# Read via data source rather than managed by this module. The RG must be
+# created manually by an operator BEFORE this TF runs because RG-scoped
+# RBAC grants (Contributor + RBAC Administrator) on the SP are themselves
+# the prerequisite for `terraform apply` to succeed — if Terraform tried
+# to create the RG itself, the SP would need broader (subscription-scoped)
+# Contributor, which we want to avoid. Operator workflow:
+#   1. `az group create -n pcpc-rg-shared -l <location> --tags ...`
+#   2. Grant SP `Contributor` + `RBAC Administrator` (ABAC: AcrPull/AcrPush)
+#      on the RG.
+#   3. `terraform init && terraform apply` (this module) — data-sources
+#      the existing RG and creates the ACR + role assignment inside it.
 # -----------------------------------------------------------------------------
-module "resource_group" {
-  source = "../modules/resource-group"
-
-  name         = "pcpc-rg-shared"
-  location     = var.location
-  environment  = "shared"
-  project_name = var.project_name
-  tags         = local.common_tags
+data "azurerm_resource_group" "shared" {
+  name = "pcpc-rg-shared"
 }
 
 # -----------------------------------------------------------------------------
@@ -107,16 +113,14 @@ module "container_registry" {
   source = "../modules/container-registry"
 
   name                = "pcpcacr${random_string.suffix.result}"
-  resource_group_name = module.resource_group.name
-  location            = var.location
+  resource_group_name = data.azurerm_resource_group.shared.name
+  location            = data.azurerm_resource_group.shared.location
   environment         = "shared"
 
   sku           = var.container_registry_sku
   admin_enabled = false
 
   tags = local.common_tags
-
-  depends_on = [module.resource_group]
 }
 
 # Grant the ADO service principal AcrPush on the shared ACR so the pipeline's

--- a/infra/shared/outputs.tf
+++ b/infra/shared/outputs.tf
@@ -7,13 +7,13 @@
 # -----------------------------------------------------------------------------
 
 output "resource_group_name" {
-  description = "Name of the shared resource group hosting the ACR."
-  value       = module.resource_group.name
+  description = "Name of the shared resource group hosting the ACR. (The RG itself is operator-managed — not in this state — but exposed here for env TFs that need the name without re-reading it.)"
+  value       = data.azurerm_resource_group.shared.name
 }
 
 output "resource_group_id" {
   description = "Resource ID of the shared resource group."
-  value       = module.resource_group.id
+  value       = data.azurerm_resource_group.shared.id
 }
 
 output "acr_name" {

--- a/infra/shared/outputs.tf
+++ b/infra/shared/outputs.tf
@@ -1,0 +1,32 @@
+# -----------------------------------------------------------------------------
+# OUTPUTS
+#
+# Consumed by env Terraform roots via `data "terraform_remote_state" "shared"`.
+# Names match the prior `module.container_registry.*` references that lived
+# in dev's TF before PR 2.5 split the ACR out into this shared root.
+# -----------------------------------------------------------------------------
+
+output "resource_group_name" {
+  description = "Name of the shared resource group hosting the ACR."
+  value       = module.resource_group.name
+}
+
+output "resource_group_id" {
+  description = "Resource ID of the shared resource group."
+  value       = module.resource_group.id
+}
+
+output "acr_name" {
+  description = "Name of the shared Container Registry (alphanumeric, random-suffixed). Used by the pipeline's image-build job to discover the registry via `az acr list -g pcpc-rg-shared`."
+  value       = module.container_registry.name
+}
+
+output "acr_id" {
+  description = "Resource ID of the shared Container Registry. Env TFs use this to scope cross-RG AcrPull role assignments to the shared ACR."
+  value       = module.container_registry.id
+}
+
+output "acr_login_server" {
+  description = "Login server hostname for the shared ACR (e.g. `pcpcacr<suffix>.azurecr.io`). Used in container_app `registry.server` and as the prefix for image references."
+  value       = module.container_registry.login_server
+}

--- a/infra/shared/variables.tf
+++ b/infra/shared/variables.tf
@@ -1,0 +1,22 @@
+variable "location" {
+  description = "Azure region for the shared resource group and its resources. Should match the region of the env workloads that pull from this ACR — cross-region pulls work but add latency."
+  type        = string
+  default     = "centralus"
+}
+
+variable "project_name" {
+  description = "Project name used in tags."
+  type        = string
+  default     = "PCPC"
+}
+
+variable "container_registry_sku" {
+  description = "SKU for the shared Container Registry. Basic is sufficient for portfolio scale (10 GiB storage, no geo-replication). Upgrade only when geo-replication or content trust become needed."
+  type        = string
+  default     = "Basic"
+
+  validation {
+    condition     = contains(["Basic", "Standard", "Premium"], var.container_registry_sku)
+    error_message = "container_registry_sku must be Basic, Standard, or Premium."
+  }
+}

--- a/infra/shared/variables.tf
+++ b/infra/shared/variables.tf
@@ -1,9 +1,3 @@
-variable "location" {
-  description = "Azure region for the shared resource group and its resources. Should match the region of the env workloads that pull from this ACR — cross-region pulls work but add latency."
-  type        = string
-  default     = "centralus"
-}
-
 variable "project_name" {
   description = "Project name used in tags."
   type        = string

--- a/pipelines/ado/azure-pipelines.yml
+++ b/pipelines/ado/azure-pipelines.yml
@@ -63,18 +63,18 @@ stages:
           functionAppName: $(FUNCTION_APP_NAME)
           functionResourceGroup: $(APIM_RESOURCE_GROUP)
 
-      # Build the Path C (ACA) container image and push to PCPC's ACR. Runs
-      # in parallel with the unified-artifact build above — they're
-      # independent. Moved out of Deploy_Dev (where it used to live inside
-      # Deploy_ACA) so the image exists in ACR *before* any Deploy_* stage
-      # runs Terraform; this unblocks adding ACA jobs to staging/prod (the
-      # Container App resource needs an image to exist on first apply).
+      # Build the Path C (ACA) container image and push to PCPC's shared ACR.
+      # Runs in parallel with the unified-artifact build above — they're
+      # independent. Moved out of Deploy_Dev (PR #167) so the image exists in
+      # ACR *before* any Deploy_* stage runs Terraform; that unblocks adding
+      # ACA jobs to staging/prod (the Container App resource needs an image
+      # to exist on first apply).
       #
-      # The image is built once and pushed to the dev-owned ACR; downstream
-      # ACA deploy jobs (Deploy_Dev/Staging/Prod) consume the canonical
-      # SHA-tagged reference via the stageDependencies output below. How
-      # staging/prod's own ACRs get the bits (cross-env AcrPull RBAC vs
-      # `az acr import`) is a PR 3 concern — out of scope here.
+      # The image is built once and pushed to the shared ACR
+      # (`pcpc-rg-shared`); dev/staging/prod ACA jobs consume the canonical
+      # SHA-tagged reference via the stageDependencies output below. The
+      # shared-RG ACR (PR 2.5) means all three envs pull symmetrically — no
+      # cross-env RBAC pointing at any single env's RG.
       #
       # No `container:` directive — the job needs host Docker daemon access
       # for `docker build` and the Trivy container-scan flow.
@@ -86,7 +86,7 @@ stages:
           - template: templates/build-and-push-image.yml
             parameters:
               azureSubscription: "az-pcpc-dev"
-              acrResourceGroup: "pcpc-rg-dev"
+              acrResourceGroup: "pcpc-rg-shared"
 
   # ============================================================================
   # STAGE 2: DEPLOY TO DEV


### PR DESCRIPTION
## Summary

Splits the PCPC-owned Container Registry out of `infra/envs/dev/` and into a new `infra/shared/` Terraform root. The shared root creates `pcpc-rg-shared` and the single ACR consumed by all three envs (dev/staging/prod). Env TFs read it via `data.terraform_remote_state.shared` and scope their own container_app UAMI's AcrPull role assignment to that ACR.

**Why:** today the ACR lives in `pcpc-rg-dev` (PR [#153](https://github.com/Abernaughty/PCPC/pull/153)). That worked while only dev had ACA, but treated dev as the "platform owner" — adding ACA to staging/prod ([upcoming PR 3](https://github.com/Abernaughty/PCPC/issues?q=label%3Apolish-sweep)) would have needed cross-RG AcrPull grants reaching back into `pcpc-rg-dev`, the same coupling Phase 2.2 explicitly moved away from. Putting the ACR in its own RG keeps each env's TF authoritative over its own RG while a shared TF root manages the shared platform piece. All three envs treat the ACR symmetrically.

## Changes

**New files (`infra/shared/`):**
- `main.tf` — backend `shared.terraform.tfstate`, `module "resource_group"` + `module "container_registry"`, `azurerm_role_assignment "ado_sp_acr_push"` scoped to the shared ACR
- `variables.tf` — `location`, `project_name`, `container_registry_sku`
- `outputs.tf` — `resource_group_name`, `acr_name`, `acr_id`, `acr_login_server`

**Modified:**
- `infra/envs/dev/main.tf` — delete `module "container_registry"` + `resource "azurerm_role_assignment" "ado_sp_acr_push"`; add `data "terraform_remote_state" "shared"`; rewire `module.container_app` to consume `data.terraform_remote_state.shared.outputs.acr_id` / `.acr_login_server`
- `infra/envs/dev/variables.tf` — drop `container_registry_sku` (moved to shared)
- `infra/envs/dev/outputs.tf` — drop the three `container_registry_*` outputs (callers now discover via `az acr list -g pcpc-rg-shared`)
- `infra/modules/container-registry/variables.tf` — relax `environment` validation to also accept `"shared"`
- `pipelines/ado/azure-pipelines.yml` — `Build_Container_Image`'s `acrResourceGroup` parameter `pcpc-rg-dev` → `pcpc-rg-shared`

Stats: 8 files, +222 / -78 lines. `terraform validate` passes for both `infra/shared/` and `infra/envs/dev/`. YAML valid.

## Out of scope

- **Staging/prod ACA wiring** — PR 3. Those envs will add their own `module "container_app"` blocks consuming the same `data.terraform_remote_state.shared`.
- **Pipeline-izing the `infra/shared/` apply** — currently one-time manual bootstrap (rare changes don't justify a `Deploy_Shared` stage right now).
- **ADR-009 amendment** — minor doc update to reframe "PCPC-owned ACR in dev-RG" as "shared-RG-hosted." Can land separately.

## Operator pre-merge steps (one-time bootstrap)

1. `az group create -n pcpc-rg-shared -l centralus --tags Project=PCPC Environment=shared ManagedBy=Terraform`
2. Grant the ADO SP `Contributor` + `Role Based Access Control Administrator` on `pcpc-rg-shared` (ABAC: `AcrPull` + `AcrPush` role-definition GUIDs, mirror of the existing grant on `pcpc-rg-dev`)
3. `cd infra/shared && terraform init && terraform apply` (manual one-time bootstrap; no CD plumbing in this PR)

## What happens on the first dev CD run after merge

1. `Build_Container_Image` discovers the new shared ACR (empty), builds + pushes the image (no skip — SHA tag absent from new ACR)
2. `Deploy_Infrastructure` (dev) — expected TF diff:
   - Destroy `azurerm_role_assignment.ado_sp_acr_push` (was scoped to old dev-RG ACR)
   - Destroy `module.container_registry.azurerm_container_registry.this` (the old dev-RG ACR — wipes the image cached there, but the shared ACR now has the fresh one)
   - Replace `module.container_app.azurerm_role_assignment.acr_pull` (scope changes → destroy + recreate)
   - Update `module.container_app.azurerm_container_app.this` `registry` block (login_server changes from old ACR FQDN to shared ACR FQDN)
3. `Deploy_ACA` runs `az containerapp update --image <shared-acr-fqdn>/pcpc/functions:<sha>` → new revision pulls from shared ACR → smoke tests pass

## Risk

**Medium.** The dev container_app's UAMI loses AcrPull on the old ACR before gaining it on the shared one (Terraform destroys then recreates the role assignment in a single apply). The running ACA revision serves from its locally-cached image during this window. If the container crashes mid-apply, ACA's restart would fail to pull until the new role assignment is in place — manual `az role assignment create --scope <new-acr> --role AcrPull --assignee <uami-principal>` would unblock. Mitigation: apply at low-traffic time, monitor revision health post-apply.

## Test plan

- [ ] Operator runs `az group create` + RBAC grants on `pcpc-rg-shared` (pre-merge)
- [ ] Operator runs `terraform apply` on `infra/shared/` — creates RG + ACR + AcrPush role assignment
- [ ] CI on this PR — validates dev TF can read the shared remote state (note: CI's plan will see no shared state until the manual apply runs; first dev plan post-bootstrap should show destroy of old ACR + recreate of role assignment as documented above)
- [ ] Tag `phase-2.2/pre-shared-acr-migration` before triggering dev CD
- [ ] Dev CD apply produces the diff documented above; smoke tests pass against `pcpc-aca-dev`
- [ ] `az containerapp show -n pcpc-aca-dev -g pcpc-rg-dev --query 'properties.template.containers[0].image'` returns the new shared-ACR FQDN
- [ ] Tag `phase-2.2/post-shared-acr-migration` after dev green

🤖 Generated with [Claude Code](https://claude.com/claude-code)