### PR TITLE
fix(frontend): Path C must add /api route prefix

### DIFF
--- a/frontend/src/lib/backends/path-c-aca.ts
+++ b/frontend/src/lib/backends/path-c-aca.ts
@@ -33,32 +33,44 @@ import type { BackendDefinition, BackendFetcher, BackendHealth } from './types';
 /**
  * Path C base URL.
  *
- * Resolved at module load from `PUBLIC_ACA_API_BASE_URL`. Set this in
- * the Vercel project per scope:
- *   dev      → https://<aca-fqdn-dev>
- *   staging  → https://<aca-fqdn-staging>   (added when Phase 2.2
- *               staging promotion lands)
- *   prod     → https://<aca-fqdn-prod>      (likewise)
+ * Resolved at module load from `PUBLIC_ACA_API_BASE_URL`. The env var is
+ * the ACA ingress host only (e.g. `https://<aca-fqdn>`); this module
+ * appends the `/api` route prefix that the Functions host serves under
+ * (see backend/functions/host.json — `extensions.http.routePrefix: "api"`).
  *
- * The dev FQDN is produced by `terraform output container_app_fqdn`
- * after the Phase 2.2 PR-2 infra applies.
+ * Set this in the Vercel project per scope:
+ *   dev      → https://<aca-fqdn-dev>
+ *   staging  → https://<aca-fqdn-staging>
+ *   prod     → https://<aca-fqdn-prod>
+ *
+ * Each env's FQDN is produced by `terraform output container_app_fqdn`
+ * after that env's Phase 2.2 infra applies.
+ *
+ * Path B doesn't need this prefix because APIM strips its own front path
+ * (`/pcpc-api/v1`) and maps to backend `/api/*` via the OpenAPI spec
+ * import. Path C bypasses APIM, so the `/api` prefix is the caller's
+ * responsibility — this module adds it once at the base.
  */
 const PATH_C_BASE = (() => {
   const fromEnv = env.PUBLIC_ACA_API_BASE_URL;
-  if (fromEnv && fromEnv.length > 0) return fromEnv.replace(/\/$/, '');
-  return '';
+  if (!fromEnv || fromEnv.length === 0) return '';
+  const trimmed = fromEnv.replace(/\/$/, '');
+  // Idempotent: tolerate operators who configured the env var with the
+  // `/api` suffix already present.
+  return trimmed.endsWith('/api') ? trimmed : `${trimmed}/api`;
 })();
 
 /**
  * Translate the canonical frontend path into a Path C URL. The Functions
  * code that handles these routes is bit-identical to Path B's, so this
- * is a passthrough — no shape translation.
+ * is a passthrough — no shape translation. The `/api` route prefix is
+ * already baked into PATH_C_BASE above.
  *
- *   Frontend canonical               Path C target
- *   /sets?language=en&all=true   →   /sets?language=en&all=true
- *   /sets/sv8/cards              →   /sets/sv8/cards
- *   /sets/sv8/cards/12345        →   /sets/sv8/cards/12345
- *   /health                      →   /health
+ *   Frontend canonical               Path C target (PATH_C_BASE includes /api)
+ *   /sets?language=en&all=true   →   <host>/api/sets?language=en&all=true
+ *   /sets/sv8/cards              →   <host>/api/sets/sv8/cards
+ *   /sets/sv8/cards/12345        →   <host>/api/sets/sv8/cards/12345
+ *   /health                      →   <host>/api/health
  */
 function translateCanonicalPath(canonicalPath: string): string {
   return `${PATH_C_BASE}${canonicalPath}`;


### PR DESCRIPTION
## Summary

Latent bug since PR #152 (Phase 2.2 frontend wiring): **Path C has never worked through the UI** because every call hit `<aca-host>/<canonical>` without the `/api` route prefix and 404'd. The toggle silently hid Path C because its healthcheck never resolved healthy.

Surfaced today after PR #171's staging+prod promotion — the operator (correctly) updated Vercel `PUBLIC_ACA_API_BASE_URL` to point Production at the new prod ACA FQDN, redeployed, and noticed Path C was still missing from the toggle. Browser DevTools showed `GET https://pcpc-aca-prod.../health → 404`, which led to the root cause.

## Root cause

Functions' [host.json](backend/functions/host.json) sets `extensions.http.routePrefix: "api"` (line 22), so all routes serve at `/api/*`. Each backend path adapter handles this differently:

| Path | How `/api` is added | Status |
|---|---|---|
| A (Vercel BFF) | `PATH_A_BASE = '/api'` baked into the base | ✓ works |
| B (APIM) | `PATH_B_BASE` ends in `/pcpc-api/v1`; APIM strips it and maps to backend `/api/*` via OpenAPI spec import | ✓ works |
| C (ACA direct) | `PATH_C_BASE` was just `https://<aca-fqdn>` — no prefix; bypasses APIM, so nothing translates | ✗ broken |

The previous "all three paths verified on `pcpc.maber.io`" in memory was via operator `curl https://<aca-fqdn>/api/health` directly, never through the toggle.

## Fix

One file ([frontend/src/lib/backends/path-c-aca.ts](frontend/src/lib/backends/path-c-aca.ts)). Append `/api` to `PATH_C_BASE` once at module load, so both `translateCanonicalPath()` (data fetches) and `healthcheck()` end up hitting the right route. Idempotent — tolerates operators who configured the env var with `/api` already present.

## Verified

\`\`\`
$ curl -s -o /dev/null -w "%{http_code}\n" https://pcpc-aca-prod.mangoforest-6f1f47e0.centralus.azurecontainerapps.io/health      → 404
$ curl -s -o /dev/null -w "%{http_code}\n" https://pcpc-aca-prod.mangoforest-6f1f47e0.centralus.azurecontainerapps.io/api/health  → 200
$ curl -s -o /dev/null -w "%{http_code}\n" https://pcpc-aca-staging.gentlesky-0c8e4ecc.centralus.azurecontainerapps.io/health     → 404
$ curl -s -o /dev/null -w "%{http_code}\n" https://pcpc-aca-staging.gentlesky-0c8e4ecc.centralus.azurecontainerapps.io/api/health → 200
$ curl -s -o /dev/null -w "%{http_code}\n" https://pcpc-aca-dev.gentlesmoke-60971ffc.centralus.azurecontainerapps.io/health       → 404
$ curl -s -o /dev/null -w "%{http_code}\n" https://pcpc-aca-dev.gentlesmoke-60971ffc.centralus.azurecontainerapps.io/api/health   → 200
\`\`\`

`pnpm check`: 0 errors (pre-existing warnings only).

## Test plan

- [ ] Merge → Vercel auto-deploys main → wait for production deployment to go READY
- [ ] On `pcpc.maber.io`, open backend toggle — Path C (ACA) should now appear alongside A and B
- [ ] Click Path C in toggle → page loads cards data successfully (no 404s in DevTools Network tab)
- [ ] Repeat for `?backend=aca` URL param to confirm explicit selection works

🤖 Generated with [Claude Code](https://claude.com/claude-code)