### PR TITLE
feat(phase-2.2): promote Path C (ACA) to staging + prod

### DIFF
--- a/infra/envs/prod/main.tf
+++ b/infra/envs/prod/main.tf
@@ -338,3 +338,87 @@ module "api_management" {
 
   depends_on = [module.resource_group]
 }
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container)
+#
+# The ACR consumed by this Container App lives in `pcpc-rg-shared` (PR 2.5),
+# not in `pcpc-rg-prod`. Each env's TF reads the shared ACR via
+# `data.terraform_remote_state.shared` and scopes its own UAMI's AcrPull
+# role assignment to that ACR. Dev/staging/prod all consume symmetrically.
+# See ADR-009's "ACR ownership" subsection for the rationale.
+# -----------------------------------------------------------------------------
+
+data "terraform_remote_state" "shared" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "pcpc-terraform-state-rg"
+    storage_account_name = "pcpctfstatedacc29c2"
+    container_name       = "tfstate"
+    key                  = "shared.terraform.tfstate"
+    tenant_id            = "5f445a68-ec75-42cf-a50f-6ec158ee675c"
+    subscription_id      = "555b4cfa-ad2e-4c71-9433-620a59cf7616"
+  }
+}
+
+module "container_app" {
+  source = "../../modules/container-app"
+
+  name                = "pcpc-aca-${local.environment}"
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  environment         = var.environment
+
+  log_analytics_workspace_id = module.log_analytics.id
+
+  acr_id           = data.terraform_remote_state.shared.outputs.acr_id
+  acr_login_server = data.terraform_remote_state.shared.outputs.acr_login_server
+  image_repository = var.container_app_image_repository
+  image_tag        = var.container_app_image_tag
+
+  min_replicas     = var.container_app_min_replicas
+  max_replicas     = var.container_app_max_replicas
+  cpu              = var.container_app_cpu
+  memory           = var.container_app_memory
+  http_concurrency = var.container_app_http_concurrency
+
+  cors_allowed_origins = var.container_app_cors_allowed_origins
+
+  # Non-secret env vars: same shape Path B uses (cosmos config, runtime
+  # flags, App Insights endpoint references). Container-runtime additions:
+  # FUNCTIONS_WORKER_RUNTIME (required) and AzureWebJobsStorage (set via
+  # secret_settings below).
+  app_settings = merge(
+    var.function_app_config, # non-secret config shared with Path B
+    {
+      "COSMOS_DB_ENDPOINT"                    = module.cosmos_db.endpoint
+      "FUNCTIONS_WORKER_RUNTIME"              = "node"
+      "APPINSIGHTS_INSTRUMENTATIONKEY"        = module.application_insights.instrumentation_key
+      "APPLICATIONINSIGHTS_CONNECTION_STRING" = module.application_insights.connection_string
+      "AZURE_FUNCTIONS_ENVIRONMENT"           = var.environment
+    }
+  )
+
+  # Secret env vars. Note we DO NOT carry over the Consumption-only
+  # WEBSITE_CONTENTAZUREFILECONNECTIONSTRING / WEBSITE_CONTENTSHARE
+  # settings here — those are file-share settings for the Functions
+  # Consumption plan, irrelevant in a container runtime.
+  secret_settings = merge(
+    local.function_app_secrets_filtered, # Scrydex creds (same map Path B uses)
+    {
+      "COSMOS_DB_CONNECTION_STRING" = module.cosmos_db.primary_sql_connection_string
+      "COSMOS_DB_KEY"               = module.cosmos_db.primary_key
+      "AzureWebJobsStorage"         = module.storage_account.primary_connection_string
+    }
+  )
+
+  tags = local.common_tags
+
+  depends_on = [
+    module.resource_group,
+    module.storage_account,
+    module.cosmos_db,
+    module.application_insights,
+    module.log_analytics,
+  ]
+}

--- a/infra/envs/prod/outputs.tf
+++ b/infra/envs/prod/outputs.tf
@@ -195,5 +195,25 @@ output "deployment_summary" {
     log_analytics        = module.log_analytics.name
     application_insights = module.application_insights.name
     api_management       = var.enable_api_management ? module.api_management[0].name : "Not deployed"
+    container_app        = module.container_app.name
   }
+}
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container) outputs
+# -----------------------------------------------------------------------------
+
+output "container_app_name" {
+  description = "Name of the Path C Container App. Used by the deploy-aca.yml pipeline template to target `az containerapp update`."
+  value       = module.container_app.name
+}
+
+output "container_app_fqdn" {
+  description = "Public ingress FQDN for the Path C Container App. Operator can repoint Vercel `PUBLIC_ACA_API_BASE_URL` (Production scope) here once prod ACA is live and verified."
+  value       = module.container_app.ingress_fqdn
+}
+
+output "container_app_resource_group" {
+  description = "Resource group containing the Container App. Convenience output for pipeline `az containerapp` invocations (same as the env-wide resource group)."
+  value       = module.resource_group.name
 }

--- a/infra/envs/prod/variables.tf
+++ b/infra/envs/prod/variables.tf
@@ -281,3 +281,61 @@ variable "oncall_email_address" {
   type        = string
   default     = "oncall@maber.io"
 }
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container) variables
+#
+# Same defaults as dev/staging — Path C is an architectural-demonstration tier
+# in production too, not the canonical user-traffic path (Path A via Vercel BFF
+# is). Tune per env later if real traffic patterns demand it. The shared ACR
+# is provisioned once in `infra/shared/` and consumed here via
+# terraform_remote_state. Env TFs only own the Container App itself.
+# -----------------------------------------------------------------------------
+
+variable "container_app_image_repository" {
+  description = "Repository path within the shared ACR for the Functions image (e.g. `pcpc/functions`). Distinct from the `pcpc-ci/*` CI tooling image repos."
+  type        = string
+  default     = "pcpc/functions"
+}
+
+variable "container_app_image_tag" {
+  description = "Initial image tag at terraform-apply time. Subsequent CD runs use `az containerapp update --image <new_sha>` to roll new revisions; the container-app module ignores image changes via lifecycle.ignore_changes."
+  type        = string
+  default     = "latest"
+}
+
+variable "container_app_min_replicas" {
+  description = "Minimum ACA replicas. Default 1 keeps the frontend's 2-second probeHealth timeout from falsely degrading Path C after idle periods (resolved as PORTFOLIO_PLAN.md open question #7)."
+  type        = number
+  default     = 1
+}
+
+variable "container_app_max_replicas" {
+  description = "Maximum ACA replicas the HTTP scale rule can scale out to."
+  type        = number
+  default     = 3
+}
+
+variable "container_app_cpu" {
+  description = "vCPU per replica."
+  type        = number
+  default     = 0.5
+}
+
+variable "container_app_memory" {
+  description = "Memory per replica (e.g. 1Gi, 2Gi)."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "container_app_http_concurrency" {
+  description = "Concurrent HTTP requests per replica before the HTTP scale rule scales out."
+  type        = number
+  default     = 10
+}
+
+variable "container_app_cors_allowed_origins" {
+  description = "Origins allowed by the ACA ingress CORS rule. Path C bypasses APIM, so this is the only allowlist gate. Keep in sync with the APIM regex policy (ADR-013) — both should be driven from the same canonical source. ACA CORS does not support regex; pass literal origins. Vercel preview origins can be added explicitly here when needed."
+  type        = list(string)
+  default     = ["https://pcpc.maber.io"]
+}

--- a/infra/envs/staging/main.tf
+++ b/infra/envs/staging/main.tf
@@ -321,3 +321,87 @@ module "api_management" {
 
   depends_on = [module.resource_group]
 }
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container)
+#
+# The ACR consumed by this Container App lives in `pcpc-rg-shared` (PR 2.5),
+# not in `pcpc-rg-staging`. Each env's TF reads the shared ACR via
+# `data.terraform_remote_state.shared` and scopes its own UAMI's AcrPull
+# role assignment to that ACR. Dev/staging/prod all consume symmetrically.
+# See ADR-009's "ACR ownership" subsection for the rationale.
+# -----------------------------------------------------------------------------
+
+data "terraform_remote_state" "shared" {
+  backend = "azurerm"
+  config = {
+    resource_group_name  = "pcpc-terraform-state-rg"
+    storage_account_name = "pcpctfstatedacc29c2"
+    container_name       = "tfstate"
+    key                  = "shared.terraform.tfstate"
+    tenant_id            = "5f445a68-ec75-42cf-a50f-6ec158ee675c"
+    subscription_id      = "555b4cfa-ad2e-4c71-9433-620a59cf7616"
+  }
+}
+
+module "container_app" {
+  source = "../../modules/container-app"
+
+  name                = "pcpc-aca-${local.environment}"
+  resource_group_name = module.resource_group.name
+  location            = var.location
+  environment         = var.environment
+
+  log_analytics_workspace_id = module.log_analytics.id
+
+  acr_id           = data.terraform_remote_state.shared.outputs.acr_id
+  acr_login_server = data.terraform_remote_state.shared.outputs.acr_login_server
+  image_repository = var.container_app_image_repository
+  image_tag        = var.container_app_image_tag
+
+  min_replicas     = var.container_app_min_replicas
+  max_replicas     = var.container_app_max_replicas
+  cpu              = var.container_app_cpu
+  memory           = var.container_app_memory
+  http_concurrency = var.container_app_http_concurrency
+
+  cors_allowed_origins = var.container_app_cors_allowed_origins
+
+  # Non-secret env vars: same shape Path B uses (cosmos config, runtime
+  # flags, App Insights endpoint references). Container-runtime additions:
+  # FUNCTIONS_WORKER_RUNTIME (required) and AzureWebJobsStorage (set via
+  # secret_settings below).
+  app_settings = merge(
+    var.function_app_config, # non-secret config shared with Path B
+    {
+      "COSMOS_DB_ENDPOINT"                    = module.cosmos_db.endpoint
+      "FUNCTIONS_WORKER_RUNTIME"              = "node"
+      "APPINSIGHTS_INSTRUMENTATIONKEY"        = module.application_insights.instrumentation_key
+      "APPLICATIONINSIGHTS_CONNECTION_STRING" = module.application_insights.connection_string
+      "AZURE_FUNCTIONS_ENVIRONMENT"           = var.environment
+    }
+  )
+
+  # Secret env vars. Note we DO NOT carry over the Consumption-only
+  # WEBSITE_CONTENTAZUREFILECONNECTIONSTRING / WEBSITE_CONTENTSHARE
+  # settings here — those are file-share settings for the Functions
+  # Consumption plan, irrelevant in a container runtime.
+  secret_settings = merge(
+    local.function_app_secrets_filtered, # Scrydex creds (same map Path B uses)
+    {
+      "COSMOS_DB_CONNECTION_STRING" = module.cosmos_db.primary_sql_connection_string
+      "COSMOS_DB_KEY"               = module.cosmos_db.primary_key
+      "AzureWebJobsStorage"         = module.storage_account.primary_connection_string
+    }
+  )
+
+  tags = local.common_tags
+
+  depends_on = [
+    module.resource_group,
+    module.storage_account,
+    module.cosmos_db,
+    module.application_insights,
+    module.log_analytics,
+  ]
+}

--- a/infra/envs/staging/outputs.tf
+++ b/infra/envs/staging/outputs.tf
@@ -195,5 +195,25 @@ output "deployment_summary" {
     log_analytics        = module.log_analytics.name
     application_insights = module.application_insights.name
     api_management       = var.enable_api_management ? module.api_management[0].name : "Not deployed"
+    container_app        = module.container_app.name
   }
+}
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container) outputs
+# -----------------------------------------------------------------------------
+
+output "container_app_name" {
+  description = "Name of the Path C Container App. Used by the deploy-aca.yml pipeline template to target `az containerapp update`."
+  value       = module.container_app.name
+}
+
+output "container_app_fqdn" {
+  description = "Public ingress FQDN for the Path C Container App. Operator can repoint Vercel `PUBLIC_ACA_API_BASE_URL` here per scope if/when staging should serve Path C."
+  value       = module.container_app.ingress_fqdn
+}
+
+output "container_app_resource_group" {
+  description = "Resource group containing the Container App. Convenience output for pipeline `az containerapp` invocations (same as the env-wide resource group)."
+  value       = module.resource_group.name
 }

--- a/infra/envs/staging/variables.tf
+++ b/infra/envs/staging/variables.tf
@@ -275,3 +275,60 @@ variable "alert_email_address" {
   type        = string
   default     = "devops@maber.io"
 }
+
+# -----------------------------------------------------------------------------
+# Phase 2.2 — Path C (ACA Container) variables
+#
+# Same defaults as dev — staging is an architectural-demonstration tier, not a
+# real higher-traffic tier. Tune per env later if needed. The shared ACR is
+# provisioned once in `infra/shared/` and consumed here via
+# terraform_remote_state. Env TFs only own the Container App itself.
+# -----------------------------------------------------------------------------
+
+variable "container_app_image_repository" {
+  description = "Repository path within the shared ACR for the Functions image (e.g. `pcpc/functions`). Distinct from the `pcpc-ci/*` CI tooling image repos."
+  type        = string
+  default     = "pcpc/functions"
+}
+
+variable "container_app_image_tag" {
+  description = "Initial image tag at terraform-apply time. Subsequent CD runs use `az containerapp update --image <new_sha>` to roll new revisions; the container-app module ignores image changes via lifecycle.ignore_changes."
+  type        = string
+  default     = "latest"
+}
+
+variable "container_app_min_replicas" {
+  description = "Minimum ACA replicas. Default 1 keeps the frontend's 2-second probeHealth timeout from falsely degrading Path C after idle periods (resolved as PORTFOLIO_PLAN.md open question #7)."
+  type        = number
+  default     = 1
+}
+
+variable "container_app_max_replicas" {
+  description = "Maximum ACA replicas the HTTP scale rule can scale out to."
+  type        = number
+  default     = 3
+}
+
+variable "container_app_cpu" {
+  description = "vCPU per replica."
+  type        = number
+  default     = 0.5
+}
+
+variable "container_app_memory" {
+  description = "Memory per replica (e.g. 1Gi, 2Gi)."
+  type        = string
+  default     = "1Gi"
+}
+
+variable "container_app_http_concurrency" {
+  description = "Concurrent HTTP requests per replica before the HTTP scale rule scales out."
+  type        = number
+  default     = 10
+}
+
+variable "container_app_cors_allowed_origins" {
+  description = "Origins allowed by the ACA ingress CORS rule. Path C bypasses APIM, so this is the only allowlist gate. Keep in sync with the APIM regex policy (ADR-013) — both should be driven from the same canonical source. ACA CORS does not support regex; pass literal origins. Vercel preview origins can be added explicitly here when needed."
+  type        = list(string)
+  default     = ["https://pcpc.maber.io"]
+}

--- a/pipelines/ado/azure-pipelines.yml
+++ b/pipelines/ado/azure-pipelines.yml
@@ -202,7 +202,18 @@ stages:
   # ============================================================================
   - stage: Deploy_Staging
     displayName: "Deploy to Staging"
-    dependsOn: Deploy_Dev
+    # `Build` is listed explicitly (in addition to Deploy_Dev) so this stage
+    # can read `stageDependencies.Build.Build_Container_Image.outputs[...]`
+    # for the Deploy_ACA job below. Per Microsoft Learn: "Output variables
+    # are only available in the next downstream stage. If multiple stages
+    # consume the same output variable, use the `dependsOn` condition."
+    # (learn.microsoft.com/azure/devops/pipelines/process/set-variables-scripts).
+    # Execution order is unchanged — Deploy_Dev already gates this stage
+    # via its own dependsOn on Build, so adding Build here just propagates
+    # the output-variable visibility.
+    dependsOn:
+      - Build
+      - Deploy_Dev
     condition: succeeded()
     variables:
       - group: vg-pcpc-staging-config
@@ -306,7 +317,12 @@ stages:
   # ============================================================================
   - stage: Deploy_Prod
     displayName: "Deploy to Production"
-    dependsOn: Deploy_Staging
+    # See the matching note on Deploy_Staging — Build is listed alongside
+    # the upstream deploy stage so Deploy_ACA can read the cross-stage
+    # image-reference output variable.
+    dependsOn:
+      - Build
+      - Deploy_Staging
     condition: succeeded()
     variables:
       - group: vg-pcpc-prod-config

--- a/pipelines/ado/azure-pipelines.yml
+++ b/pipelines/ado/azure-pipelines.yml
@@ -256,6 +256,31 @@ stages:
               environment: staging
               azureSubscription: "az-pcpc-staging"
 
+      # Phase 2.2 — Deploy Path C (ACA Container) to staging.
+      #
+      # Mirror of Deploy_Dev's Deploy_ACA job. Consumes the same canonical
+      # SHA-tagged image reference from the Build stage's Build_Container_Image
+      # job — one image build per pipeline run, all envs roll the same artifact.
+      # The infra stage above runs as `deployment:` against the `pcpc-staging`
+      # environment for the approval gate, which gates this job too via
+      # dependsOn.
+      - job: Deploy_ACA
+        displayName: "Deploy Path C (ACA Container)"
+        dependsOn: Deploy_Infrastructure
+        condition: succeeded()
+        pool:
+          vmImage: "ubuntu-latest"
+        variables:
+          containerImageReference: $[ stageDependencies.Build.Build_Container_Image.outputs['discover_image.ContainerImageReference'] ]
+        steps:
+          - template: templates/deploy-aca.yml
+            parameters:
+              environment: staging
+              azureSubscription: "az-pcpc-staging"
+              containerAppName: "pcpc-aca-staging"
+              resourceGroupName: $(APIM_RESOURCE_GROUP)
+              containerImageReference: $(containerImageReference)
+
       # Run Smoke Tests
       - job: Smoke_Tests
         displayName: "Run Smoke Tests"
@@ -335,6 +360,29 @@ stages:
               environment: prod
               azureSubscription: "az-pcpc-prod"
 
+      # Phase 2.2 — Deploy Path C (ACA Container) to prod.
+      #
+      # Mirror of Deploy_Dev / Deploy_Staging's Deploy_ACA job. Same SHA-tagged
+      # image reference from the Build stage as the other two envs. The infra
+      # stage above runs as `deployment:` against the `pcpc-prod` environment
+      # for the production approval gate, which gates this job too.
+      - job: Deploy_ACA
+        displayName: "Deploy Path C (ACA Container)"
+        dependsOn: Deploy_Infrastructure
+        condition: succeeded()
+        pool:
+          vmImage: "ubuntu-latest"
+        variables:
+          containerImageReference: $[ stageDependencies.Build.Build_Container_Image.outputs['discover_image.ContainerImageReference'] ]
+        steps:
+          - template: templates/deploy-aca.yml
+            parameters:
+              environment: prod
+              azureSubscription: "az-pcpc-prod"
+              containerAppName: "pcpc-aca-prod"
+              resourceGroupName: $(APIM_RESOURCE_GROUP)
+              containerImageReference: $(containerImageReference)
+
       # Run Smoke Tests
       - job: Smoke_Tests
         displayName: "Run Smoke Tests"
@@ -377,8 +425,8 @@ stages:
               echo ""
               echo "Deployed Components:"
               echo "  ✓ Infrastructure (Terraform)"
-              echo "  ✓ Azure Functions Backend"
-              echo "  ✓ APIM APIs & Policies"
+              echo "  ✓ Path B: Azure Functions Backend + APIM"
+              echo "  ✓ Path C: Container App (ACA)"
               echo ""
               echo "All smoke tests passed successfully."
               echo "=========================================="


### PR DESCRIPTION
## Summary

- Mirror dev's `module.container_app` + `data.terraform_remote_state.shared` into `infra/envs/staging` and `infra/envs/prod` (main.tf + variables.tf + outputs.tf). Same defaults as dev — staging/prod are architectural-demonstration tiers, not real higher-traffic tiers.
- Add `Deploy_ACA` job to both `Deploy_Staging` and `Deploy_Prod` stages in [pipelines/ado/azure-pipelines.yml](pipelines/ado/azure-pipelines.yml), mirroring the dev shape. Both consume the canonical SHA-tagged image reference from the Build stage's `Build_Container_Image` job (PR #167) via cross-stage `stageDependencies` — one image build, three envs.
- All three deploy stages now have a symmetric job set: `Deploy_Infrastructure → {Deploy_Functions, Deploy_APIM, Deploy_ACA} → Smoke_Tests`. Staging/prod gate the whole stage via the existing `pcpc-staging` / `pcpc-prod` environment approvals on the infra job, which gates `Deploy_ACA` via `dependsOn`.
- CORS allowlist for both new envs is `["https://pcpc.maber.io"]` (same as dev) — Path C from the user's browser only ever originates from the single production frontend domain.

## ⚠️ Operator prereq before merge

Each env's ADO SP creates the `acr_pull` role assignment scoped to the shared ACR. That requires `Microsoft.Authorization/roleAssignments/write` on `pcpc-rg-shared`, which **Contributor does NOT include** (confirmed twice during Phase 2.2; documented in `memory/projects/pcpc.md` Phase 2.2 lessons learned #5).

Before merging:

1. Grant `az-pcpc-staging` SP **Role Based Access Control Administrator** on `pcpc-rg-shared` with ABAC condition restricting to AcrPull + AcrPush role-definition GUIDs (same shape as dev's existing assignment `120e36f2-4ad2-45c4-ba98-52a99e2bef5e` on `pcpc-rg-dev`).
2. Grant `az-pcpc-prod` SP the same on `pcpc-rg-shared` with the same ABAC condition.

Without these, `terraform apply` will 403 on the role-assignment resource inside `module.container_app` and the rest of the module rolls back.

## Local validation

```
terraform fmt -check -recursive          # clean
terraform init -backend=false; validate  # Success! The configuration is valid.
```
Both `infra/envs/staging` and `infra/envs/prod`. Pipeline YAML parses with all three deploy stages showing the symmetric job set above.

## Test plan

- [ ] Operator: grant RBAC Admin on `pcpc-rg-shared` to both staging + prod ADO SPs (see prereq above)
- [ ] Merge → `Deploy_Dev` runs unchanged (regression check)
- [ ] `Deploy_Staging > Deploy_Infrastructure` TF plan shows `+ azurerm_user_assigned_identity.this`, `+ azurerm_role_assignment.acr_pull` (scoped to shared ACR), `+ azurerm_container_app_environment.this`, `+ azurerm_container_app.this`. Apply succeeds.
- [ ] `Deploy_Staging > Deploy_ACA`: `az containerapp update --image <sha>` succeeds, revision reaches `Running` within 5 min, smoke tests pass against the staging FQDN.
- [ ] Operator captures staging FQDN: `az containerapp show -n pcpc-aca-staging -g pcpc-rg-staging --query properties.configuration.ingress.fqdn -o tsv`
- [ ] End-to-end smoke (verifies CORS too):
      `curl -i https://<staging-fqdn>/api/health` → 200
      `curl -i -X OPTIONS https://<staging-fqdn>/api/sets -H 'Origin: https://pcpc.maber.io' -H 'Access-Control-Request-Method: GET'` → 204 with `Access-Control-Allow-Origin: https://pcpc.maber.io`
- [ ] Operator approves `pcpc-prod` env gate; same checks against prod FQDN
- [ ] Tag `phase-2.2/all-envs` once both stages are live

## Out of scope (operator follow-ups)

- Vercel `PUBLIC_ACA_API_BASE_URL` repoint to prod ACA FQDN once prod is verified live (currently points at dev for both Production + Preview scopes)
- `PORTFOLIO_PLAN.md` + memory updates once both stages ship through
- Stale staging+prod SWA orphans (`az staticwebapp delete -g pcpc-rg-{env} -n pcpc-swa-{env} --yes`)
- CI tooling image migration (separable polish item — move `pcpc-ci-*` images from `maberdevcontainerregistry` to PCPC-owned ACR in `pcpc-rg-shared`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)