### PR TITLE
fix(apim): add empty request block to get_card_info

### DIFF
--- a/apim/terraform/apis.tf
+++ b/apim/terraform/apis.tf
@@ -236,6 +236,17 @@ resource "azurerm_api_management_api_operation" "get_card_info" {
     required    = true
   }
 
+  # APIM's operation-update API rejects an operation with no `request` shape
+  # at all (returns generic "ValidationError: One or more fields contain
+  # incorrect values"). PR #169 removed the only query_parameter
+  # (`forceRefresh`), leaving this resource with no `request` block and
+  # triggering that failure on staging+prod CD. An empty `request` block
+  # is the minimal payload APIM accepts. The other operations (get_sets,
+  # get_cards_by_set) still have query_parameter children and update
+  # cleanly. See PR #169 → staging/prod CD failures for the trail.
+  request {
+  }
+
   response {
     status_code = 200
     description = "Successful response with detailed card information"


### PR DESCRIPTION
## Summary

Restores an empty \`request { }\` block to \`get_card_info\` in [apim/terraform/apis.tf](apim/terraform/apis.tf:215). PR [#169](https://github.com/Abernaughty/PCPC/pull/169) removed the only \`query_parameter\` (\`forceRefresh\`) and with it the entire \`request { ... }\` block — leaving the operation with no request shape at all, which APIM's update API rejects.

## Why

- **Reproduced on staging CD (2026-05-15 22:27 UTC)** and **prod CD (2026-05-15 23:33 UTC)** — both fail at \`Terraform Apply\` with:
  ```
  Error: creating/updating Operation (... Operation: "get-card-info"):
  unexpected status 400 (400 Bad Request) with error:
  ValidationError: One or more fields contain incorrect values
  ```
- The two other operations (\`get_sets\`, \`get_cards_by_set\`) update cleanly in the same apply because they still have non-empty \`request\` blocks (page, pageSize, etc.).
- Dev CD passed only because dev's state was already aligned with the post-#169 spec from earlier successful runs.
- APIM appears to require a \`request\` payload field on operation updates; the AzureRM provider omits the field entirely when no \`request\` block is in HCL, which APIM treats as invalid.

## Fix

Restore the block as empty:
\`\`\`hcl
request {
}
\`\`\`

Provider sends \`"request": {}\` to APIM, which is accepted. Operation semantics are unchanged (no query parameters, no body).

## Test plan

- [x] \`terraform validate\` passes (APIM env)
- [ ] Staging CD re-run completes successfully with \`get_card_info\` operation update + dependent policy update
- [ ] Prod CD re-run completes successfully

## Forward-looking

Memory file \`memory/projects/pcpc.md\` APIM gotchas should be updated with this lesson once verified: *"\`azurerm_api_management_api_operation\` requires at least an empty \`request {}\` block — omitting it entirely fails APIM's update API with a generic 400."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)