### PR TITLE
chore: remove forceRefresh end-to-end (fully redundant)

### DIFF
--- a/apim/docs/README.md
+++ b/apim/docs/README.md
@@ -194,7 +194,6 @@ Retrieve Pokemon card sets with pagination and filtering.
 - `page` (optional): Page number (default: 1)
 - `pageSize` (optional): Items per page, 1-100 (default: 100)
 - `all` (optional): Return all sets without pagination (default: false)
-- `forceRefresh` (optional): Force refresh of cached data (default: false)
 
 **Example:**
 
@@ -212,7 +211,6 @@ Retrieve cards for a specific Pokemon card set.
 - `setCode` (required): Set code (e.g., 'sv8', 'base1')
 - `page` (optional): Page number (default: 1)
 - `pageSize` (optional): Cards per page, 1-100 (default: 50)
-- `forceRefresh` (optional): Force refresh of cached data (default: false)
 
 **Example:**
 
@@ -229,7 +227,6 @@ Retrieve detailed information for a specific Pokemon card.
 
 - `setId` (required): Set identifier
 - `cardId` (required): Card identifier within the set
-- `forceRefresh` (optional): Force refresh of cached pricing data (default: false)
 
 **Example:**
 

--- a/apim/specs/pcpc-api-v1.yaml
+++ b/apim/specs/pcpc-api-v1.yaml
@@ -63,12 +63,6 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: forceRefresh
-          in: query
-          description: Force refresh of cached data
-          schema:
-            type: boolean
-            default: true
         - name: groupByExpansion
           in: query
           description: Group sets by expansion (legacy parameter)
@@ -219,12 +213,6 @@ paths:
             minimum: 1
             maximum: 100
             default: 50
-        - name: forceRefresh
-          in: query
-          description: Force refresh of cached data
-          schema:
-            type: boolean
-            default: true
       responses:
         "200":
           description: Successful response with cards for the set
@@ -299,12 +287,6 @@ paths:
             type: string
             pattern: "^[a-zA-Z0-9-_]+$"
             example: "001"
-        - name: forceRefresh
-          in: query
-          description: Force refresh of cached pricing data
-          schema:
-            type: boolean
-            default: true
       responses:
         "200":
           description: Successful response with detailed card information

--- a/apim/terraform/apis.tf
+++ b/apim/terraform/apis.tf
@@ -123,14 +123,6 @@ resource "azurerm_api_management_api_operation" "get_sets" {
       default_value = "true"
       required      = false
     }
-
-    query_parameter {
-      name          = "forceRefresh"
-      type          = "boolean"
-      description   = "Force refresh of cached data"
-      default_value = "true"
-      required      = false
-    }
   }
 
   response {
@@ -192,14 +184,6 @@ resource "azurerm_api_management_api_operation" "get_cards_by_set" {
       default_value = "50"
       required      = false
     }
-
-    query_parameter {
-      name          = "forceRefresh"
-      type          = "boolean"
-      description   = "Force refresh of cached data"
-      default_value = "true"
-      required      = false
-    }
   }
 
   response {
@@ -250,16 +234,6 @@ resource "azurerm_api_management_api_operation" "get_card_info" {
     type        = "string"
     description = "The card identifier within the set"
     required    = true
-  }
-
-  request {
-    query_parameter {
-      name          = "forceRefresh"
-      type          = "boolean"
-      description   = "Force refresh of cached pricing data"
-      default_value = "true"
-      required      = false
-    }
   }
 
   response {

--- a/apim/terraform/main.tf
+++ b/apim/terraform/main.tf
@@ -108,7 +108,6 @@ locals {
         "page",
         "pageSize",
         "all",
-        "forceRefresh",
         "groupByExpansion"
       ] : []
     }
@@ -117,16 +116,13 @@ locals {
       cache_duration = var.cache_duration_cards
       vary_by_query_parameters = var.enable_caching ? [
         "page",
-        "pageSize",
-        "forceRefresh"
+        "pageSize"
       ] : []
     }
     get_card_info = {
-      cache_enabled  = var.enable_caching
-      cache_duration = var.cache_duration_card_info
-      vary_by_query_parameters = var.enable_caching ? [
-        "forceRefresh"
-      ] : []
+      cache_enabled            = var.enable_caching
+      cache_duration           = var.cache_duration_card_info
+      vary_by_query_parameters = []
     }
   }
 

--- a/backend/functions/src/functions/GetCardInfo/index.ts
+++ b/backend/functions/src/functions/GetCardInfo/index.ts
@@ -37,7 +37,7 @@ import {
  * 1. Validate route params (setId, cardId)
  * 2. Check Redis (cache hit returns immediately)
  * 3. Check Cosmos
- * 4. If missing OR no pricing OR forceRefresh: fetch from Scrydex with prices
+ * 4. If missing OR no pricing: fetch from Scrydex with prices
  * 5. Persist + cache; return canonical Card shape
  */
 export async function getCardInfo(
@@ -89,21 +89,16 @@ export async function getCardInfo(
       `${correlationId} Processing request for card ${cardId} in set ${setId}`
     );
 
-    // SECURITY: see GetSetList for the rationale. `forceRefresh` is
-    // intentionally ignored on anonymous-auth public endpoints to
-    // prevent unbounded Scrydex API credit burn (this endpoint can also
-    // re-fetch pricing on demand, which is a separate Scrydex cost vector).
-    // Card data still re-fetches from Scrydex on legitimate cache misses
-    // (bounded by card cardinality) and on stale-pricing detection via
-    // `needsPricing` — only the forceRefresh override is removed.
-    // Addresses Codex P1 review on PR #159.
-    const forceRefresh = false;
+    // No client-controllable cache bypass — see GetSetList. Card data
+    // still re-fetches from Scrydex on legitimate cache misses (bounded
+    // by card cardinality) and on stale-pricing detection via
+    // `needsPricing` below (Codex P1 on PR #159, formalized by removing
+    // the param entirely in this PR).
     const cardsTtl = parseInt(process.env.CACHE_TTL_CARDS || "3600");
 
     monitoringService.trackEvent("request.parameters", {
       cardId,
       setId,
-      forceRefresh,
       correlationId,
     });
 
@@ -112,7 +107,7 @@ export async function getCardInfo(
     let cacheHit = false;
     let cacheAge = 0;
 
-    if (!forceRefresh && process.env.ENABLE_REDIS_CACHE === "true") {
+    if (process.env.ENABLE_REDIS_CACHE === "true") {
       const cacheStartTime = Date.now();
       context.log(`${correlationId} Checking Redis cache: ${cacheKey}`);
       const cachedEntry = await redisCacheService.get<{
@@ -182,15 +177,11 @@ export async function getCardInfo(
     }
     monitoringService.trackMetric("cosmosdb.query.duration", dbTime);
 
-    // Fetch from Scrydex if we don't have a card, the caller asked for a
-    // forced refresh, or the existing card lacks pricing.
+    // Fetch from Scrydex if we don't have a card or the existing card
+    // lacks pricing.
     const needsPricing = !cardHasPricing(card);
-    if (!card || forceRefresh || needsPricing) {
-      const reason = !card
-        ? "missing card"
-        : forceRefresh
-        ? "forceRefresh"
-        : "missing pricing";
+    if (!card || needsPricing) {
+      const reason = !card ? "missing card" : "missing pricing";
       context.log(
         `${correlationId} Fetching card from Scrydex API (${reason})`
       );

--- a/backend/functions/src/functions/GetCardsBySet/index.ts
+++ b/backend/functions/src/functions/GetCardsBySet/index.ts
@@ -71,11 +71,9 @@ export async function getCardsBySet(
 
     context.log(`${correlationId} Processing Scrydex request for setId: ${setId}`);
 
-    // SECURITY: see GetSetList for the rationale. `forceRefresh` is
-    // intentionally ignored on anonymous-auth public endpoints to
-    // prevent unbounded Scrydex API credit burn. Addresses Codex P1
-    // review on PR #159.
-    const forceRefresh = false;
+    // No client-controllable cache bypass — see GetSetList for the
+    // Scrydex-credit-burn rationale (Codex P1 on PR #159, formalized by
+    // removing the param entirely in this PR).
     const page = parseInt(request.query.get("page") || "1");
     const pageSize = Math.min(
       parseInt(request.query.get("pageSize") || "500"),
@@ -92,14 +90,13 @@ export async function getCardsBySet(
     }
 
     context.log(
-      `${correlationId} Parameters - setId: ${setId}, page: ${page}, pageSize: ${pageSize}, forceRefresh: ${forceRefresh}`
+      `${correlationId} Parameters - setId: ${setId}, page: ${page}, pageSize: ${pageSize}`
     );
 
     monitoringService.trackEvent("request.parameters", {
       setId,
       page,
       pageSize,
-      forceRefresh,
       correlationId,
     });
 
@@ -108,7 +105,7 @@ export async function getCardsBySet(
     let cacheHit = false;
     let cacheAge = 0;
 
-    if (!forceRefresh && process.env.ENABLE_REDIS_CACHE === "true") {
+    if (process.env.ENABLE_REDIS_CACHE === "true") {
       context.log(`${correlationId} Checking Redis cache for key: ${cacheKey}`);
       const cacheStartTime = Date.now();
       const cachedEntry = await redisCacheService.get<{

--- a/backend/functions/src/functions/GetSetList/index.ts
+++ b/backend/functions/src/functions/GetSetList/index.ts
@@ -36,14 +36,12 @@ export async function getSetList(
     context.log(`${correlationId} Processing Scrydex request for set list`);
 
     const language = (request.query.get("language") || "en").toLowerCase();
-    // SECURITY: the `forceRefresh` query param is intentionally ignored on
-    // this anonymous-auth public endpoint. Honoring it from untrusted
-    // callers would bypass Redis + Cosmos and hit Scrydex on every
-    // request, burning paid API credits with no upper bound. The
-    // RefreshData timer trigger keeps caches current on a 12h cadence;
-    // manual refresh is an admin path via that trigger, not the public
-    // surface. Addresses Codex P1 review on PR #159.
-    const forceRefresh = false;
+    // Cache freshness is driven by (1) language-keyed cache keys so
+    // language switches naturally miss, (2) the RefreshData timer trigger
+    // on a 12h cadence, (3) Redis TTL. There is no client-controllable
+    // cache-bypass — accepting one from anonymous public traffic would
+    // bypass Redis + Cosmos and burn paid Scrydex credits with no upper
+    // bound (Codex P1 on PR #159, formalized by removal in this PR).
     const returnAll = request.query.get("all") === "true";
     const page = parseInt(request.query.get("page") || "1");
     const pageSize = parseInt(request.query.get("pageSize") || "100");
@@ -51,7 +49,7 @@ export async function getSetList(
     const setsTtl = parseInt(process.env.CACHE_TTL_SETS || "604800"); // 7 days
 
     context.log(
-      `${correlationId} Parameters: language=${language}, returnAll=${returnAll}, page=${page}, pageSize=${pageSize}, forceRefresh=${forceRefresh}`
+      `${correlationId} Parameters: language=${language}, returnAll=${returnAll}, page=${page}, pageSize=${pageSize}`
     );
 
     const cacheKey = `${getSetListCacheKey()}-scrydex-${language}`;
@@ -59,7 +57,7 @@ export async function getSetList(
     let cacheHit = false;
     let cacheAge = 0;
 
-    if (!forceRefresh && process.env.ENABLE_REDIS_CACHE === "true") {
+    if (process.env.ENABLE_REDIS_CACHE === "true") {
       context.log(`${correlationId} Checking Redis cache with key: ${cacheKey}`);
       const cacheCheckStart = Date.now();
       const cachedEntry = await redisCacheService.get<{

--- a/frontend/src/lib/services/api.ts
+++ b/frontend/src/lib/services/api.ts
@@ -63,12 +63,10 @@ async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
 export const api = {
   /**
    * Get all Pokémon sets.
-   * @param forceRefresh - Bypass server cache
    * @param language - Language filter: 'en', 'jp', or 'both'
    */
-  async getSets(forceRefresh = false, language = 'en'): Promise<PokemonSet[]> {
+  async getSets(language = 'en'): Promise<PokemonSet[]> {
     const params = new URLSearchParams();
-    if (forceRefresh) params.set('forceRefresh', 'true');
     params.set('all', 'true');
 
     if (language === 'both') {

--- a/frontend/src/lib/stores/sets.svelte.ts
+++ b/frontend/src/lib/stores/sets.svelte.ts
@@ -57,7 +57,7 @@ interface SetsStore {
   isLoadingSets: boolean;
   language: LanguageFilter;
   showOnlineOnly: boolean;
-  loadSets(forceRefresh?: boolean): Promise<void>;
+  loadSets(bypassClientCache?: boolean): Promise<void>;
   selectSet(set: PokemonSet): void;
   clearSet(): void;
   setLanguage(lang: LanguageFilter): Promise<void>;
@@ -95,9 +95,14 @@ function createSetsStore(): SetsStore {
   }
 
   /**
-   * Load sets from API or cache
+   * Load sets from API or cache.
+   *
+   * `bypassClientCache` skips the IndexedDB read, used on language switch
+   * because the IDB store is language-agnostic (holds whatever was last
+   * fetched). Server-side caches are keyed on language already, so the API
+   * call below produces fresh data without any server-side cache-bust hint.
    */
-  async function loadSets(forceRefresh = false): Promise<void> {
+  async function loadSets(bypassClientCache = false): Promise<void> {
     if (isLoadingSets) return;
 
     isLoadingSets = true;
@@ -106,19 +111,16 @@ function createSetsStore(): SetsStore {
     try {
       let sets: PokemonSet[] | null = null;
 
-      // Try cache first if not forcing refresh
-      // Note: cache is language-agnostic (stores whatever was last fetched).
-      // When language changes, we force a fresh fetch.
-      if (!forceRefresh && browser) {
+      if (!bypassClientCache && browser) {
         sets = await db.getSetList();
         if (sets) {
           log.info(`Retrieved ${sets.length} sets from cache`);
         }
       }
 
-      // Fetch from API if not in cache or forced refresh
+      // Fetch from API if not in cache or IDB was bypassed
       if (!sets) {
-        sets = await api.getSets(forceRefresh, language);
+        sets = await api.getSets(language);
         log.info(`Retrieved ${sets.length} sets from API (language: ${language})`);
 
         // Cache the sets
@@ -186,7 +188,8 @@ function createSetsStore(): SetsStore {
       // cardsStore may not be loaded yet
     }
 
-    // Force refresh from API with new language
+    // Bypass IDB cache (language-agnostic; holds the old language) and
+    // re-fetch from the server, which is language-keyed.
     await loadSets(true);
   }
 

--- a/frontend/src/routes/api/sets/+server.ts
+++ b/frontend/src/routes/api/sets/+server.ts
@@ -23,7 +23,6 @@ export const GET: RequestHandler = async ({ url }) => {
 
   try {
     const language = url.searchParams.get('language') || 'en';
-    const forceRefresh = url.searchParams.get('forceRefresh') === 'true';
     const returnAll = url.searchParams.get('all') === 'true';
     const page = parseInt(url.searchParams.get('page') || '1');
     const pageSize = parseInt(url.searchParams.get('pageSize') || '100');
@@ -40,8 +39,9 @@ export const GET: RequestHandler = async ({ url }) => {
     let cacheHit = false;
     let cacheAge = 0;
 
-    // Check Redis cache
-    if (!forceRefresh && config.enableRedisCache) {
+    // Check Redis cache (keyed on language; freshness on language switch
+    // comes from the cache-key miss, no client-supplied bust needed)
+    if (config.enableRedisCache) {
       console.log(`[GetSets] Checking Redis cache with key: ${cacheKey}`);
       const cacheCheckStart = Date.now();
       const redisService = getRedisCacheService();

--- a/frontend/src/routes/api/sets/[set_id]/cards/+server.ts
+++ b/frontend/src/routes/api/sets/[set_id]/cards/+server.ts
@@ -65,7 +65,6 @@ export const GET: RequestHandler = async ({ params, url }) => {
   const correlationId = monitoring.createCorrelationId();
 
   const setId = params.set_id;
-  const forceRefresh = url.searchParams.get('forceRefresh') === 'true';
   const page = parseInt(url.searchParams.get('page') || '1');
   const pageSize = Math.min(parseInt(url.searchParams.get('pageSize') || '500'), 500);
 
@@ -86,8 +85,8 @@ export const GET: RequestHandler = async ({ params, url }) => {
     let cacheHit = false;
     let cacheAge = 0;
 
-    // Check Redis cache
-    if (!forceRefresh && config.enableRedisCache) {
+    // Check Redis cache (keyed on setId + pagination)
+    if (config.enableRedisCache) {
       console.log(`[GetCardsBySet] Checking Redis cache with key: ${cacheKey}`);
       const redisService = getRedisCacheService();
       const cachedEntry = await redisService.get<CacheEntry<Card[]>>(cacheKey);

--- a/frontend/src/routes/api/sets/[set_id]/cards/[card_id]/+server.ts
+++ b/frontend/src/routes/api/sets/[set_id]/cards/[card_id]/+server.ts
@@ -49,7 +49,6 @@ export const GET: RequestHandler = async ({ params, url }) => {
 
   const setId = params.set_id;
   const cardId = params.card_id;
-  const forceRefresh = url.searchParams.get('forceRefresh') === 'true';
 
   monitoring.trackEvent('function.invoked', {
     functionName: 'GetCardInfo',
@@ -67,8 +66,8 @@ export const GET: RequestHandler = async ({ params, url }) => {
     let cacheHit = false;
     let cacheAge = 0;
 
-    // Check Redis cache
-    if (!forceRefresh && config.enableRedisCache) {
+    // Check Redis cache (keyed on cardId + setId)
+    if (config.enableRedisCache) {
       console.log(`[GetCardInfo] Checking Redis cache with key: ${cacheKey}`);
       const redisService = getRedisCacheService();
       const cachedEntry = await redisService.get<CacheEntry<Card>>(cacheKey);
@@ -113,7 +112,7 @@ export const GET: RequestHandler = async ({ params, url }) => {
     // Fetch from Scrydex API (single call includes pricing via ?include=prices)
     // Also fetch if the card exists but has no pricing data (e.g. saved from list endpoint)
     const needsPricing = !cardHasPricing(card);
-    if (!card || forceRefresh || needsPricing) {
+    if (!card || needsPricing) {
       if (card && needsPricing) {
         console.log(
           `[GetCardInfo] Card ${cardId} exists but has no pricing data, fetching from Scrydex API`


### PR DESCRIPTION
## Summary

Deletes the `forceRefresh` query parameter from every layer of the system — frontend api.ts + sets store, all three BFF `+server.ts` routes, OpenAPI spec, APIM Terraform, Functions backend hardcodes. Investigation in the polish-sweep plan established that the parameter is **fully redundant** with existing freshness mechanisms; removing it tightens the API surface without changing user-visible behavior.

**Stats:** 12 files, +50 / -116 lines.

## Why this is safe (verified by direct code trace)

| Layer | Pre-PR behavior |
|---|---|
| Functions backend (Path B/C) | `forceRefresh = false` hardcoded post-[#159](https://github.com/Abernaughty/PCPC/pull/159); query string ignored |
| Path A BFF | Honored `forceRefresh=true` to bypass Redis. But cache key is `${CacheKeys.setList()}-scrydex-${language}` — already language-keyed. Only caller (language-switch) gets fresh data via cache-key miss regardless. |
| APIM | `vary_by_query_parameters` included `forceRefresh`, creating two redundant cache lanes. Language already in vary-by; collapses cleanly. |
| Frontend `loadSets(true)` | Bypassed IndexedDB (which is language-agnostic) on language switch. Preserved here via local `bypassClientCache` boolean — same behavior, no API param. |

Freshness across the system is fully covered by:
- **Language-keyed cache keys** (Redis + APIM) — language switch is a natural cache miss
- **RefreshData timer trigger** — 12h scheduled re-fetch from Scrydex
- **Redis TTL** — sets 7d, cards 1d, card info 30 min
- **`needsPricing` check** on GetCardInfo — re-fetches when cached card lacks pricing

## Files changed

**Frontend:**
- `frontend/src/lib/services/api.ts` — `api.getSets()` signature loses `forceRefresh`
- `frontend/src/lib/stores/sets.svelte.ts` — `loadSets()` param renamed `forceRefresh` → `bypassClientCache` (IDB-only, doesn't propagate to server)
- `frontend/src/routes/api/sets/+server.ts`, `[set_id]/cards/+server.ts`, `[set_id]/cards/[card_id]/+server.ts` — drop `forceRefresh` reads + cache-check conditionals; card-detail route's `if (!card || forceRefresh || needsPricing)` → `if (!card || needsPricing)`

**APIM:**
- `apim/specs/pcpc-api-v1.yaml` — drop three `forceRefresh` parameter declarations
- `apim/terraform/apis.tf` — drop three `query_parameter { name = "forceRefresh" ... }` blocks
- `apim/terraform/main.tf` — drop `"forceRefresh"` from three `vary_by_query_parameters` lists
- `apim/docs/README.md` — drop three `forceRefresh` doc entries

**Backend Functions** (cleanup of post-#159 hardcodes):
- `GetSetList`, `GetCardsBySet`, `GetCardInfo` — drop `const forceRefresh = false`, the param from `trackEvent` payloads, inline conditions, file-header comment

## Test plan

- [x] `pnpm check` on frontend: 0 errors, 18 pre-existing warnings
- [x] `npm run build` on backend Functions: clean `tsc`
- [x] `terraform validate` for APIM root: pass
- [ ] Language switch on Path A: fresh sets render (cache miss via language-keyed key)
- [ ] Language switch on Path B: fresh sets render
- [ ] Language switch on Path C: fresh sets render
- [ ] `?forceRefresh=true` against any path: APIM may now return 400 (unknown query param under strict validation) or ignore silently — confirm post-CD that this isn't a regression for unknown external callers; APIM operations are spec-driven, so unknown params typically pass through harmlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)