### PR TITLE
fix(dependabot): drop root npm block to stop duplicate workspace PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,16 +31,15 @@ updates:
       minor-and-patch:
         update-types: [minor, patch]
 
-  # Root workspace (Jest backend tests + Playwright E2E)
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-      day: monday
-    open-pull-requests-limit: 3
-    groups:
-      minor-and-patch:
-        update-types: [minor, patch]
+  # No root `/` block: with pnpm-workspace at root, Dependabot's `npm` ecosystem
+  # at `directory: /` sees every workspace member's deps via pnpm-lock.yaml and
+  # opens duplicate PRs that touch the wrong lockfiles (e.g. backend/functions
+  # uses npm not pnpm, so root-block PRs for backend deps update pnpm-lock.yaml
+  # instead of backend/functions/package-lock.json — what `npm ci` actually
+  # consumes at deploy). Root's only direct deps are test runners (jest,
+  # playwright, supertest, ts-jest, babel-*, @azure/cosmos for the seed script),
+  # all dev-time only — manual bumps are acceptable for those. See PRs #178/#179
+  # from 2026-05-18 for the duplicate-PR pattern this avoids.
 
   # Dockerfile base image (Azure Functions Node 22 image gets CVE patches)
   - package-ecosystem: docker


### PR DESCRIPTION
## Summary

- Root `/` Dependabot block + pnpm-workspace was opening duplicate PRs that touched the wrong lockfiles (pnpm-lock.yaml instead of backend/functions/package-lock.json, which is what `npm ci` actually consumes at deploy)
- Confirmed today: #178 (root cookie 0.7) and #179 (root adapter-vercel 6.3.2) are wrongly-scoped duplicates of #184 (backend cookie 1.1.1) and #185 (frontend adapter-vercel 6.3.3) respectively
- Drop the `/` block entirely; root's only direct deps are dev-time test runners (jest/playwright/supertest/ts-jest/babel-*/@azure/cosmos for the seed script), and per-workspace blocks already cover everything that ships

## Test plan

- [ ] Verify dependabot.yml is valid YAML (GitHub will reject on parse error if not)
- [ ] After merge: confirm no new duplicate PRs appear on the next weekly run (Monday 09:00 America/Chicago)
- [ ] Close #178 and #179 once this lands (they'll be made redundant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)