### PR TITLE
test(frontend): add unit tests for lib utils and services

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
 		"preview": "vite preview",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"lint": "eslint .",
-		"test": "vitest run --passWithNoTests"
+		"test": "vitest run"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.22.0",

--- a/frontend/src/lib/backends/health.test.ts
+++ b/frontend/src/lib/backends/health.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { statusFromHttp, probeHealth, HEALTH_TIMEOUT_MS } from './health';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe('statusFromHttp', () => {
+  it('maps 200 to healthy', () => {
+    expect(statusFromHttp(200)).toBe('healthy');
+  });
+
+  it('maps 207 to degraded', () => {
+    expect(statusFromHttp(207)).toBe('degraded');
+  });
+
+  it('maps everything else to unhealthy', () => {
+    expect(statusFromHttp(503)).toBe('unhealthy');
+    expect(statusFromHttp(404)).toBe('unhealthy');
+    expect(statusFromHttp(500)).toBe('unhealthy');
+  });
+});
+
+describe('probeHealth', () => {
+  it('reports a healthy backend with latency and no message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
+    );
+
+    const health = await probeHealth('https://example.test/api/health');
+    expect(health.status).toBe('healthy');
+    expect(health.message).toBeUndefined();
+    expect(health.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(health.checkedAt).toBeTypeOf('number');
+  });
+
+  it('reports a degraded backend on HTTP 207 without an error message', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('partial', { status: 207 }))
+    );
+
+    const health = await probeHealth('https://example.test/api/health');
+    expect(health.status).toBe('degraded');
+    // 207 is still within Response.ok (200-299), so no message is attached
+    expect(health.message).toBeUndefined();
+  });
+
+  it('reports an unhealthy backend on HTTP 503', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response('down', { status: 503 }))
+    );
+
+    const health = await probeHealth('https://example.test/api/health');
+    expect(health.status).toBe('unhealthy');
+    expect(health.message).toBe('HTTP 503');
+  });
+
+  it('never throws on network errors and surfaces the message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('ECONNREFUSED')));
+
+    const health = await probeHealth('https://example.test/api/health');
+    expect(health.status).toBe('unhealthy');
+    expect(health.message).toBe('ECONNREFUSED');
+    expect(health.latencyMs).toBeUndefined();
+  });
+
+  it('treats an aborted request as a timeout', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(abortError));
+
+    const health = await probeHealth('https://example.test/api/health');
+    expect(health.status).toBe('unhealthy');
+    expect(health.message).toBe(`timeout after ${HEALTH_TIMEOUT_MS}ms`);
+  });
+});

--- a/frontend/src/lib/server/services/scrydexApi.test.ts
+++ b/frontend/src/lib/server/services/scrydexApi.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeLanguageCode,
+  mapScrydexPriceToVariantPrice,
+  mapScrydexVariantToCardVariant,
+  type ScrydexPrice,
+  type ScrydexVariant,
+} from './scrydexApi';
+
+describe('normalizeLanguageCode', () => {
+  it('defaults to EN when no code is provided', () => {
+    expect(normalizeLanguageCode(undefined)).toBe('EN');
+    expect(normalizeLanguageCode('')).toBe('EN');
+  });
+
+  it('maps the Scrydex JA code to the JP display code', () => {
+    expect(normalizeLanguageCode('JA')).toBe('JP');
+    expect(normalizeLanguageCode('ja')).toBe('JP');
+  });
+
+  it('uppercases other language codes unchanged', () => {
+    expect(normalizeLanguageCode('en')).toBe('EN');
+    expect(normalizeLanguageCode('de')).toBe('DE');
+  });
+});
+
+function makePrice(overrides: Partial<ScrydexPrice> = {}): ScrydexPrice {
+  return {
+    condition: 'NM',
+    type: 'raw',
+    is_perfect: false,
+    is_error: false,
+    is_signed: false,
+    low: 1.5,
+    market: 2.25,
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+describe('mapScrydexPriceToVariantPrice', () => {
+  it('maps snake_case price fields to camelCase', () => {
+    const mapped = mapScrydexPriceToVariantPrice(
+      makePrice({
+        type: 'graded',
+        company: 'PSA',
+        grade: '10',
+        is_perfect: true,
+        mid: 3,
+        high: 4,
+      })
+    );
+    expect(mapped).toMatchObject({
+      condition: 'NM',
+      type: 'graded',
+      company: 'PSA',
+      grade: '10',
+      isPerfect: true,
+      isError: false,
+      isSigned: false,
+      low: 1.5,
+      mid: 3,
+      high: 4,
+      market: 2.25,
+      currency: 'USD',
+    });
+  });
+
+  it('maps trend windows when present', () => {
+    const mapped = mapScrydexPriceToVariantPrice(
+      makePrice({
+        trends: {
+          days_7: { price_change: 0.5, percent_change: 12.3 },
+          days_30: { price_change: -1, percent_change: -8 },
+        },
+      })
+    );
+    expect(mapped.trends?.days7).toEqual({ priceChange: 0.5, percentChange: 12.3 });
+    expect(mapped.trends?.days30).toEqual({ priceChange: -1, percentChange: -8 });
+    expect(mapped.trends?.days90).toBeUndefined();
+  });
+
+  it('leaves trends undefined when the API provides none', () => {
+    expect(mapScrydexPriceToVariantPrice(makePrice()).trends).toBeUndefined();
+  });
+});
+
+describe('mapScrydexVariantToCardVariant', () => {
+  it('maps images and prices', () => {
+    const variant: ScrydexVariant = {
+      name: 'holofoil',
+      images: [{ type: 'front', small: 's.png', medium: 'm.png', large: 'l.png' }],
+      prices: [makePrice()],
+    };
+    const mapped = mapScrydexVariantToCardVariant(variant);
+    expect(mapped.name).toBe('holofoil');
+    expect(mapped.images).toEqual([
+      { type: 'front', small: 's.png', medium: 'm.png', large: 'l.png' },
+    ]);
+    expect(mapped.prices).toHaveLength(1);
+    expect(mapped.prices[0].market).toBe(2.25);
+  });
+
+  it('defaults to an empty price list when prices are missing', () => {
+    const mapped = mapScrydexVariantToCardVariant({ name: 'normal' });
+    expect(mapped.prices).toEqual([]);
+    expect(mapped.images).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/server/utils/cache.test.ts
+++ b/frontend/src/lib/server/utils/cache.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  CacheKeys,
+  isCacheExpired,
+  formatCacheEntry,
+  parseCacheEntry,
+  getCacheAge,
+} from './cache';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-10T12:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('CacheKeys', () => {
+  it('builds stable, namespaced keys', () => {
+    expect(CacheKeys.setList()).toBe('sets:list');
+    expect(CacheKeys.cardsForSet('sv1')).toBe('cards:set:sv1');
+    expect(CacheKeys.card('sv1-25')).toBe('card:sv1-25');
+    expect(CacheKeys.cardPricing('sv1-25')).toBe('pricing:sv1-25');
+  });
+});
+
+describe('isCacheExpired', () => {
+  it('is false while within the TTL', () => {
+    const timestamp = Date.now();
+    vi.advanceTimersByTime(9_000);
+    expect(isCacheExpired(timestamp, 10)).toBe(false);
+  });
+
+  it('is true once the TTL has elapsed', () => {
+    const timestamp = Date.now();
+    vi.advanceTimersByTime(11_000);
+    expect(isCacheExpired(timestamp, 10)).toBe(true);
+  });
+});
+
+describe('formatCacheEntry / parseCacheEntry', () => {
+  it('round-trips data while fresh', () => {
+    const entry = formatCacheEntry({ hello: 'world' }, 60);
+    expect(entry.timestamp).toBe(Date.now());
+    expect(entry.ttl).toBe(60);
+    expect(parseCacheEntry(entry)).toEqual({ hello: 'world' });
+  });
+
+  it('returns null once the entry has expired', () => {
+    const entry = formatCacheEntry('data', 60);
+    vi.advanceTimersByTime(61_000);
+    expect(parseCacheEntry(entry)).toBeNull();
+  });
+
+  it('returns null for a missing entry', () => {
+    expect(parseCacheEntry(null)).toBeNull();
+  });
+});
+
+describe('getCacheAge', () => {
+  it('reports whole seconds since the timestamp', () => {
+    const timestamp = Date.now();
+    vi.advanceTimersByTime(2_500);
+    expect(getCacheAge(timestamp)).toBe(2);
+  });
+});

--- a/frontend/src/lib/server/utils/errors.test.ts
+++ b/frontend/src/lib/server/utils/errors.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { apiError, apiSuccess } from './errors';
+
+describe('apiError', () => {
+  it('returns a JSON response with the given status and message', async () => {
+    const response = apiError('Set not found', 404);
+    expect(response.status).toBe(404);
+
+    const body = await response.json();
+    expect(body.status).toBe(404);
+    expect(body.error).toBe('Set not found');
+    expect(body.data).toBeUndefined();
+    expect(new Date(body.timestamp).getTime()).not.toBeNaN();
+  });
+
+  it('defaults to status 500', async () => {
+    const response = apiError('boom');
+    expect(response.status).toBe(500);
+    expect((await response.json()).status).toBe(500);
+  });
+});
+
+describe('apiSuccess', () => {
+  it('wraps data with status and timestamp', async () => {
+    const response = apiSuccess({ cards: [1, 2, 3] });
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.status).toBe(200);
+    expect(body.data).toEqual({ cards: [1, 2, 3] });
+    expect(body.error).toBeUndefined();
+  });
+
+  it('passes through the cached flag and custom status', async () => {
+    const response = apiSuccess('ok', 201, true);
+    expect(response.status).toBe(201);
+
+    const body = await response.json();
+    expect(body.cached).toBe(true);
+  });
+});

--- a/frontend/src/lib/services/expansionMapper.test.ts
+++ b/frontend/src/lib/services/expansionMapper.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getExpansionForSet,
+  groupSetsByExpansion,
+  prepareGroupedSetsForDropdown,
+  parseDateToTimestamp,
+  formatMonthYear,
+  getDateRangeLabel,
+} from './expansionMapper';
+import type { PokemonSet } from '$lib/types';
+
+function makeSet(overrides: Partial<PokemonSet> = {}): PokemonSet {
+  return {
+    id: 'sv1',
+    code: 'SV1',
+    name: 'Scarlet & Violet',
+    series: 'Scarlet & Violet',
+    releaseDate: '2023/03/31',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(2026, 5, 10));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('parseDateToTimestamp', () => {
+  it('parses slash-separated dates', () => {
+    expect(parseDateToTimestamp('2023/03/31')).toBe(new Date('2023-03-31').getTime());
+  });
+
+  it('parses dash-separated dates', () => {
+    expect(parseDateToTimestamp('2023-03-31')).toBeGreaterThan(0);
+  });
+
+  it('returns 0 for missing or unparseable dates', () => {
+    expect(parseDateToTimestamp(undefined)).toBe(0);
+    expect(parseDateToTimestamp('')).toBe(0);
+    expect(parseDateToTimestamp('not a date')).toBe(0);
+  });
+});
+
+describe('formatMonthYear', () => {
+  it('formats as "Mon YYYY"', () => {
+    expect(formatMonthYear('2023/08/11')).toBe('Aug 2023');
+  });
+
+  it('returns empty string for missing or invalid dates', () => {
+    expect(formatMonthYear(undefined)).toBe('');
+    expect(formatMonthYear('garbage')).toBe('');
+  });
+});
+
+describe('getDateRangeLabel', () => {
+  it('uses "present" when the newest set is from the current year or later', () => {
+    const sets = [
+      makeSet({ releaseDate: '2023/03/31' }),
+      makeSet({ id: 'sv9', releaseDate: '2026/01/30' }),
+    ];
+    expect(getDateRangeLabel(sets)).toBe('2023 – present');
+  });
+
+  it('uses a closed year range for past eras', () => {
+    const sets = [
+      makeSet({ releaseDate: '2019/02/01' }),
+      makeSet({ id: 'swsh12', releaseDate: '2022/11/11' }),
+    ];
+    expect(getDateRangeLabel(sets)).toBe('2019 – 2022');
+  });
+
+  it('collapses to a single year when min and max match', () => {
+    expect(getDateRangeLabel([makeSet({ releaseDate: '2021/06/18' })])).toBe('2021');
+  });
+
+  it('returns empty string when no sets have parseable dates', () => {
+    expect(getDateRangeLabel([makeSet({ releaseDate: undefined })])).toBe('');
+    expect(getDateRangeLabel([])).toBe('');
+  });
+});
+
+describe('getExpansionForSet', () => {
+  it('uses the series field when present', () => {
+    expect(getExpansionForSet(makeSet({ series: 'Sword & Shield' }))).toBe('Sword & Shield');
+  });
+
+  it('falls back to "Other" when series is missing', () => {
+    expect(getExpansionForSet(makeSet({ series: '' }))).toBe('Other');
+  });
+});
+
+describe('groupSetsByExpansion', () => {
+  it('groups sets by their series', () => {
+    const grouped = groupSetsByExpansion([
+      makeSet({ id: 'a', series: 'Scarlet & Violet' }),
+      makeSet({ id: 'b', series: 'Sword & Shield' }),
+      makeSet({ id: 'c', series: 'Scarlet & Violet' }),
+    ]);
+    expect(Object.keys(grouped).sort()).toEqual(['Scarlet & Violet', 'Sword & Shield']);
+    expect(grouped['Scarlet & Violet'].map((s) => s.id)).toEqual(['a', 'c']);
+  });
+
+  it('returns an empty record for empty input', () => {
+    expect(groupSetsByExpansion([])).toEqual({});
+  });
+});
+
+describe('prepareGroupedSetsForDropdown', () => {
+  it('sorts sets within a group newest first', () => {
+    const groups = prepareGroupedSetsForDropdown({
+      'Scarlet & Violet': [
+        makeSet({ id: 'old', releaseDate: '2023/03/31' }),
+        makeSet({ id: 'new', releaseDate: '2025/05/30' }),
+        makeSet({ id: 'mid', releaseDate: '2024/01/26' }),
+      ],
+    });
+    expect(groups[0].items.map((s) => s.id)).toEqual(['new', 'mid', 'old']);
+  });
+
+  it('sorts groups by their newest set, newest group first', () => {
+    const groups = prepareGroupedSetsForDropdown({
+      'Sword & Shield': [makeSet({ id: 'swsh', releaseDate: '2022/11/11' })],
+      'Scarlet & Violet': [makeSet({ id: 'sv', releaseDate: '2025/05/30' })],
+      'Sun & Moon': [makeSet({ id: 'sm', releaseDate: '2019/11/01' })],
+    });
+    expect(groups.map((g) => g.label)).toEqual([
+      'Scarlet & Violet',
+      'Sword & Shield',
+      'Sun & Moon',
+    ]);
+  });
+
+  it('always sorts the "Other" group last, even with the newest dates', () => {
+    const groups = prepareGroupedSetsForDropdown({
+      Other: [makeSet({ id: 'x', releaseDate: '2026/05/01' })],
+      'Scarlet & Violet': [makeSet({ id: 'sv', releaseDate: '2023/03/31' })],
+    });
+    expect(groups.map((g) => g.label)).toEqual(['Scarlet & Violet', 'Other']);
+  });
+
+  it('attaches a dateRange to each group', () => {
+    const groups = prepareGroupedSetsForDropdown({
+      'Sword & Shield': [
+        makeSet({ id: 'a', releaseDate: '2020/02/07' }),
+        makeSet({ id: 'b', releaseDate: '2022/11/11' }),
+      ],
+    });
+    expect(groups[0].dateRange).toBe('2020 – 2022');
+  });
+});

--- a/frontend/src/lib/utils/rarityMap.test.ts
+++ b/frontend/src/lib/utils/rarityMap.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getRarityInfo,
+  getRarityColor,
+  getRarityWeight,
+  isGradientRarity,
+  RARITY_LEGEND,
+} from './rarityMap';
+
+describe('getRarityInfo', () => {
+  it('returns the mapped info for a known rarity', () => {
+    const info = getRarityInfo('Common');
+    expect(info.label).toBe('Common');
+    expect(info.weight).toBe(0);
+    expect(info.color).toBe('var(--rarity-common)');
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(getRarityInfo('  RARE HOLO  ').label).toBe('Rare Holo');
+    expect(getRarityInfo('uLtRa RaRe').label).toBe('Ultra Rare');
+  });
+
+  it('returns the Unknown default for unmapped strings', () => {
+    const info = getRarityInfo('Mythical Sparkle Rare');
+    expect(info.label).toBe('Unknown');
+    expect(info.weight).toBe(-1);
+  });
+
+  it('returns the Unknown default for null, undefined, and empty input', () => {
+    expect(getRarityInfo(null).weight).toBe(-1);
+    expect(getRarityInfo(undefined).weight).toBe(-1);
+    expect(getRarityInfo('').weight).toBe(-1);
+  });
+});
+
+describe('getRarityWeight', () => {
+  it('orders rarities from common to hyper rare', () => {
+    const order = [
+      'Common',
+      'Uncommon',
+      'Rare',
+      'Rare Holo',
+      'Ultra Rare',
+      'Rare Secret',
+      'Hyper Rare',
+    ];
+    const weights = order.map(getRarityWeight);
+    const sorted = [...weights].sort((a, b) => a - b);
+    expect(weights).toEqual(sorted);
+    expect(new Set(weights).size).toBe(weights.length);
+  });
+
+  it('groups aliases into the same tier', () => {
+    expect(getRarityWeight('Holo Rare')).toBe(getRarityWeight('Rare Holo'));
+    expect(getRarityWeight('SIR')).toBe(getRarityWeight('Special Illustration Rare'));
+  });
+});
+
+describe('isGradientRarity', () => {
+  it('is true for special illustration rarities and their aliases', () => {
+    expect(isGradientRarity('Special Illustration Rare')).toBe(true);
+    expect(isGradientRarity('sar')).toBe(true);
+    expect(isGradientRarity('sir')).toBe(true);
+  });
+
+  it('is false for solid-color rarities and unknown input', () => {
+    expect(isGradientRarity('Rare')).toBe(false);
+    expect(isGradientRarity('Hyper Rare')).toBe(false);
+    expect(isGradientRarity(undefined)).toBe(false);
+  });
+});
+
+describe('getRarityColor', () => {
+  it('returns the CSS custom property for the rarity', () => {
+    expect(getRarityColor('Hyper Rare')).toBe('var(--rarity-hyper)');
+    expect(getRarityColor('nonsense')).toBe('var(--rarity-common)');
+  });
+});
+
+describe('RARITY_LEGEND', () => {
+  it('lists entries from most common to rarest', () => {
+    expect(RARITY_LEGEND[0].label).toBe('C');
+    expect(RARITY_LEGEND[RARITY_LEGEND.length - 1].label).toBe('HyR');
+  });
+});


### PR DESCRIPTION
Ports the 46 unit tests from maber-web's `apps/pcpc` (the modules are shared lineage and almost entirely identical) and adds 8 new tests for the backend-toggle health probe.

## Coverage
- `rarityMap` (10), `expansionMapper` (17), server `cache` (7), server `errors` (4), `scrydexApi` mappers (8) — ported as-is (CRLF→LF normalization only)
- `backends/health` (8, new) — `statusFromHttp` mapping, healthy/degraded/unhealthy probe responses, network-error swallowing, abort timeout. Note: HTTP 207 maps to `degraded` with no error message attached (207 is inside `Response.ok`) — documented in a test comment.

## Honesty fix
Removes `--passWithNoTests` from `frontend/package.json` — the test script now fails if the suite ever goes empty.

## Verification
- frontend vitest: 6 files, **54/54 pass**
- frontend eslint/svelte-check: 0 errors (pre-existing warnings unchanged)
- root Jest: 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)