### PR TITLE
fix(frontend): make chart column fill width on mobile

### DIFF
--- a/frontend/src/lib/components/CardResultsPanel.svelte
+++ b/frontend/src/lib/components/CardResultsPanel.svelte
@@ -137,7 +137,8 @@
     .results-header { flex-direction: column; gap: 6px; align-items: center; text-align: center; }
     .header-meta { justify-content: center; }
     .results-layout { flex-direction: column; align-items: center; }
-    .results-sidebar { position: static; }
+    .results-sidebar { position: static; width: 100%; max-width: 260px; }
+    .results-main { width: 100%; min-width: 0; }
   }
 
   @media (max-width: 480px) {

--- a/frontend/src/lib/components/PriceDetailChart.svelte
+++ b/frontend/src/lib/components/PriceDetailChart.svelte
@@ -83,4 +83,5 @@
 
 <style>
   .detail-chart-container { border: 0.5px solid var(--amber-border); border-radius: var(--radius-input); padding: 12px; margin-top: 8px; background-color: rgba(196, 154, 108, 0.02); height: 200px; animation: expand-in 0.25s ease-out; position: relative; }
+  @media (max-width: 768px) { .detail-chart-container { height: 170px; padding: 10px; } }
 </style>


### PR DESCRIPTION
## Problem

On mobile, the price-history charts on the card results view render wider than the viewport, clipping the y-axis price labels on the left and the "Current:" label / Close / Details controls on the right.

**Root cause:** the `@media (max-width: 768px)` rule in `CardResultsPanel.svelte` sets `align-items: center` on `.results-layout`, which overrides flexbox's default `stretch`. As a result `.results-main` — the column holding every chart (`HeroPrice`, `PriceDetailChart`, `CompareChart`, and the `TrendSparkline`s in `PriceCard`) — shrinks to its content instead of filling the column. Chart.js charts (`responsive: true, maintainAspectRatio: false`) then have no definite parent width and blow out wider than the screen. Because the content is centered, the overflow is symmetric, and `html, body { overflow-x: hidden }` turns it into hard clipping rather than a scrollbar.

## Fix

- `.results-main { width: 100%; min-width: 0 }` in the stacked mobile layout — gives Chart.js a definite container width (fixes all four chart/canvas components at once, since they all live inside this column).
- `.results-sidebar { width: 100%; max-width: 260px }` — keeps the card image centered at a comfortable size.
- Added the missing mobile height rule to `PriceDetailChart` (`170px` at `≤768px`) to match the other charts.

No JS / Chart.js config changes — purely a container-width issue.

## Verification

This is the same source change already merged in the maber-web monorepo copy of this frontend (`apps/pcpc`), where it was verified with the real components:

- **390px**: `scrollWidth === viewport` (no overflow); hero chart shows full y-axis labels + "Current:" value; expanded detail chart's Close button fully visible.
- **320px**: no overflow, all 8 canvases fit, CompareChart filters/legend/axes reflow cleanly.
- **Desktop 1280px**: two-column row layout unchanged, no overflow.

This is the repo that deploys `pcpc.maber.io`, so this PR is what ships the fix to production.