### PR TITLE
docs: sync stale docs with current Scrydex three-path state

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All three paths share the same Cosmos DB account and the same TypeScript types v
 
 **Azure** · API Management · Functions v4 · Container Apps + KEDA · Cosmos DB · Redis · Application Insights · Key Vault · Managed Identity · ACR
 
-**IaC + Pipelines** · Terraform (9 modules) · Azure DevOps multi-stage pipelines · ACR-backed CI containers · Static Web Apps
+**IaC + Pipelines** · Terraform (10 modules) · Azure DevOps multi-stage pipelines · ACR-backed CI containers · Static Web Apps
 
 **Architecture / Practice** · ADR-driven design · Repository consolidation via `git filter-repo` · Multi-runtime type sharing · Architectural decision documentation
 
@@ -59,7 +59,7 @@ All three paths share the same Cosmos DB account and the same TypeScript types v
 
 ## Architecture decision records
 
-Decisions live in [`docs/adr/`](docs/adr/). The existing ADRs (001–006) cover earlier infrastructure choices (package manager, runtime, caching, devcontainer, schema, API integration). The three-path portfolio story adds:
+Decisions live in [`docs/adr/`](docs/adr/). The earlier ADRs — [ADR-001](docs/adr/ADR-001-package-manager-standardization.md) (package manager) and [ADR-004](docs/adr/ADR-004-devcontainer-acr-optimization.md) (devcontainer ACR optimization) — cover foundational infrastructure choices. The three-path portfolio story adds:
 
 - **[ADR-007](docs/adr/ADR-007-api-architecture-spectrum.md)** — API architecture spectrum (why three paths exist) *(Accepted, Phase 1)*
 - **[ADR-008](docs/adr/ADR-008-apim-vs-bff-gateway.md)** — APIM vs SvelteKit BFF as gateway *(Accepted, Phase 1)*

--- a/docs/LOCAL_DEVELOPMENT.md
+++ b/docs/LOCAL_DEVELOPMENT.md
@@ -4,25 +4,26 @@ This guide will help you set up and test the Azure Functions backend locally wit
 
 ## Prerequisites
 
-- Node.js (v18 or later)
+- Node.js (v22 or later)
 - Azure Functions Core Tools (`npm install -g azure-functions-core-tools@4 --unsafe-perm true`)
 - Docker (for Cosmos DB Emulator)
-- Valid API keys for PokeData and Pokemon TCG APIs
+- A valid Scrydex API key and team ID
 
 ## Environment Setup
 
 ### 1. Environment Variables
 
-Copy the `.env.example` to `.env` and configure:
+Copy the `local.settings.json.example` to `local.settings.json` and configure:
 
 ```bash
-cp .env.example .env
+cp local.settings.json.example local.settings.json
 ```
 
 Key variables to configure:
 
-- `POKEDATA_API_KEY` - Your PokeData API key
-- `POKEMON_TCG_API_KEY` - Your Pokemon TCG API key
+- `SCRYDEX_API_KEY` - Your Scrydex API key
+- `SCRYDEX_TEAM_ID` - Your Scrydex team ID
+- `SCRYDEX_API_BASE_URL` - Scrydex API base URL (defaults to `https://api.scrydex.com/pokemon/v1`)
 - `COSMOS_DB_CONNECTION_STRING` - Points to local emulator
 - `DEBUG_MODE=true` - Enables enhanced logging
 
@@ -40,7 +41,7 @@ The connection string includes `DisableServerCertificateValidation=true` for the
 ### 3. Install Dependencies
 
 ```bash
-cd app/backend
+cd backend/functions
 npm install
 ```
 
@@ -49,7 +50,7 @@ npm install
 ### Start the Function Runtime
 
 ```bash
-cd app/backend
+cd backend/functions
 func start
 ```
 
@@ -62,19 +63,23 @@ You should see enhanced startup logging showing:
 
 ### Expected Startup Output
 
+Startup logging is emitted through the leveled `logger` in `src/index.ts`. With
+`DEBUG_MODE=true` you will see an environment-variable status block followed by
+service initialization, for example:
+
 ```
-🚀 [STARTUP] Initializing Azure Functions services...
-📊 [STARTUP] Environment: development
-🐛 [STARTUP] Debug Mode: ENABLED
-🔧 [STARTUP] Environment Variables Status:
-  - COSMOS_DB_CONNECTION_STRING: ✅ SET
-  - POKEDATA_API_KEY: ✅ SET
-  - POKEMON_TCG_API_KEY: ✅ SET
-🗄️ [STARTUP] Initializing Cosmos DB Service...
-🔥 [STARTUP] Initializing PokeData API Service...
-🔥 [PokeDataApiService] Base URL: https://www.pokedata.io/v0
-🔥 [PokeDataApiService] API Key: SET (eyJ0eXAiOiJKV1QiLCJh...)
-✅ [STARTUP] All services initialized successfully!
+[INFO] Initializing Azure Functions services (env: development)
+[DEBUG] Environment variable status {
+  COSMOS_DB_CONNECTION_STRING: true,
+  COSMOS_DB_DATABASE_NAME: 'PokemonCards',
+  COSMOS_DB_CARDS_CONTAINER_NAME: 'Cards',
+  COSMOS_DB_SETS_CONTAINER_NAME: 'Sets',
+  SCRYDEX_API_KEY: true,
+  SCRYDEX_TEAM_ID: true,
+  SCRYDEX_API_BASE_URL: 'https://api.scrydex.com/pokemon/v1',
+  REDIS_CACHE_ENABLED: false
+}
+[INFO] All services initialized
 ```
 
 ## Testing the Functions
@@ -89,19 +94,12 @@ chmod +x test-endpoints.sh
 ./test-endpoints.sh
 ```
 
-### Option 2: Node.js Test Runner
+### Option 2: Manual cURL Testing
 
 ```bash
-# Install axios if not already installed
-npm install axios
+# Health check
+curl http://localhost:7071/api/health
 
-# Run tests
-node test-runner.js
-```
-
-### Option 3: Manual cURL Testing
-
-```bash
 # Basic sets endpoint
 curl http://localhost:7071/api/sets
 
@@ -129,17 +127,15 @@ curl "http://localhost:7071/api/sets?all=true"
 
 ### Example API Call Logs
 
+External data is fetched through `ScrydexApiService`. With debug logging enabled,
+outbound calls and their responses are logged (URLs and timing logged; the API
+key and team ID are never printed), for example:
+
 ```
-🔥 [PokeDataApiService] Getting all sets - START
-🔥 [PokeDataApiService] Making HTTP GET request:
-🔥 [PokeDataApiService]   URL: https://www.pokedata.io/v0/sets
-🔥 [PokeDataApiService]   Headers: {"Authorization":"Bearer eyJ0eXAiOiJKV1QiLCJh...","Content-Type":"application/json"}
-🔥 [PokeDataApiService] Response received (156ms):
-🔥 [PokeDataApiService]   Status: 200 OK
-🔥 [PokeDataApiService]   Content-Type: application/json
-🔥 [PokeDataApiService]   Data type: object
-🔥 [PokeDataApiService]   Data is array: true
-🔥 [PokeDataApiService] Successfully retrieved 245 sets
+[INFO] [ScrydexApiService] Getting all sets
+[DEBUG] [ScrydexApiService] GET https://api.scrydex.com/pokemon/v1/sets
+[DEBUG] [ScrydexApiService] Response 200 OK (156ms)
+[INFO] [ScrydexApiService] Retrieved 245 sets
 ```
 
 ## Troubleshooting
@@ -149,7 +145,7 @@ curl "http://localhost:7071/api/sets?all=true"
 #### 1. 500 Internal Server Error
 
 - Check the function logs for detailed error information
-- Verify API keys are correctly set in `.env`
+- Verify API keys are correctly set in `local.settings.json`
 - Ensure Cosmos DB emulator is running and accessible
 
 #### 2. Connection Refused
@@ -160,18 +156,18 @@ curl "http://localhost:7071/api/sets?all=true"
 
 #### 3. API Authentication Errors
 
-- Verify `POKEDATA_API_KEY` is valid and not expired
-- Check API key format (should be a JWT token)
-- Test API key directly with curl:
+- Verify `SCRYDEX_API_KEY` and `SCRYDEX_TEAM_ID` are valid and not expired
+- Confirm `SCRYDEX_API_BASE_URL` points at the correct Scrydex endpoint
+- Test the API key directly with curl:
   ```bash
-  curl -H "Authorization: Bearer YOUR_API_KEY" https://www.pokedata.io/v0/sets
+  curl -H "X-Api-Key: YOUR_API_KEY" -H "X-Team-ID: YOUR_TEAM_ID" https://api.scrydex.com/pokemon/v1/sets
   ```
 
 #### 4. Cosmos DB Connection Issues
 
 - Verify emulator is running: `curl -k https://cosmosdb-emulator:8081/`
 - Check connection string includes `DisableServerCertificateValidation=true`
-- Ensure database `pokedata` and container `cards` exist
+- Ensure database `PokemonCards` and containers `Cards`/`Sets` exist
 
 ### Debug Mode Features
 
@@ -219,14 +215,12 @@ Once local development is working:
 ## File Structure
 
 ```
-app/backend/
-├── .env                    # Environment variables
-├── test-endpoints.sh       # Bash test script
-├── test-runner.js         # Node.js test runner
-├── LOCAL_DEVELOPMENT.md   # This guide
+backend/functions/
+├── local.settings.json          # Local config (gitignored)
+├── local.settings.json.example  # Config template
 ├── src/
-│   ├── index.ts           # Enhanced service initialization
-│   ├── functions/         # Function implementations
-│   └── services/          # Enhanced API services
+│   ├── index.ts                 # Service initialization + function registration
+│   ├── functions/               # Function implementations
+│   └── services/                # API and data services
 └── package.json
 ```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,11 +23,7 @@ Each ADR follows a standardized format:
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
 | [ADR-001](./ADR-001-package-manager-standardization.md) | Package Manager Standardization | Accepted | 2025-09-22 |
-| [ADR-002](./ADR-002-nodejs-runtime-modernization.md) | Node.js Runtime Modernization | Accepted | 2025-09-22 |
-| [ADR-003](./ADR-003-caching-architecture-design.md) | Caching Architecture Design | Accepted | 2025-09-22 |
 | [ADR-004](./ADR-004-devcontainer-acr-optimization.md) | DevContainer ACR Optimization | Accepted | 2025-09-28 |
-| [ADR-005](./ADR-005-database-schema-design.md) | Database Schema Design | Accepted | 2025-09-28 |
-| [ADR-006](./ADR-006-api-integration-strategy.md) | API Integration Strategy | Accepted | 2025-09-22 |
 | [ADR-007](./ADR-007-api-architecture-spectrum.md) | API Architecture Spectrum (three paths) | Accepted | 2026-05-06 |
 | [ADR-008](./ADR-008-apim-vs-bff-gateway.md) | APIM vs SvelteKit BFF as Gateway | Accepted | 2026-05-06 |
 | [ADR-009](./ADR-009-functions-consumption-vs-container-apps.md) | Functions Consumption vs Container Apps | Accepted | 2026-05-12 |
@@ -41,7 +37,7 @@ These ADRs document the architectural reasoning behind PCPC's three-path deploym
 
 | ADR | Title | Phase | Status |
 |-----|-------|-------|--------|
-| [ADR-010](./ADR-010-path-to-aks.md) | Path to AKS (speculative) | 3 (optional) | Planned |
+| ADR-010 — Path to AKS (speculative) *(not yet written)* | Path to AKS (speculative) | 3 (optional) | Planned |
 
 ## Decision Process
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,17 +17,16 @@
 
 ## API Overview
 
-The PCPC API provides RESTful endpoints for accessing Pokemon card data, pricing information, and set metadata. The API is built on Azure Functions v4 with Node.js 22 LTS and follows OpenAPI 3.0 specifications.
+The PCPC API provides RESTful endpoints for accessing Pokemon card data, pricing information, and set metadata. All card, set, and pricing data originates from the [Scrydex](https://scrydex.com) API and is persisted in Cosmos DB and (optionally) cached in Redis. The HTTP API is implemented as Azure Functions v4 on Node.js 22 LTS and is described by an OpenAPI 3.0 contract published through Azure API Management (APIM).
 
 ### API Features
 
-- **RESTful Design**: Standard HTTP methods and status codes
-- **JSON Responses**: All responses in JSON format with consistent structure
-- **Comprehensive Data**: Card metadata, pricing, images, and set information
-- **Performance Optimized**: Multi-tier caching for sub-second response times
-- **Error Handling**: Detailed error responses with actionable information
-- **Rate Limiting**: Fair usage policies with clear limits
-- **Versioning**: API versioning for backward compatibility
+- **RESTful Design**: Standard HTTP methods (read-only `GET`) and status codes
+- **JSON Responses**: All responses use a single consistent envelope
+- **Scrydex-native Data**: Card metadata, multi-condition/graded pricing, images, and set information sourced from Scrydex
+- **Performance Optimized**: Redis + Cosmos DB caching with a 12-hour background refresh timer
+- **Error Handling**: Flat, consistent error envelope
+- **Gateway Rate Limiting**: Fair usage enforced at the APIM gateway
 
 ### API Architecture
 
@@ -35,106 +34,140 @@ The PCPC API provides RESTful endpoints for accessing Pokemon card data, pricing
 graph TB
     subgraph "Client Applications"
         WEB[Web Frontend]
-        MOBILE[Mobile Apps]
         THIRD_PARTY[Third-party Integrations]
     end
 
-    subgraph "API Gateway"
-        APIM[Azure API Management<br/>Rate Limiting & Authentication]
-        CACHE[Response Cache<br/>5-60 minute TTL]
+    subgraph "API Gateway (Path B)"
+        APIM[Azure API Management<br/>Subscription Keys, Rate Limiting, CORS]
     end
 
-    subgraph "Backend Services"
-        FUNCTIONS[Azure Functions v4<br/>Business Logic]
-        SERVICES[Service Layer<br/>Data Processing]
+    subgraph "Backends"
+        SVELTE[SvelteKit BFF<br/>Path A: /api/* routes]
+        FUNCTIONS[Azure Functions v4<br/>Paths B/C: business logic]
     end
 
-    subgraph "Data Sources"
+    subgraph "Data & Cache"
+        REDIS[Redis Cache<br/>optional]
         COSMOS[Cosmos DB<br/>Primary Data Store]
-        POKEDATA[PokeData API<br/>Pricing Data]
-        POKEMONTCG[Pokemon TCG API<br/>Metadata]
+        SCRYDEX[Scrydex API<br/>Source of Truth]
     end
 
+    WEB --> SVELTE
     WEB --> APIM
-    MOBILE --> APIM
     THIRD_PARTY --> APIM
 
-    APIM --> CACHE
-    CACHE --> FUNCTIONS
-    FUNCTIONS --> SERVICES
-
-    SERVICES --> COSMOS
-    SERVICES --> POKEDATA
-    SERVICES --> POKEMONTCG
+    APIM --> FUNCTIONS
+    SVELTE --> REDIS
+    SVELTE --> COSMOS
+    SVELTE --> SCRYDEX
+    FUNCTIONS --> REDIS
+    FUNCTIONS --> COSMOS
+    FUNCTIONS --> SCRYDEX
 ```
+
+### Request paths
+
+The same logical endpoints are served by more than one runtime:
+
+- **Path A — SvelteKit BFF**: server routes under `/api/*` in the frontend app. Calls Scrydex/Cosmos/Redis directly.
+- **Path B — Azure Functions behind APIM**: the OpenAPI contract published at `*.azure-api.net/pokedata-api`. APIM provides subscription-key auth, rate limiting, the developer portal, and observability.
+- **Path C — Azure Functions on Azure Container Apps**: the same Functions code, fronted by ACA ingress (CORS) instead of APIM.
+
+The Azure Functions host registers its routes with the `api` route prefix (`backend/functions/host.json`), so all Functions endpoints live under `/api`. The Functions read endpoints use `authLevel: "anonymous"` — authentication is enforced at the gateway, not the function host.
+
+Response shapes are nearly identical across paths; the only meaningful difference is the health endpoint envelope (see [Health Check](#health-check)).
 
 ## Authentication
 
-### Subscription Key Authentication
+### Subscription Key Authentication (APIM gateway)
 
-The PCPC API uses subscription key authentication through Azure API Management. All requests must include a valid subscription key.
+The Azure Functions HTTP triggers are registered with `authLevel: "anonymous"`; there is no function-key check at the host. Authentication is enforced **at the Azure API Management gateway** (Path B). All requests through APIM must include a valid subscription key, supplied either as a header (recommended) or a query parameter.
 
 #### Header Authentication (Recommended)
 
 ```http
-GET /api/sets
-Host: api.pcpc.example.com
+GET /pokedata-api/sets
+Host: maber-apim-prod.azure-api.net
 Ocp-Apim-Subscription-Key: your-subscription-key-here
 ```
 
 #### Query Parameter Authentication
 
 ```http
-GET /api/sets?subscription-key=your-subscription-key-here
-Host: api.pcpc.example.com
+GET /pokedata-api/sets?subscription-key=your-subscription-key-here
+Host: maber-apim-prod.azure-api.net
 ```
 
-### Obtaining API Keys
+> Both schemes are defined in the OpenAPI contract (`apim/specs/pcpc-api-v1.yaml`): `apiKeyHeader` (`Ocp-Apim-Subscription-Key`) and `apiKeyQuery` (`subscription-key`).
 
-1. **Starter Product**: Basic access with standard rate limits
-
-   - **Rate Limit**: 300 calls per 60 seconds
-   - **Features**: All public endpoints
-   - **Cost**: Free
-
-2. **Premium Product**: Enhanced access with higher limits
-   - **Rate Limit**: 1000 calls per 60 seconds
-   - **Features**: All endpoints + priority support
-   - **Cost**: Contact for pricing
-
-### Future Authentication Methods
-
-- **OAuth 2.0**: User authentication for personalized features
-- **JWT Tokens**: Stateless authentication for mobile apps
-- **Certificate-based**: High-security scenarios
+When calling the Azure Functions host directly (local development, or Path C via ACA ingress), no subscription key is required because the function endpoints are anonymous. CORS and rate limiting are then handled by the relevant gateway/ingress rather than the function code.
 
 ## Base URLs
 
-### Production Environment
+### APIM Gateway (Path B)
+
+The APIM base path is `/pokedata-api` (no `/api` or version segment). From `apim/specs/pcpc-api-v1.yaml`:
 
 ```
-https://api.pcpc.example.com/api/v1
+https://maber-apim-test.azure-api.net/pokedata-api      (development)
+https://maber-apim-staging.azure-api.net/pokedata-api   (staging)
+https://maber-apim-prod.azure-api.net/pokedata-api      (production)
 ```
 
-### Development Environment
+### Azure Functions (local development)
 
-```
-https://api-dev.pcpc.example.com/api/v1
-```
-
-### Local Development
+Functions run locally with the `api` route prefix:
 
 ```
 http://localhost:7071/api
 ```
 
+### SvelteKit BFF (Path A)
+
+Served from the frontend application origin under `/api`, e.g. `https://<frontend-host>/api`.
+
+> Endpoint paths below are written relative to the chosen base URL (e.g. `/sets` is `https://maber-apim-prod.azure-api.net/pokedata-api/sets` via APIM, or `http://localhost:7071/api/sets` locally).
+
 ## API Endpoints
 
-### Sets Endpoints
+All endpoints are `GET` only. There are exactly four:
 
-#### Get All Sets
+| Method | Path                            | Description                       |
+| ------ | ------------------------------- | --------------------------------- |
+| GET    | `/sets`                         | List Pokemon card sets            |
+| GET    | `/sets/{setId}/cards`           | List cards for a set              |
+| GET    | `/sets/{setId}/cards/{cardId}`  | Get a single card with pricing    |
+| GET    | `/health`                       | Service and dependency health     |
 
-Retrieve a paginated list of Pokemon card sets with optional filtering.
+### Response Envelope
+
+Every successful response uses the same envelope (`ApiResponse<T>` in `backend/shared/src/types/envelopes.ts`, produced by `apiSuccess` in `frontend/src/lib/server/utils/errors.ts`):
+
+```json
+{
+  "status": 200,
+  "data": {  },
+  "timestamp": "2025-06-16T10:30:00.000Z",
+  "cached": true,
+  "cacheAge": 300
+}
+```
+
+| Field       | Type    | Notes                                                          |
+| ----------- | ------- | -------------------------------------------------------------- |
+| `status`    | integer | HTTP status code, mirrored in the body                         |
+| `data`      | object  | Endpoint-specific payload                                      |
+| `timestamp` | string  | ISO 8601 response time                                         |
+| `cached`    | boolean | Whether the payload was served from cache                      |
+| `cacheAge`  | integer | Age of cached data in seconds (present only on cache hits)     |
+
+> There is **no** top-level `success` field and **no** `version` field on data responses.
+
+---
+
+### Get Set List
+
+Retrieve a list of Pokemon card sets. Results are sorted by release date (newest first) and annotated with `releaseYear` and `isRecent`.
 
 ```http
 GET /sets
@@ -142,18 +175,19 @@ GET /sets
 
 **Query Parameters:**
 
-| Parameter | Type    | Required | Default | Description                        |
-| --------- | ------- | -------- | ------- | ---------------------------------- |
-| `page`    | integer | No       | 1       | Page number for pagination         |
-| `limit`   | integer | No       | 20      | Number of sets per page (max 100)  |
-| `series`  | string  | No       | -       | Filter by series name              |
-| `recent`  | boolean | No       | false   | Show only recent sets              |
-| `all`     | boolean | No       | false   | Return all sets without pagination |
+| Parameter  | Type    | Required | Default | Description                                                            |
+| ---------- | ------- | -------- | ------- | ---------------------------------------------------------------------- |
+| `language` | string  | No       | `en`    | Language code used to query Scrydex expansions (lowercased)            |
+| `all`      | boolean | No       | `false` | When `true`, return all sets without pagination                        |
+| `page`     | integer | No       | `1`     | Page number for pagination                                             |
+| `pageSize` | integer | No       | `100`   | Number of sets per page                                                |
+
+> There is no client-controllable cache-bypass parameter. Freshness comes from language-keyed cache keys, the 12-hour `RefreshData` timer, and the Redis TTL.
 
 **Example Request:**
 
 ```http
-GET /sets?page=1&limit=10&series=Base
+GET /sets?page=1&pageSize=2&language=en
 Ocp-Apim-Subscription-Key: your-key-here
 ```
 
@@ -161,105 +195,49 @@ Ocp-Apim-Subscription-Key: your-key-here
 
 ```json
 {
-  "success": true,
+  "status": 200,
   "data": {
     "sets": [
       {
-        "id": "base1",
-        "series": "Base",
-        "name": "Base Set",
-        "releaseDate": "1999-01-09",
-        "totalCards": 102,
-        "symbolUrl": "https://images.pokemontcg.io/base1/symbol.png",
-        "logoUrl": "https://images.pokemontcg.io/base1/logo.png",
-        "isRecent": false,
-        "metadata": {
-          "source": "pokemontcg",
-          "lastUpdated": "2025-09-28T21:00:00Z"
-        }
+        "id": "sv8",
+        "code": "sv8",
+        "name": "Surging Sparks",
+        "series": "Scarlet & Violet",
+        "releaseDate": "2024-11-08",
+        "total": 252,
+        "printedTotal": 191,
+        "language": "English",
+        "languageCode": "EN",
+        "isOnlineOnly": false,
+        "logo": "https://images.scrydex.com/sv8/logo",
+        "symbol": "https://images.scrydex.com/sv8/symbol",
+        "cardCount": 252,
+        "isCurrent": true,
+        "lastUpdated": "2025-06-16T09:00:00.000Z",
+        "releaseYear": 2024,
+        "isRecent": true
       }
     ],
     "pagination": {
-      "currentPage": 1,
-      "totalPages": 15,
-      "totalSets": 142,
-      "hasNext": true,
-      "hasPrevious": false
+      "page": 1,
+      "pageSize": 2,
+      "totalCount": 150,
+      "totalPages": 75
     }
   },
-  "timestamp": "2025-09-28T21:00:00Z",
-  "version": "1.0.0"
+  "timestamp": "2025-06-16T10:30:00.000Z",
+  "cached": true,
+  "cacheAge": 300
 }
 ```
 
-**Response Codes:**
+**Response Codes:** `200` OK, `404` no sets found for the language, `500` server error. (Through APIM: `401` for a missing/invalid subscription key, `429` when rate-limited.)
 
-- `200 OK`: Successful response
-- `400 Bad Request`: Invalid query parameters
-- `401 Unauthorized`: Missing or invalid API key
-- `429 Too Many Requests`: Rate limit exceeded
-- `500 Internal Server Error`: Server error
+---
 
-#### Get Set by ID
+### Get Cards By Set
 
-Retrieve detailed information about a specific Pokemon card set.
-
-```http
-GET /sets/{setId}
-```
-
-**Path Parameters:**
-
-| Parameter | Type   | Required | Description                   |
-| --------- | ------ | -------- | ----------------------------- |
-| `setId`   | string | Yes      | Unique identifier for the set |
-
-**Example Request:**
-
-```http
-GET /sets/base1
-Ocp-Apim-Subscription-Key: your-key-here
-```
-
-**Example Response:**
-
-```json
-{
-  "success": true,
-  "data": {
-    "id": "base1",
-    "series": "Base",
-    "name": "Base Set",
-    "releaseDate": "1999-01-09",
-    "totalCards": 102,
-    "symbolUrl": "https://images.pokemontcg.io/base1/symbol.png",
-    "logoUrl": "https://images.pokemontcg.io/base1/logo.png",
-    "isRecent": false,
-    "cards": {
-      "total": 102,
-      "breakdown": {
-        "Common": 32,
-        "Uncommon": 32,
-        "Rare": 16,
-        "Rare Holo": 16,
-        "Energy": 6
-      }
-    },
-    "metadata": {
-      "source": "pokemontcg",
-      "lastUpdated": "2025-09-28T21:00:00Z"
-    }
-  },
-  "timestamp": "2025-09-28T21:00:00Z",
-  "version": "1.0.0"
-}
-```
-
-### Cards Endpoints
-
-#### Get Cards by Set
-
-Retrieve all cards from a specific Pokemon card set with optional filtering and pagination.
+Retrieve the cards belonging to a set, with pricing. Results are paginated in-memory after the full set is loaded from cache/Cosmos/Scrydex.
 
 ```http
 GET /sets/{setId}/cards
@@ -267,24 +245,25 @@ GET /sets/{setId}/cards
 
 **Path Parameters:**
 
-| Parameter | Type   | Required | Description                   |
-| --------- | ------ | -------- | ----------------------------- |
-| `setId`   | string | Yes      | Unique identifier for the set |
+| Parameter | Type   | Required | Description                  |
+| --------- | ------ | -------- | ---------------------------- |
+| `setId`   | string | Yes      | Set identifier (e.g. `sv8`)  |
+
+> The published OpenAPI contract names this path segment `setCode`; the Azure Functions route binds it as `setId`. They refer to the same value.
 
 **Query Parameters:**
 
-| Parameter        | Type    | Required | Default | Description                         |
-| ---------------- | ------- | -------- | ------- | ----------------------------------- |
-| `page`           | integer | No       | 1       | Page number for pagination          |
-| `limit`          | integer | No       | 20      | Number of cards per page (max 100)  |
-| `rarity`         | string  | No       | -       | Filter by card rarity               |
-| `name`           | string  | No       | -       | Search by card name (partial match) |
-| `includePricing` | boolean | No       | true    | Include pricing information         |
+| Parameter  | Type    | Required | Default | Description                                       |
+| ---------- | ------- | -------- | ------- | ------------------------------------------------- |
+| `page`     | integer | No       | `1`     | Page number (must be `>= 1`)                      |
+| `pageSize` | integer | No       | `500`   | Cards per page, capped at `500` (must be `>= 1`)  |
+
+> No other query parameters are supported (no `rarity`, `name`, `includePricing`, etc.). There is no client-controllable cache-bypass parameter.
 
 **Example Request:**
 
 ```http
-GET /sets/base1/cards?page=1&limit=5&rarity=Rare%20Holo
+GET /sets/sv8/cards?page=1&pageSize=2
 Ocp-Apim-Subscription-Key: your-key-here
 ```
 
@@ -292,50 +271,74 @@ Ocp-Apim-Subscription-Key: your-key-here
 
 ```json
 {
-  "success": true,
+  "status": 200,
   "data": {
-    "setId": "base1",
-    "setName": "Base Set",
     "cards": [
       {
-        "id": "base1-1",
+        "id": "sv8-001",
+        "name": "Exeggcute",
+        "number": "1",
         "cardNumber": "1",
-        "name": "Alakazam",
-        "rarity": "Rare Holo",
-        "images": {
-          "small": "https://images.pokemontcg.io/base1/1.png",
-          "large": "https://images.pokemontcg.io/base1/1_hires.png"
-        },
-        "pricing": {
-          "market": 45.5,
-          "low": 35.0,
-          "mid": 45.5,
-          "high": 65.0,
-          "lastUpdated": "2025-09-28T20:30:00Z"
-        },
-        "metadata": {
-          "tcgSetId": "base1",
-          "pokeDataId": "base-set-alakazam-1",
-          "lastSync": "2025-09-28T21:00:00Z"
-        }
+        "printedNumber": "001",
+        "rarity": "Common",
+        "rarityCode": "C",
+        "artist": "Sumiyoshi Kizuki",
+        "images": [
+          {
+            "type": "front",
+            "small": "https://images.scrydex.com/sv8/sv8-001/small",
+            "medium": "https://images.scrydex.com/sv8/sv8-001/medium",
+            "large": "https://images.scrydex.com/sv8/sv8-001/large"
+          }
+        ],
+        "variants": [
+          {
+            "name": "Normal",
+            "prices": [
+              {
+                "condition": "NM",
+                "type": "raw",
+                "isPerfect": false,
+                "isError": false,
+                "isSigned": false,
+                "low": 0.05,
+                "mid": 0.12,
+                "high": 0.5,
+                "market": 0.1,
+                "currency": "USD",
+                "trends": {
+                  "days7": { "priceChange": -0.01, "percentChange": -9.1 },
+                  "days30": { "priceChange": 0.02, "percentChange": 25.0 }
+                }
+              }
+            ]
+          }
+        ],
+        "setCode": "sv8",
+        "setId": "sv8",
+        "setName": "Surging Sparks",
+        "pricingLastUpdated": "2025-06-16T09:00:00.000Z"
       }
     ],
     "pagination": {
-      "currentPage": 1,
-      "totalPages": 4,
-      "totalCards": 16,
-      "hasNext": true,
-      "hasPrevious": false
+      "page": 1,
+      "pageSize": 2,
+      "totalCount": 252,
+      "totalPages": 126
     }
   },
-  "timestamp": "2025-09-28T21:00:00Z",
-  "version": "1.0.0"
+  "timestamp": "2025-06-16T10:30:00.000Z",
+  "cached": false
 }
 ```
 
-#### Get Card Details
+**Response Codes:** `200` OK, `400` missing/invalid `setId` or pagination params, `404` no cards for the set, `500` server error.
 
-Retrieve detailed information about a specific Pokemon card including pricing and variants.
+---
+
+### Get Card Info
+
+Retrieve a single card by set and card identifier, including its variants and pricing. If the cached/stored card lacks pricing, the service re-fetches it from Scrydex with prices.
 
 ```http
 GET /sets/{setId}/cards/{cardId}
@@ -345,21 +348,15 @@ GET /sets/{setId}/cards/{cardId}
 
 | Parameter | Type   | Required | Description                    |
 | --------- | ------ | -------- | ------------------------------ |
-| `setId`   | string | Yes      | Unique identifier for the set  |
-| `cardId`  | string | Yes      | Unique identifier for the card |
+| `setId`   | string | Yes      | Set identifier (e.g. `sv8`)    |
+| `cardId`  | string | Yes      | Card identifier (e.g. `sv8-001`) |
 
-**Query Parameters:**
-
-| Parameter         | Type    | Required | Default | Description                               |
-| ----------------- | ------- | -------- | ------- | ----------------------------------------- |
-| `includePricing`  | boolean | No       | true    | Include detailed pricing information      |
-| `includeVariants` | boolean | No       | false   | Include card variants (1st Edition, etc.) |
-| `priceHistory`    | boolean | No       | false   | Include price history data                |
+**Query Parameters:** None.
 
 **Example Request:**
 
 ```http
-GET /sets/base1/cards/base1-1?includePricing=true&includeVariants=true
+GET /sets/sv8/cards/sv8-001
 Ocp-Apim-Subscription-Key: your-key-here
 ```
 
@@ -367,422 +364,350 @@ Ocp-Apim-Subscription-Key: your-key-here
 
 ```json
 {
-  "success": true,
+  "status": 200,
   "data": {
-    "id": "base1-1",
-    "setId": "base1",
-    "setName": "Base Set",
+    "id": "sv8-001",
+    "name": "Exeggcute",
+    "number": "1",
     "cardNumber": "1",
-    "name": "Alakazam",
-    "rarity": "Rare Holo",
-    "type": "Psychic",
-    "hp": 80,
-    "images": {
-      "small": "https://images.pokemontcg.io/base1/1.png",
-      "large": "https://images.pokemontcg.io/base1/1_hires.png"
-    },
-    "pricing": {
-      "normal": {
-        "market": 45.5,
-        "low": 35.0,
-        "mid": 45.5,
-        "high": 65.0,
-        "lastUpdated": "2025-09-28T20:30:00Z"
-      },
-      "holofoil": {
-        "market": 85.0,
-        "low": 70.0,
-        "mid": 85.0,
-        "high": 120.0,
-        "lastUpdated": "2025-09-28T20:30:00Z"
+    "printedNumber": "001",
+    "rarity": "Common",
+    "rarityCode": "C",
+    "artist": "Sumiyoshi Kizuki",
+    "images": [
+      {
+        "type": "front",
+        "small": "https://images.scrydex.com/sv8/sv8-001/small",
+        "medium": "https://images.scrydex.com/sv8/sv8-001/medium",
+        "large": "https://images.scrydex.com/sv8/sv8-001/large"
       }
-    },
+    ],
     "variants": [
       {
-        "type": "1st Edition",
-        "available": false,
-        "reason": "Not available for Base Set"
-      },
-      {
-        "type": "Shadowless",
-        "available": true,
-        "pricing": {
-          "market": 125.0,
-          "low": 100.0,
-          "mid": 125.0,
-          "high": 180.0
-        }
+        "name": "Normal",
+        "prices": [
+          {
+            "condition": "NM",
+            "type": "raw",
+            "isPerfect": false,
+            "isError": false,
+            "isSigned": false,
+            "low": 0.05,
+            "mid": 0.12,
+            "high": 0.5,
+            "market": 0.1,
+            "currency": "USD"
+          },
+          {
+            "condition": "Graded",
+            "type": "graded",
+            "company": "PSA",
+            "grade": "10",
+            "isPerfect": true,
+            "isError": false,
+            "isSigned": false,
+            "low": 20.0,
+            "mid": 28.5,
+            "high": 40.0,
+            "market": 30.0,
+            "currency": "USD"
+          }
+        ]
       }
     ],
-    "metadata": {
-      "tcgSetId": "base1",
-      "pokeDataId": "base-set-alakazam-1",
-      "lastSync": "2025-09-28T21:00:00Z"
-    }
+    "setCode": "sv8",
+    "setId": "sv8",
+    "setName": "Surging Sparks",
+    "pricingLastUpdated": "2025-06-16T09:00:00.000Z"
   },
-  "timestamp": "2025-09-28T21:00:00Z",
-  "version": "1.0.0"
+  "timestamp": "2025-06-16T10:30:00.000Z",
+  "cached": false
 }
 ```
 
-### Search Endpoints
+**Response Codes:** `200` OK, `400` missing/empty identifiers, `404` card not found, `500` server error.
 
-#### Search Cards
+---
 
-Search for Pokemon cards across all sets with advanced filtering options.
+### Health Check
 
-```http
-GET /search/cards
-```
-
-**Query Parameters:**
-
-| Parameter   | Type    | Required | Default   | Description                           |
-| ----------- | ------- | -------- | --------- | ------------------------------------- |
-| `q`         | string  | Yes      | -         | Search query (card name, set, etc.)   |
-| `page`      | integer | No       | 1         | Page number for pagination            |
-| `limit`     | integer | No       | 20        | Number of results per page (max 100)  |
-| `rarity`    | string  | No       | -         | Filter by rarity                      |
-| `series`    | string  | No       | -         | Filter by series                      |
-| `type`      | string  | No       | -         | Filter by Pokemon type                |
-| `minPrice`  | number  | No       | -         | Minimum price filter                  |
-| `maxPrice`  | number  | No       | -         | Maximum price filter                  |
-| `sortBy`    | string  | No       | relevance | Sort by: relevance, name, price, date |
-| `sortOrder` | string  | No       | asc       | Sort order: asc, desc                 |
-
-**Example Request:**
-
-```http
-GET /search/cards?q=Charizard&rarity=Rare%20Holo&minPrice=50&sortBy=price&sortOrder=desc
-Ocp-Apim-Subscription-Key: your-key-here
-```
-
-**Example Response:**
-
-```json
-{
-  "success": true,
-  "data": {
-    "query": "Charizard",
-    "filters": {
-      "rarity": "Rare Holo",
-      "minPrice": 50
-    },
-    "results": [
-      {
-        "id": "base1-4",
-        "setId": "base1",
-        "setName": "Base Set",
-        "cardNumber": "4",
-        "name": "Charizard",
-        "rarity": "Rare Holo",
-        "images": {
-          "small": "https://images.pokemontcg.io/base1/4.png",
-          "large": "https://images.pokemontcg.io/base1/4_hires.png"
-        },
-        "pricing": {
-          "market": 350.0,
-          "low": 280.0,
-          "mid": 350.0,
-          "high": 450.0,
-          "lastUpdated": "2025-09-28T20:30:00Z"
-        },
-        "relevanceScore": 0.95
-      }
-    ],
-    "pagination": {
-      "currentPage": 1,
-      "totalPages": 3,
-      "totalResults": 25,
-      "hasNext": true,
-      "hasPrevious": false
-    }
-  },
-  "timestamp": "2025-09-28T21:00:00Z",
-  "version": "1.0.0"
-}
-```
-
-### Health and Status Endpoints
-
-#### API Health Check
-
-Check the health and status of the API and its dependencies.
+Check the health of the service and its runtime dependencies.
 
 ```http
 GET /health
 ```
 
-**Example Response:**
+**Status codes:** `200` (all healthy), `207` (one or more components degraded), `503` (a component is unhealthy).
+
+The dependencies reported are `runtime`, `cosmosdb` (when a Cosmos connection string is configured), `scrydexApi` (when a Scrydex API key is configured), and `redis` (reported as `disabled` when Redis caching is off).
+
+> **Path difference:** the health endpoint is the one place the envelope differs between runtimes. The Azure Functions response (Paths B/C) nests components under `checks` and includes `version` and `environment`. The SvelteKit BFF (Path A) nests them under `components` and omits `version`/`environment`. The health endpoint does **not** use the standard `ApiResponse` envelope.
+
+**Example Response (Azure Functions — Paths B/C):**
 
 ```json
 {
-  "success": true,
-  "data": {
-    "status": "healthy",
-    "version": "1.0.0",
-    "timestamp": "2025-09-28T21:00:00Z",
-    "dependencies": {
-      "cosmosDb": {
-        "status": "healthy",
-        "responseTime": "45ms"
-      },
-      "pokeDataApi": {
-        "status": "healthy",
-        "responseTime": "120ms"
-      },
-      "pokemonTcgApi": {
-        "status": "healthy",
-        "responseTime": "95ms"
-      },
-      "redisCache": {
-        "status": "optional",
-        "responseTime": "N/A"
-      }
+  "status": "healthy",
+  "timestamp": "2025-06-16T10:30:00.000Z",
+  "checks": {
+    "runtime": {
+      "status": "healthy",
+      "responseTime": 0,
+      "message": "Function runtime operational",
+      "lastChecked": "2025-06-16T10:30:00.000Z"
+    },
+    "cosmosdb": {
+      "status": "healthy",
+      "responseTime": 45,
+      "message": "Cosmos DB connection successful",
+      "lastChecked": "2025-06-16T10:30:00.000Z"
+    },
+    "scrydexApi": {
+      "status": "healthy",
+      "responseTime": 120,
+      "message": "Scrydex API accessible",
+      "lastChecked": "2025-06-16T10:30:00.000Z"
+    },
+    "redis": {
+      "status": "disabled",
+      "message": "Redis caching is disabled"
     }
+  },
+  "version": "1.0.0",
+  "environment": "production"
+}
+```
+
+**Example Response (SvelteKit BFF — Path A):**
+
+```json
+{
+  "status": "healthy",
+  "timestamp": "2025-06-16T10:30:00.000Z",
+  "components": {
+    "runtime": { "status": "healthy", "latency": 0, "message": "Function runtime operational" },
+    "cosmosdb": { "status": "healthy", "latency": 45, "message": "Cosmos DB connection successful" },
+    "scrydexApi": { "status": "healthy", "latency": 120, "message": "Scrydex API accessible" },
+    "redis": { "status": "disabled", "message": "Redis caching is disabled" }
   }
 }
 ```
 
-#### API Statistics
-
-Get usage statistics and performance metrics for the API.
-
-```http
-GET /stats
-```
-
-**Example Response:**
-
-```json
-{
-  "success": true,
-  "data": {
-    "requests": {
-      "total": 1250000,
-      "today": 15000,
-      "lastHour": 850
-    },
-    "performance": {
-      "averageResponseTime": "245ms",
-      "p95ResponseTime": "450ms",
-      "p99ResponseTime": "850ms"
-    },
-    "cacheHitRate": 0.85,
-    "errorRate": 0.002,
-    "uptime": "99.95%"
-  },
-  "timestamp": "2025-09-28T21:00:00Z",
-  "version": "1.0.0"
-}
-```
+Component `status` values are `healthy`, `degraded`, `unhealthy`, or `disabled`.
 
 ## Data Models
+
+All models below are camelCase canonical shapes mapped from Scrydex at the service boundary (`backend/functions/src/utils/scrydexToCosmos.ts`). The on-wire card shape is produced by `cardToApiResponse` (`backend/functions/src/utils/cardToApiResponse.ts`); the SvelteKit BFF applies the same mapping (`cardToFrontend`).
 
 ### Set Model
 
 ```json
 {
   "id": "string",
-  "series": "string",
+  "code": "string",
   "name": "string",
-  "releaseDate": "string (ISO 8601)",
-  "totalCards": "integer",
-  "symbolUrl": "string (URL)",
-  "logoUrl": "string (URL)",
-  "isRecent": "boolean",
-  "metadata": {
-    "source": "string",
-    "lastUpdated": "string (ISO 8601)"
-  }
+  "series": "string",
+  "releaseDate": "string (ISO date, optional)",
+  "total": "integer (optional)",
+  "printedTotal": "integer (optional)",
+  "language": "string (optional)",
+  "languageCode": "string (optional, e.g. EN, JP)",
+  "isOnlineOnly": "boolean (optional)",
+  "logo": "string URL (optional)",
+  "symbol": "string URL (optional)",
+  "cardCount": "integer (optional)",
+  "isCurrent": "boolean (optional)",
+  "lastUpdated": "string (ISO 8601, optional)"
 }
 ```
 
-### Card Model
+The `/sets` endpoint additionally annotates each set with `releaseYear` (integer) and `isRecent` (boolean).
+
+> Note: image fields are `symbol` and `logo` (not `symbolUrl`/`logoUrl`); the card count fields are `total`/`cardCount` (not `totalCards`). There is no `metadata.source` field.
+
+### Card Model (on-wire)
 
 ```json
 {
   "id": "string",
-  "setId": "string",
-  "cardNumber": "string",
   "name": "string",
+  "number": "string",
+  "cardNumber": "string",
+  "printedNumber": "string (optional)",
   "rarity": "string",
+  "rarityCode": "string (optional)",
+  "artist": "string (optional)",
+  "images": "CardImage[] (optional)",
+  "variants": "CardVariant[] (optional)",
+  "setCode": "string",
+  "setId": "string",
+  "setName": "string",
+  "pricingLastUpdated": "string (ISO 8601, optional)"
+}
+```
+
+> `number` and `cardNumber` carry the same value (kept for compatibility). There is no `type`, `hp`, `pokeDataId`, `tcgSetId`, or `metadata` field. Pricing is **not** a flat object — it lives inside `variants[].prices[]`.
+
+### Image Model
+
+Images are an **array** of `CardImage` objects:
+
+```json
+{
   "type": "string",
-  "hp": "integer",
-  "images": {
-    "small": "string (URL)",
-    "large": "string (URL)"
-  },
-  "pricing": {
-    "market": "number",
-    "low": "number",
-    "mid": "number",
-    "high": "number",
-    "lastUpdated": "string (ISO 8601)"
-  },
-  "metadata": {
-    "tcgSetId": "string",
-    "pokeDataId": "string",
-    "lastSync": "string (ISO 8601)"
-  }
+  "small": "string URL",
+  "medium": "string URL",
+  "large": "string URL"
 }
 ```
 
-### Pricing Model
+### Variant Model
 
 ```json
 {
-  "market": "number",
+  "name": "string",
+  "images": "CardImage[] (optional)",
+  "prices": "VariantPrice[]"
+}
+```
+
+### Pricing Model (`VariantPrice`)
+
+Pricing is per-variant and per-condition/grade. Each entry in `variants[].prices[]`:
+
+```json
+{
+  "condition": "string",
+  "type": "raw | graded",
+  "company": "string (optional, e.g. PSA, for graded)",
+  "grade": "string (optional, e.g. 10, for graded)",
+  "isPerfect": "boolean",
+  "isError": "boolean",
+  "isSigned": "boolean",
   "low": "number",
-  "mid": "number",
-  "high": "number",
-  "currency": "string (default: USD)",
-  "condition": "string (default: Near Mint)",
-  "lastUpdated": "string (ISO 8601)",
-  "source": "string"
+  "mid": "number (optional)",
+  "high": "number (optional)",
+  "market": "number",
+  "currency": "string",
+  "trends": "PriceTrends (optional)"
 }
 ```
 
-### Error Model
+### Price Trends Model
 
 ```json
 {
-  "success": false,
-  "error": {
-    "code": "string",
-    "message": "string",
-    "details": "string",
-    "timestamp": "string (ISO 8601)",
-    "requestId": "string"
-  }
+  "days1": { "priceChange": "number", "percentChange": "number" },
+  "days7": { "priceChange": "number", "percentChange": "number" },
+  "days14": { "priceChange": "number", "percentChange": "number" },
+  "days30": { "priceChange": "number", "percentChange": "number" },
+  "days90": { "priceChange": "number", "percentChange": "number" },
+  "days180": { "priceChange": "number", "percentChange": "number" }
 }
 ```
+
+All `daysN` keys are optional, and each `TrendData` value has `priceChange` and `percentChange`.
 
 ### Pagination Model
 
 ```json
 {
-  "currentPage": "integer",
-  "totalPages": "integer",
-  "totalResults": "integer",
-  "hasNext": "boolean",
-  "hasPrevious": "boolean",
-  "nextPage": "string (URL)",
-  "previousPage": "string (URL)"
+  "page": "integer",
+  "pageSize": "integer",
+  "totalCount": "integer",
+  "totalPages": "integer"
 }
 ```
+
+### Error Model
+
+See [Error Handling](#error-handling).
 
 ## Error Handling
 
 ### Error Response Format
 
-All API errors follow a consistent format with detailed information for debugging and user feedback.
+Errors use a **flat** envelope (no nested `error` object, no `success` field). The exact fields depend on the runtime:
+
+**SvelteKit BFF (Path A)** — `apiError` in `frontend/src/lib/server/utils/errors.ts`:
 
 ```json
 {
-  "success": false,
-  "error": {
-    "code": "INVALID_SET_ID",
-    "message": "The specified set ID does not exist",
-    "details": "Set ID 'invalid-set' was not found in the database",
-    "timestamp": "2025-09-28T21:00:00Z",
-    "requestId": "req-12345-67890"
-  }
+  "status": 404,
+  "error": "Card sv8-999 not found",
+  "timestamp": "2025-06-16T10:30:00.000Z"
 }
 ```
 
-### Common Error Codes
+**Azure Functions (Paths B/C)** — `createErrorResponse`/`handleError` in `backend/functions/src/utils/errorUtils.ts`:
 
-| HTTP Status | Error Code                 | Description                        | Resolution                                   |
-| ----------- | -------------------------- | ---------------------------------- | -------------------------------------------- |
-| 400         | `INVALID_PARAMETER`        | Invalid query parameter            | Check parameter format and values            |
-| 400         | `MISSING_PARAMETER`        | Required parameter missing         | Include all required parameters              |
-| 401         | `INVALID_API_KEY`          | API key is invalid or missing      | Verify subscription key                      |
-| 403         | `INSUFFICIENT_PERMISSIONS` | API key lacks required permissions | Upgrade to appropriate product tier          |
-| 404         | `SET_NOT_FOUND`            | Specified set does not exist       | Verify set ID exists                         |
-| 404         | `CARD_NOT_FOUND`           | Specified card does not exist      | Verify card ID exists in set                 |
-| 429         | `RATE_LIMIT_EXCEEDED`      | Too many requests                  | Wait before making more requests             |
-| 500         | `INTERNAL_ERROR`           | Server error occurred              | Retry request, contact support if persistent |
-| 502         | `EXTERNAL_API_ERROR`       | External service unavailable       | Retry request, may return cached data        |
-| 503         | `SERVICE_UNAVAILABLE`      | API temporarily unavailable        | Retry with exponential backoff               |
+```json
+{
+  "error": "Card not found: sv8-999",
+  "status": 404,
+  "timestamp": "2025-06-16T10:30:00.000Z",
+  "path": "GetCardInfo",
+  "details": null
+}
+```
+
+| Field         | Type    | Notes                                                                 |
+| ------------- | ------- | --------------------------------------------------------------------- |
+| `status`      | integer | HTTP status code                                                      |
+| `error`       | string  | Human-readable error message                                          |
+| `timestamp`   | string  | ISO 8601                                                              |
+| `path`        | string  | Functions only — the originating function/context name                |
+| `details`     | any     | Functions only — optional extra context (stack trace in development)  |
+| `correlationId` | string | Documented in the OpenAPI contract for debugging; not emitted by the current handler code |
+
+### Common Status Codes
+
+| HTTP Status | When                                                                 |
+| ----------- | -------------------------------------------------------------------- |
+| 200         | Successful response                                                  |
+| 207         | Health check: at least one component degraded                       |
+| 400         | Missing/invalid path or query parameters                            |
+| 401         | APIM: missing or invalid subscription key                           |
+| 404         | Set or card not found                                               |
+| 429         | APIM: rate limit exceeded                                           |
+| 500         | Server error                                                        |
+| 503         | Health check: a component is unhealthy                              |
 
 ### Error Handling Best Practices
 
-1. **Check HTTP Status Codes**: Always check the HTTP status code first
-2. **Parse Error Response**: Extract error code and message for specific handling
-3. **Implement Retry Logic**: Use exponential backoff for transient errors
-4. **Log Request IDs**: Include request ID in support requests
-5. **Handle Rate Limits**: Implement proper rate limiting in client applications
+1. **Check HTTP Status Codes**: Always check the HTTP status code first.
+2. **Read the `error` string**: It contains the human-readable reason.
+3. **Implement Retry Logic**: Use exponential backoff for `429`/`5xx`.
+4. **Handle Rate Limits**: Respect APIM rate-limit responses in client applications.
 
 ## Rate Limiting
 
-### Rate Limit Headers
-
-All API responses include rate limiting headers:
-
-```http
-X-RateLimit-Limit: 300
-X-RateLimit-Remaining: 299
-X-RateLimit-Reset: 1640995200
-X-RateLimit-Reset-After: 60
-```
-
-### Rate Limit Tiers
-
-| Product Tier   | Requests per Minute | Burst Limit | Reset Window |
-| -------------- | ------------------- | ----------- | ------------ |
-| **Starter**    | 300                 | 50          | 60 seconds   |
-| **Premium**    | 1000                | 200         | 60 seconds   |
-| **Enterprise** | Custom              | Custom      | Custom       |
-
-### Rate Limit Exceeded Response
-
-```json
-{
-  "success": false,
-  "error": {
-    "code": "RATE_LIMIT_EXCEEDED",
-    "message": "Rate limit exceeded",
-    "details": "You have exceeded the rate limit of 300 requests per minute",
-    "retryAfter": 45,
-    "timestamp": "2025-09-28T21:00:00Z",
-    "requestId": "req-12345-67890"
-  }
-}
-```
+Rate limiting is enforced at the APIM gateway (Path B), not in the Functions code. Limits are configured per APIM product/subscription. When a limit is exceeded, APIM returns `429 Too Many Requests`; clients should back off and retry. The Functions host itself applies concurrency throttling via `host.json` (`maxConcurrentRequests`, `maxOutstandingRequests`, `dynamicThrottlesEnabled`) rather than per-subscription rate limits.
 
 ## Caching
 
-### Cache Headers
+Responses indicate cache state via the `cached` and `cacheAge` envelope fields. Card and cards-by-set responses also set a `Cache-Control: public, max-age=<ttl>` header.
 
-API responses include caching headers to optimize performance:
+### Server-side cache flow
 
-```http
-Cache-Control: public, max-age=3600
-ETag: "abc123def456"
-Last-Modified: Sat, 28 Sep 2025 21:00:00 GMT
-Vary: Accept-Encoding
-```
+For each request the backend tries, in order: Redis (when `ENABLE_REDIS_CACHE=true`) → Cosmos DB → Scrydex API. Fresh Scrydex results are written back to Cosmos and Redis. Cards-by-set additionally performs staleness checks (expected card count vs. stored count, and presence of pricing) before serving stored data.
 
-### Cache Strategies by Endpoint
+Default TTLs (overridable via environment variables):
 
-| Endpoint                | Cache Duration | Strategy                             |
-| ----------------------- | -------------- | ------------------------------------ |
-| `/sets`                 | 60 minutes     | Public cache, stale-while-revalidate |
-| `/sets/{id}`            | 60 minutes     | Public cache, immutable for old sets |
-| `/sets/{id}/cards`      | 30 minutes     | Public cache, conditional requests   |
-| `/sets/{id}/cards/{id}` | 30 minutes     | Public cache, ETag validation        |
-| `/search/cards`         | 15 minutes     | Private cache, vary by query         |
-| `/health`               | 5 minutes      | Public cache, short TTL              |
+| Data           | Env var            | Default            |
+| -------------- | ------------------ | ------------------ |
+| Set list       | `CACHE_TTL_SETS`   | 604800s (7 days)   |
+| Cards          | `CACHE_TTL_CARDS`  | 3600s–86400s\*     |
+
+\* Card detail defaults to 3600s; cards-by-set defaults to 86400s in the Functions handler.
+
+Background refresh is handled by the `RefreshData` timer trigger (every 12 hours) and `MonitorScrydexUsage` (every 6 hours).
 
 ### Client-Side Caching
 
-Recommended client-side caching strategies:
-
-1. **HTTP Caching**: Respect cache headers for automatic caching
-2. **Application Cache**: Cache frequently accessed data locally
-3. **Conditional Requests**: Use ETag and Last-Modified headers
-4. **Background Refresh**: Update cache in background for better UX
+1. **HTTP Caching**: Respect `Cache-Control` headers where present.
+2. **Application Cache**: Cache frequently accessed data locally.
+3. **Background Refresh**: Update local caches in the background for better UX.
 
 ## Examples
 
@@ -792,9 +717,10 @@ Recommended client-side caching strategies:
 const axios = require("axios");
 
 class PCPCApiClient {
-  constructor(apiKey, baseUrl = "https://api.pcpc.example.com/api/v1") {
-    this.apiKey = apiKey;
-    this.baseUrl = baseUrl;
+  constructor(
+    apiKey,
+    baseUrl = "https://maber-apim-prod.azure-api.net/pokedata-api"
+  ) {
     this.client = axios.create({
       baseURL: baseUrl,
       headers: {
@@ -804,119 +730,49 @@ class PCPCApiClient {
     });
   }
 
-  async getSets(options = {}) {
-    const { page = 1, limit = 20, series, recent } = options;
-    const params = { page, limit };
-    if (series) params.series = series;
-    if (recent) params.recent = recent;
-
-    try {
-      const response = await this.client.get("/sets", { params });
-      return response.data;
-    } catch (error) {
-      throw this.handleError(error);
-    }
+  async getSets({ page = 1, pageSize = 100, language = "en", all = false } = {}) {
+    const params = { page, pageSize, language };
+    if (all) params.all = true;
+    const { data } = await this.client.get("/sets", { params });
+    return data; // { status, data: { sets, pagination }, timestamp, cached, cacheAge }
   }
 
-  async getCardsBySet(setId, options = {}) {
-    const { page = 1, limit = 20, rarity, includePricing = true } = options;
-    const params = { page, limit, includePricing };
-    if (rarity) params.rarity = rarity;
-
-    try {
-      const response = await this.client.get(`/sets/${setId}/cards`, {
-        params,
-      });
-      return response.data;
-    } catch (error) {
-      throw this.handleError(error);
-    }
+  async getCardsBySet(setId, { page = 1, pageSize = 500 } = {}) {
+    const { data } = await this.client.get(`/sets/${setId}/cards`, {
+      params: { page, pageSize },
+    });
+    return data; // { status, data: { cards, pagination }, ... }
   }
 
-  async getCard(setId, cardId, options = {}) {
-    const { includePricing = true, includeVariants = false } = options;
-    const params = { includePricing, includeVariants };
-
-    try {
-      const response = await this.client.get(`/sets/${setId}/cards/${cardId}`, {
-        params,
-      });
-      return response.data;
-    } catch (error) {
-      throw this.handleError(error);
-    }
+  async getCard(setId, cardId) {
+    const { data } = await this.client.get(`/sets/${setId}/cards/${cardId}`);
+    return data; // { status, data: <card>, ... }
   }
 
-  async searchCards(query, options = {}) {
-    const {
-      page = 1,
-      limit = 20,
-      rarity,
-      minPrice,
-      maxPrice,
-      sortBy = "relevance",
-    } = options;
-    const params = { q: query, page, limit, sortBy };
-    if (rarity) params.rarity = rarity;
-    if (minPrice) params.minPrice = minPrice;
-    if (maxPrice) params.maxPrice = maxPrice;
-
-    try {
-      const response = await this.client.get("/search/cards", { params });
-      return response.data;
-    } catch (error) {
-      throw this.handleError(error);
-    }
-  }
-
-  handleError(error) {
-    if (error.response) {
-      const { status, data } = error.response;
-      const apiError = new Error(data.error?.message || "API Error");
-      apiError.code = data.error?.code;
-      apiError.status = status;
-      apiError.requestId = data.error?.requestId;
-      return apiError;
-    }
-    return error;
+  async health() {
+    const { data } = await this.client.get("/health");
+    return data;
   }
 }
 
-// Usage Example
+// Usage
 const client = new PCPCApiClient("your-api-key-here");
 
 async function example() {
   try {
-    // Get all sets
-    const sets = await client.getSets({ page: 1, limit: 10 });
+    const sets = await client.getSets({ pageSize: 10 });
     console.log("Sets:", sets.data.sets);
 
-    // Get cards from Base Set
-    const cards = await client.getCardsBySet("base1", {
-      rarity: "Rare Holo",
-      includePricing: true,
-    });
+    const cards = await client.getCardsBySet("sv8", { pageSize: 50 });
     console.log("Cards:", cards.data.cards);
 
-    // Get specific card details
-    const card = await client.getCard("base1", "base1-4", {
-      includePricing: true,
-      includeVariants: true,
-    });
+    const card = await client.getCard("sv8", "sv8-001");
     console.log("Card:", card.data);
-
-    // Search for Charizard cards
-    const searchResults = await client.searchCards("Charizard", {
-      rarity: "Rare Holo",
-      minPrice: 100,
-      sortBy: "price",
-      sortOrder: "desc",
-    });
-    console.log("Search Results:", searchResults.data.results);
+    console.log("First price:", card.data.variants?.[0]?.prices?.[0]);
   } catch (error) {
-    console.error("API Error:", error.message);
-    console.error("Error Code:", error.code);
-    console.error("Request ID:", error.requestId);
+    const body = error.response?.data;
+    console.error("API Error:", body?.error || error.message);
+    console.error("Status:", body?.status);
   }
 }
 
@@ -927,217 +783,125 @@ example();
 
 ```python
 import requests
-from typing import Optional, Dict, Any
 import time
-
-class PCPCApiClient:
-    def __init__(self, api_key: str, base_url: str = "https://api.pcpc.example.com/api/v1"):
-        self.api_key = api_key
-        self.base_url = base_url
-        self.session = requests.Session()
-        self.session.headers.update({
-            'Ocp-Apim-Subscription-Key': api_key,
-            'Content-Type': 'application/json'
-        })
-
-    def _make_request(self, method: str, endpoint: str, params: Optional[Dict] = None) -> Dict[str, Any]:
-        url = f"{self.base_url}{endpoint}"
-
-        try:
-            response = self.session.request(method, url, params=params)
-            response.raise_for_status()
-            return response.json()
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 429:
-                # Handle rate limiting with exponential backoff
-                retry_after = int(e.response.headers.get('Retry-After', 60))
-                time.sleep(retry_after)
-                return self._make_request(method, endpoint, params)
-            else:
-                error_data = e.response.json() if e.response.content else {}
-                raise APIError(
-                    message=error_data.get('error', {}).get('message', str(e)),
-                    code=error_data.get('error', {}).get('code'),
-                    status_code=e.response.status_code,
-                    request_id=error_data.get('error', {}).get('requestId')
-                )
-
-    def get_sets(self, page: int = 1, limit: int = 20, series: Optional[str] = None,
-                 recent: Optional[bool] = None) -> Dict[str, Any]:
-        params = {'page': page, 'limit': limit}
-        if series:
-            params['series'] = series
-        if recent is not None:
-            params['recent'] = recent
-
-        return self._make_request('GET', '/sets', params)
-
-    def get_cards_by_set(self, set_id: str, page: int = 1, limit: int = 20,
-                        rarity: Optional[str] = None, include_pricing: bool = True) -> Dict[str, Any]:
-        params = {'page': page, 'limit': limit, 'includePricing': include_pricing}
-        if rarity:
-            params['rarity'] = rarity
-
-        return self._make_request('GET', f'/sets/{set_id}/cards', params)
-
-    def get_card(self, set_id: str, card_id: str, include_pricing: bool = True,
-                 include_variants: bool = False) -> Dict[str, Any]:
-        params = {'includePricing': include_pricing, 'includeVariants': include_variants}
-        return self._make_request('GET', f'/sets/{set_id}/cards/{card_id}', params)
-
-    def search_cards(self, query: str, page: int = 1, limit: int = 20,
-                    rarity: Optional[str] = None, min_price: Optional[float] = None,
-                    max_price: Optional[float] = None, sort_by: str = "relevance") -> Dict[str, Any]:
-        params = {'q': query, 'page': page, 'limit': limit, 'sortBy': sort_by}
-        if rarity:
-            params['rarity'] = rarity
-        if min_price:
-            params['minPrice'] = min_price
-        if max_price:
-            params['maxPrice'] = max_price
-
-        return self._make_request('GET', '/search/cards', params)
+from typing import Optional, Dict, Any
 
 
 class APIError(Exception):
-    """Custom exception for API errors"""
-    def __init__(self, message: str, code: Optional[str] = None,
-                 status_code: Optional[int] = None, request_id: Optional[str] = None):
+    def __init__(self, message: str, status: Optional[int] = None):
         super().__init__(message)
-        self.code = code
-        self.status_code = status_code
-        self.request_id = request_id
+        self.status = status
 
 
-# Usage Example
+class PCPCApiClient:
+    def __init__(self, api_key: str,
+                 base_url: str = "https://maber-apim-prod.azure-api.net/pokedata-api"):
+        self.base_url = base_url
+        self.session = requests.Session()
+        self.session.headers.update({
+            "Ocp-Apim-Subscription-Key": api_key,
+            "Content-Type": "application/json",
+        })
+
+    def _get(self, endpoint: str, params: Optional[Dict] = None) -> Dict[str, Any]:
+        resp = self.session.get(f"{self.base_url}{endpoint}", params=params)
+        if resp.status_code == 429:
+            retry_after = int(resp.headers.get("Retry-After", 60))
+            time.sleep(retry_after)
+            return self._get(endpoint, params)
+        if not resp.ok:
+            body = resp.json() if resp.content else {}
+            raise APIError(body.get("error", resp.reason), resp.status_code)
+        return resp.json()
+
+    def get_sets(self, page: int = 1, page_size: int = 100,
+                 language: str = "en", all: bool = False) -> Dict[str, Any]:
+        params = {"page": page, "pageSize": page_size, "language": language}
+        if all:
+            params["all"] = "true"
+        return self._get("/sets", params)
+
+    def get_cards_by_set(self, set_id: str, page: int = 1,
+                         page_size: int = 500) -> Dict[str, Any]:
+        return self._get(f"/sets/{set_id}/cards",
+                         {"page": page, "pageSize": page_size})
+
+    def get_card(self, set_id: str, card_id: str) -> Dict[str, Any]:
+        return self._get(f"/sets/{set_id}/cards/{card_id}")
+
+    def health(self) -> Dict[str, Any]:
+        return self._get("/health")
+
+
+# Usage
 client = PCPCApiClient("your-api-key-here")
 
 try:
-    # Get all sets
-    sets = client.get_sets(page=1, limit=10)
-    print("Sets:", sets['data']['sets'])
+    sets = client.get_sets(page_size=10)
+    print("Sets:", sets["data"]["sets"])
 
-    # Get cards from Base Set
-    cards = client.get_cards_by_set("base1", rarity="Rare Holo", include_pricing=True)
-    print("Cards:", cards['data']['cards'])
+    cards = client.get_cards_by_set("sv8", page_size=50)
+    print("Cards:", cards["data"]["cards"])
 
-    # Get specific card details
-    card = client.get_card("base1", "base1-4", include_pricing=True, include_variants=True)
-    print("Card:", card['data'])
-
-    # Search for Charizard cards
-    search_results = client.search_cards("Charizard", rarity="Rare Holo",
-                                       min_price=100, sort_by="price")
-    print("Search Results:", search_results['data']['results'])
-
+    card = client.get_card("sv8", "sv8-001")
+    print("Card:", card["data"]["name"])
+    variants = card["data"].get("variants", [])
+    if variants and variants[0].get("prices"):
+        print("First price:", variants[0]["prices"][0])
 except APIError as e:
-    print(f"API Error: {e}")
-    print(f"Error Code: {e.code}")
-    print(f"Status Code: {e.status_code}")
-    print(f"Request ID: {e.request_id}")
+    print(f"API Error ({e.status}): {e}")
 ```
 
 ### cURL Examples
 
-#### Get All Sets
+#### Get Set List
 
 ```bash
-curl -X GET "https://api.pcpc.example.com/api/v1/sets?page=1&limit=10" \
-  -H "Ocp-Apim-Subscription-Key: your-api-key-here" \
-  -H "Content-Type: application/json"
+curl -X GET "https://maber-apim-prod.azure-api.net/pokedata-api/sets?page=1&pageSize=10" \
+  -H "Ocp-Apim-Subscription-Key: your-api-key-here"
 ```
 
 #### Get Cards by Set
 
 ```bash
-curl -X GET "https://api.pcpc.example.com/api/v1/sets/base1/cards?rarity=Rare%20Holo" \
-  -H "Ocp-Apim-Subscription-Key: your-api-key-here" \
-  -H "Content-Type: application/json"
+curl -X GET "https://maber-apim-prod.azure-api.net/pokedata-api/sets/sv8/cards?pageSize=50" \
+  -H "Ocp-Apim-Subscription-Key: your-api-key-here"
 ```
 
-#### Search Cards
+#### Get Card Info
 
 ```bash
-curl -X GET "https://api.pcpc.example.com/api/v1/search/cards?q=Charizard&minPrice=100" \
-  -H "Ocp-Apim-Subscription-Key: your-api-key-here" \
-  -H "Content-Type: application/json"
+curl -X GET "https://maber-apim-prod.azure-api.net/pokedata-api/sets/sv8/cards/sv8-001" \
+  -H "Ocp-Apim-Subscription-Key: your-api-key-here"
+```
+
+#### Local Development (Azure Functions, no subscription key)
+
+```bash
+curl -X GET "http://localhost:7071/api/sets?pageSize=10"
+curl -X GET "http://localhost:7071/api/health"
 ```
 
 ## SDKs and Tools
 
-### Official SDKs
+### OpenAPI Specification
 
-- **JavaScript/Node.js**: Available via npm (`npm install pcpc-api-client`)
-- **Python**: Available via pip (`pip install pcpc-api-client`)
-- **C#/.NET**: Available via NuGet (`Install-Package PCPC.ApiClient`)
-- **Go**: Available via go get (`go get github.com/pcpc/go-client`)
+The authoritative HTTP contract is published at `apim/specs/pcpc-api-v1.yaml` (OpenAPI 3.0.1) and surfaced through the APIM developer portal. Use it to generate clients or import into API tooling.
 
-### Third-Party Tools
+### Recommended Tooling
 
-- **Postman Collection**: Import our comprehensive API collection
-- **OpenAPI Specification**: Available at `/api/v1/openapi.json`
-- **Swagger UI**: Interactive documentation at `/docs`
-- **Insomnia Collection**: REST client collection available
+- **Postman / Insomnia**: Import the OpenAPI spec to generate a collection.
+- **APIM Developer Portal**: Interactive try-it console with subscription-key management.
 
 ### Development Tools
 
-#### API Testing
-
 ```bash
-# Test API health
-curl -X GET "https://api.pcpc.example.com/api/v1/health" \
+# Health check (local Functions)
+curl -X GET "http://localhost:7071/api/health"
+
+# Validate subscription key through APIM
+curl -X GET "https://maber-apim-prod.azure-api.net/pokedata-api/sets?pageSize=1" \
   -H "Ocp-Apim-Subscription-Key: your-key"
-
-# Validate API key
-curl -X GET "https://api.pcpc.example.com/api/v1/sets?limit=1" \
-  -H "Ocp-Apim-Subscription-Key: your-key"
-```
-
-#### Rate Limit Testing
-
-```bash
-# Check current rate limit status
-curl -I -X GET "https://api.pcpc.example.com/api/v1/health" \
-  -H "Ocp-Apim-Subscription-Key: your-key"
-```
-
-### Integration Examples
-
-#### Webhook Integration
-
-```javascript
-// Example webhook handler for real-time price updates
-app.post("/webhook/price-updates", (req, res) => {
-  const { cardId, oldPrice, newPrice, timestamp } = req.body;
-
-  // Process price update
-  console.log(`Price update for ${cardId}: ${oldPrice} -> ${newPrice}`);
-
-  res.status(200).json({ received: true });
-});
-```
-
-#### Batch Processing
-
-```python
-import asyncio
-import aiohttp
-
-async def fetch_multiple_cards(session, card_ids):
-    tasks = []
-    for card_id in card_ids:
-        task = fetch_card_details(session, card_id)
-        tasks.append(task)
-
-    results = await asyncio.gather(*tasks)
-    return results
-
-async def fetch_card_details(session, card_id):
-    url = f"https://api.pcpc.example.com/api/v1/sets/{card_id.split('-')[0]}/cards/{card_id}"
-    headers = {'Ocp-Apim-Subscription-Key': 'your-key'}
-
-    async with session.get(url, headers=headers) as response:
-        return await response.json()
 ```
 
 ---
@@ -1157,24 +921,7 @@ async def fetch_card_details(session, card_id):
 - **Issue Tracker**: Report bugs and request features
 - **Discussions**: Community Q&A and feature discussions
 
-### Support Channels
-
-- **Documentation**: Comprehensive guides and references
-- **Community Support**: GitHub Discussions and Issues
-- **Premium Support**: Available for Premium and Enterprise tiers
-
-### Status and Updates
-
-- **API Status**: [https://status.pcpc.example.com](https://status.pcpc.example.com)
-- **Changelog**: [API version history and updates](../CHANGELOG.md)
-- **Announcements**: Follow our GitHub repository for updates
-
 ---
 
-**Last Updated**: September 28, 2025  
-**API Version**: 1.0.0  
-**Documentation Version**: 1.0.0
-
-```
-
-```
+**Data Source**: Scrydex
+**API Contract**: `apim/specs/pcpc-api-v1.yaml` (OpenAPI 3.0.1, version 1.0)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -70,7 +70,7 @@ graph TB
 The same logical endpoints are served by more than one runtime:
 
 - **Path A — SvelteKit BFF**: server routes under `/api/*` in the frontend app. Calls Scrydex/Cosmos/Redis directly.
-- **Path B — Azure Functions behind APIM**: the OpenAPI contract published at `*.azure-api.net/pokedata-api`. APIM provides subscription-key auth, rate limiting, the developer portal, and observability.
+- **Path B — Azure Functions behind APIM**: served at `pcpc-apim-{env}.azure-api.net/pcpc-api/{version}` (e.g. `https://pcpc-apim-dev.azure-api.net/pcpc-api/v1`). APIM provides rate limiting, the developer portal, and observability. The API and its `starter` product are deployed with `subscription_required = false`, so the public demo path needs no key (see [Authentication](#authentication)).
 - **Path C — Azure Functions on Azure Container Apps**: the same Functions code, fronted by ACA ingress (CORS) instead of APIM.
 
 The Azure Functions host registers its routes with the `api` route prefix (`backend/functions/host.json`), so all Functions endpoints live under `/api`. The Functions read endpoints use `authLevel: "anonymous"` — authentication is enforced at the gateway, not the function host.
@@ -79,23 +79,27 @@ Response shapes are nearly identical across paths; the only meaningful differenc
 
 ## Authentication
 
-### Subscription Key Authentication (APIM gateway)
+The Azure Functions HTTP triggers are registered with `authLevel: "anonymous"` (`backend/functions/src/index.ts`); there is no function-key check at the host. Access control is delegated to the gateway in front of them.
 
-The Azure Functions HTTP triggers are registered with `authLevel: "anonymous"`; there is no function-key check at the host. Authentication is enforced **at the Azure API Management gateway** (Path B). All requests through APIM must include a valid subscription key, supplied either as a header (recommended) or a query parameter.
+### Path B (APIM) — subscription keys are optional, tier-dependent
 
-#### Header Authentication (Recommended)
+The PCPC API and its `starter` product are deployed with `subscription_required = false` (`apim/terraform/apis.tf`, `apim/terraform/variables.tf`), so the **public demo path requires no subscription key** — the frontend Path B client calls APIM without one (`frontend/src/lib/backends/path-b-azure.ts`). A subscription key is only required for the `premium` and `unlimited` products (`subscription_required = true`), which apply tighter rate limits/quotas for trusted consumers.
+
+When a key *is* required (premium/unlimited tiers), supply it as a header (recommended) or a query parameter:
+
+#### Header (recommended)
 
 ```http
-GET /pokedata-api/sets
-Host: maber-apim-prod.azure-api.net
+GET /pcpc-api/v1/sets
+Host: pcpc-apim-dev.azure-api.net
 Ocp-Apim-Subscription-Key: your-subscription-key-here
 ```
 
-#### Query Parameter Authentication
+#### Query parameter
 
 ```http
-GET /pokedata-api/sets?subscription-key=your-subscription-key-here
-Host: maber-apim-prod.azure-api.net
+GET /pcpc-api/v1/sets?subscription-key=your-subscription-key-here
+Host: pcpc-apim-dev.azure-api.net
 ```
 
 > Both schemes are defined in the OpenAPI contract (`apim/specs/pcpc-api-v1.yaml`): `apiKeyHeader` (`Ocp-Apim-Subscription-Key`) and `apiKeyQuery` (`subscription-key`).
@@ -106,13 +110,15 @@ When calling the Azure Functions host directly (local development, or Path C via
 
 ### APIM Gateway (Path B)
 
-The APIM base path is `/pokedata-api` (no `/api` or version segment). From `apim/specs/pcpc-api-v1.yaml`:
+The APIM API path is `pcpc-api/{version}` (set in `apim/terraform/apis.tf` as `path = "pcpc-api/${var.api_version}"`; `api_version` defaults to `v1`). Custom domains (`api.pcpc.maber.io`) are deferred per [ADR-012](adr/ADR-012-apim-managed-cert-suspension.md), so the working base URL is the per-environment APIM hostname:
 
 ```
-https://maber-apim-test.azure-api.net/pokedata-api      (development)
-https://maber-apim-staging.azure-api.net/pokedata-api   (staging)
-https://maber-apim-prod.azure-api.net/pokedata-api      (production)
+https://pcpc-apim-dev.azure-api.net/pcpc-api/v1      (development)
+https://pcpc-apim-staging.azure-api.net/pcpc-api/v1  (staging)
+https://pcpc-apim-prod.azure-api.net/pcpc-api/v1     (production)
 ```
+
+The frontend Path B client reads this from the `PUBLIC_AZURE_API_BASE_URL` env var and falls back to the dev URL above (`frontend/src/lib/backends/path-b-azure.ts`).
 
 ### Azure Functions (local development)
 
@@ -126,7 +132,7 @@ http://localhost:7071/api
 
 Served from the frontend application origin under `/api`, e.g. `https://<frontend-host>/api`.
 
-> Endpoint paths below are written relative to the chosen base URL (e.g. `/sets` is `https://maber-apim-prod.azure-api.net/pokedata-api/sets` via APIM, or `http://localhost:7071/api/sets` locally).
+> Endpoint paths below are written relative to the chosen base URL (e.g. `/sets` is `https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets` via APIM, or `http://localhost:7071/api/sets` locally).
 
 ## API Endpoints
 
@@ -718,14 +724,15 @@ const axios = require("axios");
 
 class PCPCApiClient {
   constructor(
-    apiKey,
-    baseUrl = "https://maber-apim-prod.azure-api.net/pokedata-api"
+    { baseUrl = "https://pcpc-apim-dev.azure-api.net/pcpc-api/v1", apiKey } = {}
   ) {
     this.client = axios.create({
       baseURL: baseUrl,
       headers: {
-        "Ocp-Apim-Subscription-Key": apiKey,
         "Content-Type": "application/json",
+        // The starter (demo) product needs no key; only the premium/unlimited
+        // products set subscription_required = true.
+        ...(apiKey ? { "Ocp-Apim-Subscription-Key": apiKey } : {}),
       },
     });
   }
@@ -755,8 +762,8 @@ class PCPCApiClient {
   }
 }
 
-// Usage
-const client = new PCPCApiClient("your-api-key-here");
+// Usage — no key needed for the public demo path
+const client = new PCPCApiClient();
 
 async function example() {
   try {
@@ -794,14 +801,14 @@ class APIError(Exception):
 
 
 class PCPCApiClient:
-    def __init__(self, api_key: str,
-                 base_url: str = "https://maber-apim-prod.azure-api.net/pokedata-api"):
+    def __init__(self, base_url: str = "https://pcpc-apim-dev.azure-api.net/pcpc-api/v1",
+                 api_key: Optional[str] = None):
         self.base_url = base_url
         self.session = requests.Session()
-        self.session.headers.update({
-            "Ocp-Apim-Subscription-Key": api_key,
-            "Content-Type": "application/json",
-        })
+        self.session.headers.update({"Content-Type": "application/json"})
+        # The starter (demo) product needs no key; only premium/unlimited do.
+        if api_key:
+            self.session.headers["Ocp-Apim-Subscription-Key"] = api_key
 
     def _get(self, endpoint: str, params: Optional[Dict] = None) -> Dict[str, Any]:
         resp = self.session.get(f"{self.base_url}{endpoint}", params=params)
@@ -833,8 +840,8 @@ class PCPCApiClient:
         return self._get("/health")
 
 
-# Usage
-client = PCPCApiClient("your-api-key-here")
+# Usage — no key needed for the public demo path
+client = PCPCApiClient()
 
 try:
     sets = client.get_sets(page_size=10)
@@ -854,26 +861,27 @@ except APIError as e:
 
 ### cURL Examples
 
+The public demo path (starter product) requires no subscription key:
+
 #### Get Set List
 
 ```bash
-curl -X GET "https://maber-apim-prod.azure-api.net/pokedata-api/sets?page=1&pageSize=10" \
-  -H "Ocp-Apim-Subscription-Key: your-api-key-here"
+curl -X GET "https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets?page=1&pageSize=10"
 ```
 
 #### Get Cards by Set
 
 ```bash
-curl -X GET "https://maber-apim-prod.azure-api.net/pokedata-api/sets/sv8/cards?pageSize=50" \
-  -H "Ocp-Apim-Subscription-Key: your-api-key-here"
+curl -X GET "https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets/sv8/cards?pageSize=50"
 ```
 
 #### Get Card Info
 
 ```bash
-curl -X GET "https://maber-apim-prod.azure-api.net/pokedata-api/sets/sv8/cards/sv8-001" \
-  -H "Ocp-Apim-Subscription-Key: your-api-key-here"
+curl -X GET "https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets/sv8/cards/sv8-001"
 ```
+
+> For the `premium`/`unlimited` products (which set `subscription_required = true`), add `-H "Ocp-Apim-Subscription-Key: your-key"`.
 
 #### Local Development (Azure Functions, no subscription key)
 
@@ -899,8 +907,11 @@ The authoritative HTTP contract is published at `apim/specs/pcpc-api-v1.yaml` (O
 # Health check (local Functions)
 curl -X GET "http://localhost:7071/api/health"
 
-# Validate subscription key through APIM
-curl -X GET "https://maber-apim-prod.azure-api.net/pokedata-api/sets?pageSize=1" \
+# Through APIM (demo path — no key required)
+curl -X GET "https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets?pageSize=1"
+
+# With a subscription key (premium/unlimited products)
+curl -X GET "https://pcpc-apim-dev.azure-api.net/pcpc-api/v1/sets?pageSize=1" \
   -H "Ocp-Apim-Subscription-Key: your-key"
 ```
 

--- a/docs/architecture-comparison.md
+++ b/docs/architecture-comparison.md
@@ -195,7 +195,7 @@ between Consumption and ACA is in
 
 - Azure API Management with declarative policies and a developer portal
 - Azure Functions v4 on Node.js 22 with idiomatic separation of concerns
-- 9-module Terraform composition (resource group, key vault, cosmos, function app, storage, app insights, log analytics, APIM, static web app legacy module)
+- 10-module Terraform composition (resource group, key vault, cosmos, function app, storage, app insights, log analytics, APIM, container registry, container app)
 - Azure DevOps multi-stage pipelines with ACR-backed CI containers
 - Application Insights + Log Analytics for end-to-end observability
 - Managed identity, Key Vault references, audit log integration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,18 @@
 # PCPC System Architecture
 
-> **Comprehensive technical architecture documentation for the Pokemon Card Price Checker enterprise application**
+> **Comprehensive technical architecture documentation for the Pokemon Card Price Checker portfolio application**
+
+> **Phase 2.2 (current).** PCPC ships one product three ways from one repo.
+> A single SvelteKit frontend talks to three interchangeable backends —
+> selected at runtime via `?backend=vercel|azure|aca`. The operational
+> tradeoff story between the three paths lives in
+> [architecture-comparison.md](./architecture-comparison.md); this document
+> is the structural reference for the components that make up each path.
 
 ## Table of Contents
 
 - [Architecture Overview](#architecture-overview)
+- [The Three-Path Architecture](#the-three-path-architecture)
 - [System Components](#system-components)
 - [Data Architecture](#data-architecture)
 - [Integration Patterns](#integration-patterns)
@@ -19,1101 +27,701 @@
 
 ### High-Level System Architecture
 
-The PCPC system follows a modern cloud-native, serverless architecture pattern with clear separation of concerns and scalable design.
+PCPC is a SvelteKit web application that fetches Pokemon card data and
+pricing from a single upstream source (the **Scrydex API**), caches it in
+**Cosmos DB** (with an optional **Redis** layer), and serves it to the
+browser. The distinguishing feature is that the same product is reachable
+through three architecturally different backend paths from one frontend.
 
 ```mermaid
 graph TB
-    subgraph "Client Layer"
+    subgraph Client["Client Layer"]
         WEB[Web Browser]
-        MOBILE[Mobile Browser]
     end
 
-
-    subgraph "Frontend Layer"
-        SWA[Azure Static Web Apps<br/>Svelte SPA]
-        ASSETS[Static Assets<br/>Images, CSS, JS]
+    subgraph Frontend["Frontend — Vercel"]
+        SK[SvelteKit 2 / Svelte 5 runes<br/>Tailwind v4<br/>adapter-vercel]
+        TOGGLE["Backend abstraction<br/>?backend=vercel|azure|aca"]
     end
 
-    subgraph "API Gateway Layer"
-        APIM[Azure API Management<br/>Consumption Tier]
-        POLICIES[Policy Engine<br/>Rate Limiting, CORS, Auth]
-        CACHE_APIM[Response Cache<br/>5-60 minutes TTL]
+    subgraph Paths["Three Backend Paths"]
+        PA[Path A<br/>SvelteKit +server.ts BFF<br/>Vercel serverless]
+        PB[Path B<br/>APIM Consumption<br/>→ Azure Functions v4]
+        PC[Path C<br/>ACA ingress + KEDA<br/>→ same Functions image]
     end
 
-    subgraph "Backend Services Layer"
-        AF[Azure Functions v4<br/>Node.js 22 LTS]
-        subgraph "Functions"
-            GET_SETS[GetSetList<br/>HTTP Trigger]
-            GET_CARDS[GetCardsBySet<br/>HTTP Trigger]
-            GET_CARD[GetCardInfo<br/>HTTP Trigger]
-            REFRESH[RefreshData<br/>Timer Trigger]
-            MONITOR[MonitorCredits<br/>Timer Trigger]
-        end
+    subgraph Data["Shared Data Layer"]
+        COSMOS[Cosmos DB<br/>PokemonCards database]
+        REDIS[Redis Cache<br/>optional — ENABLE_REDIS_CACHE]
     end
 
-    subgraph "Data Layer"
-        COSMOS[Cosmos DB<br/>Serverless NoSQL]
-        subgraph "Containers"
-            SETS_CONTAINER[Sets Container<br/>Partition: /series]
-            CARDS_CONTAINER[Cards Container<br/>Partition: /setId]
-        end
-        REDIS[Redis Cache<br/>Optional (future)]
-        BLOB[Azure Blob Storage<br/>Image Assets]
+    subgraph Upstream["Upstream"]
+        SCRYDEX[Scrydex API<br/>api.scrydex.com]
     end
 
-    subgraph "External APIs"
-        POKEDATA[PokeData API<br/>Enhanced Pricing]
-        POKEMONTCG[Pokemon TCG API<br/>Card Metadata]
+    subgraph Obs["Monitoring"]
+        APPINSIGHTS[Application Insights<br/>@azure/monitor-opentelemetry]
+        LOGS[Log Analytics]
     end
 
-    subgraph "Monitoring & Observability"
-        APPINSIGHTS[Application Insights<br/>Telemetry & Logging]
-        MONITOR_AZURE[Azure Monitor<br/>Metrics & Alerts]
-        LOGS[Log Analytics<br/>Centralized Logging]
-    end
+    WEB --> SK
+    SK --> TOGGLE
+    TOGGLE --> PA
+    TOGGLE --> PB
+    TOGGLE --> PC
 
-    WEB --> SWA
-    MOBILE --> SWA
-    SWA --> ASSETS
-    SWA --> APIM
-    APIM --> POLICIES
-    APIM --> CACHE_APIM
-    APIM --> AF
-    AF --> GET_SETS
-    AF --> GET_CARDS
-    AF --> GET_CARD
-    AF --> REFRESH
-    AF --> MONITOR
-    AF --> COSMOS
-    AF --> SETS_CONTAINER
-    AF --> CARDS_CONTAINER
-    AF --> REDIS
-    AF --> BLOB
-    AF --> POKEDATA
-    AF --> POKEMONTCG
-    AF --> APPINSIGHTS
-    APPINSIGHTS --> MONITOR_AZURE
+    PA --> COSMOS
+    PB --> COSMOS
+    PC --> COSMOS
+    COSMOS --> REDIS
+    PA --> SCRYDEX
+    PB --> SCRYDEX
+    PC --> SCRYDEX
+
+    PB --> APPINSIGHTS
+    PC --> APPINSIGHTS
     APPINSIGHTS --> LOGS
 ```
 
+All three paths converge on the same Cosmos DB account and the same
+Scrydex upstream, and Path B and Path C run byte-identical Azure Functions
+code. The cache hierarchy is **Redis → Cosmos → Scrydex upstream**: a
+cache miss falls through to Scrydex and writes back through the same
+layers.
+
 ### Architecture Principles
 
-#### 1. Cloud-Native Design
+#### 1. One product, multiple architectures
 
-- **Serverless-First**: Leverage Azure Functions and Cosmos DB serverless for optimal cost and scaling
-- **Managed Services**: Minimize operational overhead with fully managed Azure services
-- **Auto-Scaling**: Automatic scaling based on demand without manual intervention
+The repository deliberately ships the same application through three
+backend topologies so the architectural comparison is *operational*, not
+merely described. See [architecture-comparison.md](./architecture-comparison.md)
+and [ADR-007 — API Architecture Spectrum](./adr/ADR-007-api-architecture-spectrum.md).
 
-#### 2. Microservices Architecture
+#### 2. Runtime-selectable backends with graceful degradation
 
-- **Function-Based Services**: Each business capability implemented as separate Azure Function
-- **Independent Deployment**: Functions can be deployed independently without affecting others
-- **Loose Coupling**: Services communicate through well-defined APIs and events
+The active backend is chosen at runtime and the frontend degrades
+gracefully: a path that fails its healthcheck is hidden from the toggle
+rather than producing user-visible errors. A visitor who never engages
+the toggle always gets the default (Path A) experience.
 
-#### 3. API-First Design
+#### 3. Shared data and types
 
-- **Unified Gateway**: Single entry point through Azure API Management
-- **Consistent Interface**: RESTful APIs with OpenAPI specifications
-- **Version Management**: API versioning strategy for backward compatibility
+All paths share one Cosmos DB account and the same TypeScript types via
+`@pcpc/shared`. Path B and Path C ship the identical Functions source from
+`backend/functions/src/`.
 
-#### 4. Performance-Optimized
+#### 4. Cloud-native, scale-to-zero
 
-- **Caching**: Browser, API Management, and application-level caching
-- **Optimized Data Access**: Efficient Cosmos DB partitioning and indexing strategies
+Each path is serverless or scale-to-zero capable: Vercel serverless
+(Path A), APIM Consumption + Functions Consumption (Path B), and ACA with
+KEDA-ready scaling (Path C).
 
-#### 5. Security-First
+#### 5. Security and observability at the gateway
 
-- **Defense in Depth**: Multiple security layers from network to application
-- **Zero Trust**: Explicit verification for every request and resource access
-- **Managed Identity**: Azure AD integration for service-to-service authentication
+Read endpoints are anonymous at the Functions layer; cross-cutting
+concerns (CORS, rate limiting, telemetry) are owned by the gateway — APIM
+on Path B, ACA ingress on Path C. Secrets are sourced from Key Vault /
+Vercel env vars, and service-to-service auth uses managed identity.
+
+## The Three-Path Architecture
+
+This is the centerpiece of PCPC. The full operational, cost, and
+security comparison is in
+[architecture-comparison.md](./architecture-comparison.md); the summary
+below is the structural view.
+
+```mermaid
+graph TB
+    BROWSER[Browser<br/>pcpc.maber.io]
+
+    subgraph FE["SvelteKit on Vercel"]
+        ROUTER["Backend registry + store<br/>(lib/backends)"]
+    end
+
+    BROWSER --> ROUTER
+
+    ROUTER -->|"?backend=vercel"| PA
+    ROUTER -->|"?backend=azure"| PB
+    ROUTER -->|"?backend=aca"| PC
+
+    subgraph PathA["Path A — Vercel BFF (default)"]
+        PA["+server.ts routes<br/>lib/server/services"]
+    end
+
+    subgraph PathB["Path B — APIM + Functions"]
+        APIM[APIM Consumption]
+        FUNC_B[Azure Functions v4<br/>Node.js 22, ZIP]
+        APIM --> FUNC_B
+    end
+
+    subgraph PathC["Path C — ACA Container"]
+        INGRESS[ACA Ingress + KEDA]
+        FUNC_C[Azure Functions v4<br/>Node.js 22, OCI image]
+        INGRESS --> FUNC_C
+    end
+
+    PB --> APIM
+    PC --> INGRESS
+
+    PA --> COSMOS[(Cosmos DB<br/>PokemonCards)]
+    FUNC_B --> COSMOS
+    FUNC_C --> COSMOS
+    COSMOS -.->|cache miss| SCRYDEX[Scrydex API]
+```
+
+### Runtime backend selection
+
+The active path is chosen by the `?backend=` URL parameter and persisted
+in `localStorage`, with a corner badge showing the active backend and its
+last healthcheck latency. The abstraction lives in
+`frontend/src/lib/backends/`:
+
+| File | Responsibility |
+| --- | --- |
+| `types.ts` | `BackendId` (`vercel \| azure \| aca`), `BackendDefinition`, `BackendFetcher`, `BackendHealth` |
+| `store.svelte.ts` | Svelte 5 runes store; registry of the three backends, URL/localStorage sync, periodic health refresh, auto-fallback to default |
+| `health.ts` | `probeHealth()` with `HEALTH_TIMEOUT_MS = 2000`; maps HTTP 200→healthy, 207→degraded, else→unhealthy |
+| `path-a-vercel.ts` | Path A fetcher + healthcheck (`/api` prefix, same Vercel deployment) |
+| `path-b-azure.ts` | Path B fetcher; base URL from `PUBLIC_AZURE_API_BASE_URL`, defaults to the dev APIM hostname |
+| `path-c-aca.ts` | Path C fetcher; base URL from `PUBLIC_ACA_API_BASE_URL`, no fallback (unset ⇒ path hidden) |
+| `index.ts` | Public re-exports; consumers import only from `$lib/backends` |
+
+`lib/services/api.ts` delegates every request to `backendStore.active.fetcher`,
+so swapping paths swaps the implementation while routes, stores, and
+components stay unchanged.
+
+### Health-probe graceful degradation
+
+Each backend exposes a `/health` (or `/api/health`) endpoint returning
+`200` healthy, `207` degraded, or `503` unhealthy. The store probes every
+registered backend on init and on a 60s interval. `probeHealth` aborts
+after `HEALTH_TIMEOUT_MS` (2000 ms) and never throws. If the active
+backend goes unhealthy while the default (Path A / `vercel`) is still
+healthy, the store automatically reverts to the default — so the user
+experience never regresses below "Path A works." Path C is hidden from the
+toggle entirely when `PUBLIC_ACA_API_BASE_URL` is unset.
+
+### Path comparison (summary)
+
+| | Path A — Vercel BFF | Path B — APIM + Functions | Path C — ACA Container |
+| --- | --- | --- | --- |
+| Ingress | SvelteKit `+server.ts` (same Vercel deploy) | APIM Consumption | ACA ingress (L7) |
+| Business logic | SvelteKit server routes | Azure Functions v4 (ZIP) | Azure Functions v4 (OCI image) |
+| Scaling | Vercel per-request | APIM + Functions Consumption (scale-to-zero) | ACA scale rules, KEDA-ready (`min_replicas=1` in PCPC) |
+| IaC | None (Vercel project settings) | 9 base Terraform modules + APIM-as-code | + `container-app` module |
+| Code | SvelteKit-native | Functions source | Byte-identical Functions source |
+
+See [ADR-008 (APIM vs BFF gateway)](./adr/ADR-008-apim-vs-bff-gateway.md)
+and [ADR-009 (Functions Consumption vs ACA)](./adr/ADR-009-functions-consumption-vs-container-apps.md)
+for the decision narratives.
 
 ## System Components
 
 ### Frontend Components
 
-#### Svelte Single Page Application (SPA)
+The frontend is a **SvelteKit 2 / Svelte 5 (runes)** application styled
+with **Tailwind CSS v4**, built with **Vite**, and deployed to **Vercel**
+via `@sveltejs/adapter-vercel`. It is *not* an Azure Static Web App and
+*not* a Rollup-bundled SPA.
 
 ```mermaid
 graph TB
-    subgraph "Svelte Application Architecture"
-        APP[App.svelte<br/>Root Component]
+    subgraph SK["SvelteKit Application (frontend/src)"]
+        ROUTES["routes/<br/>pages + /api/** BFF endpoints"]
 
-        subgraph "Components"
-            SEARCH[SearchableSelect<br/>Card Search Interface]
-            CARD_SELECT[CardSearchSelect<br/>Card Selection]
-            VARIANT[CardVariantSelector<br/>Variant Selection]
-            THEME[ThemeToggle<br/>UI Theme Management]
-            DEBUG[DebugPanel<br/>Development Tools]
+        subgraph Lib["lib/"]
+            BACKENDS["backends/<br/>registry, store, path-a/b/c, health"]
+            COMPONENTS["components/<br/>SearchableSelect, CardSearchSelect,<br/>CardVariantSelector, BackendToggle, …"]
+            SERVICES["services/<br/>api.ts, db.ts, expansionMapper.ts, logger.ts"]
+            STORES["stores/ (Svelte 5 runes)<br/>cards, sets, pricing, theme, ui"]
+            SERVER["server/ (server-only)"]
         end
 
-        subgraph "Services"
-            HYBRID[HybridDataService<br/>Data Orchestration]
-            CLOUD[CloudDataService<br/>API Communication]
-            FEATURE[FeatureFlagService<br/>Feature Management]
-            CACHE_SVC[CacheService<br/>IndexedDB Management]
-        end
-
-        subgraph "Stores"
-            SET_STORE[SetStore<br/>Set Data State]
-            THEME_STORE[ThemeStore<br/>UI Theme State]
-            APP_STATE[AppState<br/>Application State]
-        end
-
-        subgraph "Utilities"
-            API_CLIENT[ApiClient<br/>HTTP Communication]
-            CACHE_UTIL[CacheUtils<br/>Storage Management]
-            DEBUG_UTIL[DebugUtils<br/>Development Helpers]
+        subgraph ServerSvc["server/services (Path A backend)"]
+            FE_COSMOS[cosmosDb.ts]
+            FE_REDIS[redisCache.ts]
+            FE_SCRYDEX[scrydexApi.ts]
+            FE_MON[monitoring.ts]
         end
     end
 
-    APP --> SEARCH
-    APP --> CARD_SELECT
-    APP --> VARIANT
-    APP --> THEME
-    APP --> DEBUG
-
-    SEARCH --> HYBRID
-    CARD_SELECT --> HYBRID
-    VARIANT --> CLOUD
-
-    HYBRID --> CLOUD
-    HYBRID --> CACHE_SVC
-    CLOUD --> API_CLIENT
-    CACHE_SVC --> CACHE_UTIL
-
-    SEARCH --> SET_STORE
-    THEME --> THEME_STORE
-    APP --> APP_STATE
+    ROUTES --> BACKENDS
+    ROUTES --> SERVER
+    SERVER --> FE_COSMOS
+    SERVER --> FE_REDIS
+    SERVER --> FE_SCRYDEX
+    SERVER --> FE_MON
+    COMPONENTS --> SERVICES
+    SERVICES --> BACKENDS
+    COMPONENTS --> STORES
 ```
 
-**Key Features**:
+**Key structure**:
 
-- **Reactive Components**: Svelte's compiled reactivity for optimal performance
-- **State Management**: Centralized state with Svelte stores
-- **Service Layer**: Clean separation between UI and business logic
-- **Caching Strategy**: Sophisticated IndexedDB caching with TTL management
+- **`lib/backends/`** — the runtime backend abstraction (registry/store,
+  health probe, three path definitions) described above.
+- **`routes/api/**/+server.ts`** — the Path A BFF endpoints (see below).
+- **`lib/server/services/`** — server-only implementations used by the
+  BFF: `cosmosDb.ts`, `redisCache.ts`, `scrydexApi.ts`, `monitoring.ts`
+  (mirroring the backend Functions services so Path A serves identical
+  Scrydex-shaped data).
+- **`lib/server/utils/`** — `cache.ts`, `errors.ts`; **`lib/server/config.ts`**
+  and **`lib/server/models/types.ts`**.
+- **`lib/services/`** — client services: `api.ts` (delegates to the active
+  backend), `db.ts`, `expansionMapper.ts`, `logger.ts`.
+- **`lib/stores/`** — Svelte 5 runes stores (`*.svelte.ts`): `cards`,
+  `sets`, `pricing`, `theme`, `ui`.
+- **`lib/components/`** — UI components including `BackendToggle.svelte`
+  (the path switcher), search/selection components, and pricing/chart
+  components.
 
-#### Static Web App Hosting
+#### Path A BFF routes (`routes/api/**/+server.ts`)
 
-- **Hosting**: Azure Static Web Apps
-- **Environment Configuration**: Separate configurations for dev/staging/production
-- **Planned**: Custom domain and CDN integration
+| Route | Purpose |
+| --- | --- |
+| `GET /api/sets` | List Pokemon sets |
+| `GET /api/sets/[set_id]/cards` | Cards for a set |
+| `GET /api/sets/[set_id]/cards/[card_id]` | Individual card details and pricing |
+| `GET /api/health` | Path A health probe (200/207/503) |
 
-### Backend Components
+These run as Vercel serverless functions in the same deployment as the
+page rendering, using `lib/server/services/*` to talk to Cosmos, Redis,
+and Scrydex directly — no separate gateway.
 
-#### Azure Functions v4 Architecture
+#### Frontend Hosting
+
+- **Hosting**: Vercel (via `@sveltejs/adapter-vercel`)
+- **Custom domain**: `pcpc.maber.io` (Vercel + Cloudflare)
+- **Build**: Vite (`vite build`); tests via Vitest
+
+### Backend Components (Path B / Path C)
+
+The backend is an **Azure Functions v4** app on **Node.js 22**, written in
+TypeScript. The *same* compiled code runs in two envelopes: a ZIP on a
+Consumption-plan Function App (Path B) and an OCI container image on Azure
+Container Apps (Path C). Source: `backend/functions/src/`.
 
 ```mermaid
 graph TB
-    subgraph "Azure Functions Runtime v4"
-        HOST[Functions Host<br/>Node.js 22 LTS]
-
-        subgraph "HTTP Triggered Functions"
-            GET_SETS[GetSetList<br/>GET /api/sets]
-            GET_CARDS[GetCardsBySet<br/>GET /api/sets/{setId}/cards]
-            GET_CARD[GetCardInfo<br/>GET /api/sets/{setId}/cards/{cardId}]
+    subgraph Host["Azure Functions Runtime v4 — Node.js 22"]
+        subgraph HTTP["HTTP Triggered Functions"]
+            GET_SETS["GetSetList<br/>GET /api/sets"]
+            GET_CARDS["GetCardsBySet<br/>GET /api/sets/{setId}/cards"]
+            GET_CARD["GetCardInfo<br/>GET /api/sets/{setId}/cards/{cardId}"]
+            HEALTH["HealthCheck<br/>GET /api/health"]
         end
 
-        subgraph "Timer Triggered Functions"
+        subgraph Timer["Timer Triggered Functions"]
             REFRESH[RefreshData<br/>0 0 */12 * * *]
-            MONITOR[MonitorCredits<br/>0 0 */6 * * *]
+            MONITOR[MonitorScrydexUsage<br/>0 0 */6 * * *]
         end
 
-        subgraph "Service Layer"
-            COSMOS_SVC[CosmosDbService<br/>Database Operations]
-            REDIS_SVC[RedisCacheService<br/>Caching Operations]
-            POKEDATA_SVC[PokeDataApiService<br/>Pricing API Integration]
-            POKEMONTCG_SVC[PokemonTcgApiService<br/>Metadata API Integration]
-            BLOB_SVC[BlobStorageService<br/>Asset Management]
-            IMAGE_SVC[ImageEnhancementService<br/>Image Processing]
-            MAPPING_SVC[PokeDataToTcgMappingService<br/>Data Mapping]
-            CREDIT_SVC[CreditMonitoringService<br/>Usage Tracking]
+        subgraph Services["Service Layer (services/)"]
+            COSMOS_SVC[CosmosDbService]
+            REDIS_SVC[RedisCacheService]
+            SCRYDEX_SVC[ScrydexApiService]
+            MON_SVC[MonitoringService]
         end
 
-        subgraph "Utilities"
-            CACHE_UTIL[CacheUtils<br/>Cache Management]
-            ERROR_UTIL[ErrorHandling<br/>Error Processing]
-            LOG_UTIL[LoggingUtils<br/>Structured Logging]
-            CONFIG_UTIL[ConfigUtils<br/>Configuration Management]
+        subgraph Utils["Utilities (utils/)"]
+            CACHE_UTIL[cacheUtils]
+            CARD_UTIL[cardToApiResponse]
+            ERR_UTIL[errorUtils]
+            LOG_UTIL[logger]
+            SCRY_UTIL[scrydexToCosmos]
         end
     end
-
-    HOST --> GET_SETS
-    HOST --> GET_CARDS
-    HOST --> GET_CARD
-    HOST --> REFRESH
-    HOST --> MONITOR
 
     GET_SETS --> COSMOS_SVC
     GET_SETS --> REDIS_SVC
-    GET_SETS --> POKEDATA_SVC
-
+    GET_SETS --> SCRYDEX_SVC
     GET_CARDS --> COSMOS_SVC
-    GET_CARDS --> POKEMONTCG_SVC
-    GET_CARDS --> MAPPING_SVC
-
+    GET_CARDS --> REDIS_SVC
+    GET_CARDS --> SCRYDEX_SVC
     GET_CARD --> COSMOS_SVC
-    GET_CARD --> IMAGE_SVC
-    GET_CARD --> POKEDATA_SVC
-
+    GET_CARD --> SCRYDEX_SVC
     REFRESH --> COSMOS_SVC
-    REFRESH --> POKEDATA_SVC
-    REFRESH --> POKEMONTCG_SVC
+    REFRESH --> SCRYDEX_SVC
+    MONITOR --> SCRYDEX_SVC
+    HEALTH --> COSMOS_SVC
+    HEALTH --> REDIS_SVC
 
-    MONITOR --> CREDIT_SVC
-    MONITOR --> LOG_UTIL
-
+    COSMOS_SVC --> SCRY_UTIL
+    SCRYDEX_SVC --> CARD_UTIL
     COSMOS_SVC --> CACHE_UTIL
-    REDIS_SVC --> ERROR_UTIL
-    POKEDATA_SVC --> CONFIG_UTIL
+    GET_SETS --> ERR_UTIL
+    COSMOS_SVC --> LOG_UTIL
+    GET_SETS --> MON_SVC
 ```
+
+**Services** (exactly four, instantiated in `backend/functions/src/index.ts`):
+
+| Service | Purpose |
+| --- | --- |
+| `CosmosDbService` | Read/write Cards and Sets in Cosmos DB (`PokemonCards` database) |
+| `RedisCacheService` | Optional cache layer, gated by `ENABLE_REDIS_CACHE` |
+| `ScrydexApiService` | Pricing + metadata from `api.scrydex.com` (key + team id) |
+| `MonitoringService` | Application Insights telemetry via `@azure/monitor-opentelemetry` (singleton) |
+
+**Utilities** (`utils/`): `cacheUtils`, `cardToApiResponse`, `errorUtils`,
+`logger`, `scrydexToCosmos`.
 
 **Function Specifications**:
 
-| Function           | Trigger     | Purpose                              | Dependencies                               |
-| ------------------ | ----------- | ------------------------------------ | ------------------------------------------ |
-| **GetSetList**     | HTTP GET    | Retrieve paginated Pokemon card sets | CosmosDB, PokeData API, Redis Cache        |
-| **GetCardsBySet**  | HTTP GET    | Fetch cards for specific set         | CosmosDB, Pokemon TCG API, Mapping Service |
-| **GetCardInfo**    | HTTP GET    | Individual card details and pricing  | CosmosDB, Image Service, PokeData API      |
-| **RefreshData**    | Timer (12h) | Background data synchronization      | All external APIs, CosmosDB                |
-| **MonitorCredits** | Timer (6h)  | API usage monitoring and alerting    | Credit Service, Logging                    |
+| Function | Trigger | Purpose | Dependencies |
+| --- | --- | --- | --- |
+| **GetSetList** | HTTP GET `sets` | List Pokemon sets | CosmosDbService, RedisCacheService, ScrydexApiService |
+| **GetCardsBySet** | HTTP GET `sets/{setId}/cards` | Cards for a set | CosmosDbService, RedisCacheService, ScrydexApiService |
+| **GetCardInfo** | HTTP GET `sets/{setId}/cards/{cardId}` | Card details + pricing | CosmosDbService, ScrydexApiService |
+| **HealthCheck** | HTTP GET `health` | Dependency health, drives the toggle's degradation (200/207/503) | CosmosDbService, RedisCacheService |
+| **RefreshData** | Timer `0 0 */12 * * *` | Background data sync from Scrydex into Cosmos | CosmosDbService, ScrydexApiService |
+| **MonitorScrydexUsage** | Timer `0 0 */6 * * *` | Track Scrydex API usage / quota | ScrydexApiService, MonitoringService |
 
-### API Gateway Components
+All HTTP triggers use `authLevel: "anonymous"` — auth lives at the gateway
+layer (APIM on Path B, ACA ingress on Path C), which keeps the application
+code byte-identical across both runtimes.
 
-#### Azure API Management Configuration
+#### Containerization (Path C)
 
-```mermaid
-graph TB
-    subgraph "API Management Layer"
-        APIM_GATEWAY[APIM Gateway<br/>Consumption Tier]
+`backend/functions/Dockerfile` is a multi-stage build on
+`mcr.microsoft.com/azure-functions/node:4-node22`:
 
-        subgraph "Products"
-            STARTER[Starter Product<br/>Basic Access]
-            PREMIUM[Premium Product<br/>Enhanced Limits]
-        end
+- **Build stage**: copies `shared/` (so the `file:../shared` `@pcpc/shared`
+  reference resolves), runs `npm ci`, then `tsc`.
+- **Runtime stage**: copies only `dist/`, `host.json`, and the manifests
+  onto the official Functions base image, runs `npm ci --omit=dev`
+  (excluding the types-only `@pcpc/shared`), and applies Debian OS security
+  patches to stay ahead of base-image CVE lag.
+- No `HEALTHCHECK` and no `ENTRYPOINT`/`CMD` overrides — ACA's
+  `ingress.health_probes` is the canonical probe and the base image's
+  entrypoint launches the host.
 
-        subgraph "APIs"
-            PCPC_API[PCPC API v1<br/>OpenAPI 3.0]
-            subgraph "Operations"
-                OP_SETS[GET /sets<br/>List Pokemon Sets]
-                OP_CARDS[GET /sets/{setId}/cards<br/>Cards by Set]
-                OP_CARD[GET /sets/{setId}/cards/{cardId}<br/>Card Details]
-            end
-        end
+Build context is `backend/`; the image is published to ACR as
+`pcpc/functions:<tag>` and CVE-scanned (Trivy, HIGH+) before push.
 
-        subgraph "Policies"
-            GLOBAL[Global Policy<br/>CORS, Rate Limiting]
-            CACHE_POLICY[Cache Policy<br/>Response Caching]
-            BACKEND[Backend Policy<br/>Function Integration]
-        end
+### API Gateway Component (Path B)
 
-        subgraph "Backend"
-            FUNCTION_BACKEND[Azure Functions Backend<br/>Load Balancing]
-        end
-    end
-
-    APIM_GATEWAY --> STARTER
-    APIM_GATEWAY --> PREMIUM
-    APIM_GATEWAY --> PCPC_API
-
-    PCPC_API --> OP_SETS
-    PCPC_API --> OP_CARDS
-    PCPC_API --> OP_CARD
-
-    APIM_GATEWAY --> GLOBAL
-    APIM_GATEWAY --> CACHE_POLICY
-    APIM_GATEWAY --> BACKEND
-
-    BACKEND --> FUNCTION_BACKEND
-```
-
-**Policy Configuration**:
-
-- **Rate Limiting**: 300 calls per 60 seconds (configurable by environment)
-- **CORS**: Configured for frontend domains with credentials support
-- **Caching**: Response caching with 5-60 minute TTL based on endpoint
-- **Authentication**: Subscription key authentication with future OAuth2 support
+Azure API Management on the **Consumption** tier fronts the Function App on
+Path B. APIM imports the API from the OpenAPI spec and maps its front path
+(`/pcpc-api/v1`) onto the backend `/api/*` routes. APIM provides CORS
+(regex policy, see [ADR-013](./adr/ADR-013-cors-regex-policy.md)), rate
+limiting (available, not currently configured), the developer portal, and
+request-level observability. `subscription_required = false` for the demo.
+Path C deliberately bypasses APIM and re-implements CORS at the ACA ingress
+`cors` block — see [architecture-comparison.md](./architecture-comparison.md#current-known-limitations).
 
 ## Data Architecture
 
 ### Database Design
 
-#### Cosmos DB Container Strategy
+PCPC uses a single Cosmos DB account (serverless) with the **`PokemonCards`**
+database. The `cosmos-db` Terraform module provisions three containers:
+
+| Container | Purpose |
+| --- | --- |
+| **Cards** | Individual card documents (metadata + Scrydex pricing) |
+| **Sets** | Pokemon set metadata |
+| **set_mappings** | Set-code / id mapping records |
 
 ```mermaid
 graph TB
-    subgraph "Cosmos DB Account (Serverless)"
-        DATABASE[PCPC Database]
-
-        subgraph "Sets Container"
-            SETS_PARTITION[Partition Key: /series<br/>Logical Partitions by Series]
-            SETS_INDEX[Composite Indexes<br/>series + releaseDate<br/>series + name]
-            SETS_DATA[Set Documents<br/>Metadata, Release Info]
-        end
-
-        subgraph "Cards Container"
-            CARDS_PARTITION[Partition Key: /setId<br/>Logical Partitions by Set]
-            CARDS_INDEX[Composite Indexes<br/>setId + cardNumber<br/>setId + name<br/>setId + rarity]
-            CARDS_DATA[Card Documents<br/>Metadata, Pricing, Images]
-        end
-
-        subgraph "Performance Optimization"
-            HOT_PARTITION[Hot Partition Mitigation<br/>Popular sets distributed]
-            QUERY_PATTERNS[Optimized Query Patterns<br/>Single-partition queries preferred]
-            RU_ANALYSIS[RU Cost Analysis<br/>2-5 RU single-partition<br/>5-50 RU cross-partition]
-        end
+    subgraph Account["Cosmos DB Account (Serverless)"]
+        DB[(PokemonCards database)]
+        CARDS[Cards container]
+        SETS[Sets container]
+        MAPPINGS[set_mappings container]
     end
 
-    DATABASE --> SETS_PARTITION
-    DATABASE --> CARDS_PARTITION
-
-    SETS_PARTITION --> SETS_INDEX
-    SETS_PARTITION --> SETS_DATA
-
-    CARDS_PARTITION --> CARDS_INDEX
-    CARDS_PARTITION --> CARDS_DATA
-
-    SETS_INDEX --> HOT_PARTITION
-    CARDS_INDEX --> QUERY_PATTERNS
-    HOT_PARTITION --> RU_ANALYSIS
+    DB --> CARDS
+    DB --> SETS
+    DB --> MAPPINGS
 ```
 
-**Container Specifications**:
+Container, database, and partition-key names are configurable via Terraform
+variables and the Functions `config` (`COSMOS_DB_DATABASE_NAME`,
+`COSMOS_DB_CARDS_CONTAINER_NAME`, `COSMOS_DB_SETS_CONTAINER_NAME`).
 
-| Container | Partition Key | Purpose                          | Indexing Strategy                                                     |
-| --------- | ------------- | -------------------------------- | --------------------------------------------------------------------- |
-| **Sets**  | `/series`     | Pokemon card set metadata        | Composite indexes on series + releaseDate, series + name              |
-| **Cards** | `/setId`      | Individual card data and pricing | Composite indexes on setId + cardNumber, setId + name, setId + rarity |
-
-#### Data Models
-
-**Set Document Structure**:
-
-```json
-{
-  "id": "base1",
-  "series": "Base",
-  "name": "Base Set",
-  "releaseDate": "1999-01-09",
-  "totalCards": 102,
-  "symbolUrl": "https://images.pokemontcg.io/base1/symbol.png",
-  "logoUrl": "https://images.pokemontcg.io/base1/logo.png",
-  "isRecent": false,
-  "metadata": {
-    "source": "pokemontcg",
-    "lastUpdated": "2025-09-28T21:00:00Z"
-  }
-}
-```
-
-**Card Document Structure**:
-
-```json
-{
-  "id": "base1-1",
-  "setId": "base1",
-  "cardNumber": "1",
-  "name": "Alakazam",
-  "rarity": "Rare Holo",
-  "images": {
-    "small": "https://images.pokemontcg.io/base1/1.png",
-    "large": "https://images.pokemontcg.io/base1/1_hires.png"
-  },
-  "pricing": {
-    "market": 45.5,
-    "low": 35.0,
-    "mid": 45.5,
-    "high": 65.0,
-    "lastUpdated": "2025-09-28T20:30:00Z"
-  },
-  "metadata": {
-    "tcgSetId": "base1",
-    "pokeDataId": "base-set-alakazam-1",
-    "lastSync": "2025-09-28T21:00:00Z"
-  }
-}
-```
+All schema is **Scrydex-canonical** (post-Phase-2.1 cutover). The Functions
+backend and the Path A BFF both emit canonical Scrydex-shaped envelopes
+from `@pcpc/shared`, so no client-side reshape is needed on any path.
 
 ### Caching Architecture
 
-#### Multi-Tier Caching Strategy
+The cache hierarchy is **Redis → Cosmos → Scrydex upstream**, shared by all
+three paths (see [ADR-003](./adr/ADR-003-caching-architecture-design.md)).
 
 ```mermaid
 graph TB
-    subgraph "Client-Side Caching"
-        BROWSER[Browser Cache<br/>Static Assets]
-        INDEXEDDB[IndexedDB<br/>Application Data]
-        subgraph "IndexedDB Stores"
-            SET_CACHE[setList<br/>TTL: 24h]
-            CARD_CACHE[cardsBySet<br/>TTL: 12h]
-            PRICE_CACHE[cardPricing<br/>TTL: 6h]
-            CONFIG_CACHE[config<br/>TTL: 1h]
-        end
-    end
+    REQUEST[Request for set / card / pricing]
+    REDIS{Redis hit?<br/>optional, ENABLE_REDIS_CACHE}
+    COSMOS{Cosmos hit?}
+    UPSTREAM[Scrydex API]
 
-    %% CDN layer not in use currently; caching at gateway/app levels
-    subgraph "Edge/Static Caching"
-        STATIC_CACHE[Static Assets<br/>TTL: 30 days]
-        API_CACHE[API Responses<br/>TTL: 5-60 minutes]
-    end
-
-    subgraph "API Gateway Caching"
-        APIM_CACHE[APIM Response Cache<br/>Environment-based TTL]
-        SET_RESPONSE[Set List Responses<br/>TTL: 60 minutes]
-        CARD_RESPONSE[Card Responses<br/>TTL: 30 minutes]
-        PRICE_RESPONSE[Pricing Responses<br/>TTL: 5 minutes]
-    end
-
-    subgraph "Application Caching"
-        REDIS_CACHE[Redis Cache<br/>Optional Performance Layer]
-        MEMORY_CACHE[In-Memory Cache<br/>Function Instance Cache]
-        COMPUTED_CACHE[Computed Results<br/>Expensive Operations]
-    end
-
-    BROWSER --> INDEXEDDB
-    INDEXEDDB --> SET_CACHE
-    INDEXEDDB --> CARD_CACHE
-    INDEXEDDB --> PRICE_CACHE
-    INDEXEDDB --> CONFIG_CACHE
-
-    APIM_CACHE --> API_CACHE
-
-    APIM_CACHE --> SET_RESPONSE
-    APIM_CACHE --> CARD_RESPONSE
-    APIM_CACHE --> PRICE_RESPONSE
-
-    REDIS_CACHE --> MEMORY_CACHE
-    REDIS_CACHE --> COMPUTED_CACHE
+    REQUEST --> REDIS
+    REDIS -->|miss / disabled| COSMOS
+    REDIS -->|hit| RESPONSE[Response]
+    COSMOS -->|hit| RESPONSE
+    COSMOS -->|miss| UPSTREAM
+    UPSTREAM --> WRITEBACK[Write back to Cosmos / Redis]
+    WRITEBACK --> RESPONSE
 ```
 
-**Cache Invalidation Strategy**:
-
-- **Time-Based**: TTL expiration for different data types
-- **Event-Based**: Manual invalidation on data updates
-- **Version-Based**: Cache versioning for breaking changes
-- **Graceful Degradation**: Fallback to source when cache unavailable
+- **Redis** is optional and gated by `ENABLE_REDIS_CACHE`; when disabled or
+  unavailable the system degrades to Cosmos + upstream.
+- **Cosmos** is the durable cache and source of truth for served data;
+  `RefreshData` repopulates it on a 12-hour timer.
+- **Graceful degradation**: a missing cache layer never fails the request;
+  it falls through to the next layer.
 
 ## Integration Patterns
 
-### External API Integration
-
-#### Hybrid API Strategy
+### Scrydex API integration
 
 ```mermaid
 graph TB
-    subgraph "PCPC Backend"
-        FUNCTIONS[Azure Functions]
-        MAPPING[Data Mapping Service]
-        CACHE[Cache Layer]
+    subgraph Backend["Any path's backend"]
+        SCRYDEX_SVC[ScrydexApiService]
+        TO_COSMOS[scrydexToCosmos]
+        TO_API[cardToApiResponse]
     end
 
-    subgraph "External APIs"
-        POKEDATA[PokeData API<br/>Enhanced Pricing Data]
-        POKEMONTCG[Pokemon TCG API<br/>Card Metadata]
-    end
+    SCRYDEX[Scrydex API<br/>api.scrydex.com]
 
-    subgraph "Data Sources"
-        PRICING[Pricing Information<br/>Market Values, Trends]
-        METADATA[Card Metadata<br/>Names, Images, Sets]
-        IMAGES[Card Images<br/>High-Quality Assets]
-    end
-
-    subgraph "Integration Patterns"
-        CIRCUIT_BREAKER[Circuit Breaker<br/>Fault Tolerance]
-        RETRY_LOGIC[Retry Logic<br/>Exponential Backoff]
-        RATE_LIMITING[Rate Limiting<br/>API Quota Management]
-        FALLBACK[Fallback Strategy<br/>Graceful Degradation]
-    end
-
-    FUNCTIONS --> MAPPING
-    FUNCTIONS --> CACHE
-
-    FUNCTIONS --> POKEDATA
-    FUNCTIONS --> POKEMONTCG
-
-    POKEDATA --> PRICING
-    POKEMONTCG --> METADATA
-    POKEMONTCG --> IMAGES
-
-    FUNCTIONS --> CIRCUIT_BREAKER
-    FUNCTIONS --> RETRY_LOGIC
-    FUNCTIONS --> RATE_LIMITING
-    FUNCTIONS --> FALLBACK
+    SCRYDEX_SVC --> SCRYDEX
+    SCRYDEX --> TO_COSMOS
+    TO_COSMOS --> COSMOS[(Cosmos DB)]
+    COSMOS --> TO_API
+    TO_API --> CLIENT[Frontend envelope]
 ```
 
-**API Integration Specifications**:
+Scrydex is the single upstream for both card metadata and pricing.
+Responses are normalized into Cosmos documents (`scrydexToCosmos`) and
+served to the frontend as canonical envelopes (`cardToApiResponse`). Usage
+is tracked by the `MonitorScrydexUsage` timer.
 
-| API                 | Purpose                                | Rate Limits      | Caching Strategy | Fallback             |
-| ------------------- | -------------------------------------- | ---------------- | ---------------- | -------------------- |
-| **PokeData API**    | Enhanced pricing data, graded values   | 1000 calls/day   | 6-hour TTL       | Cached pricing data  |
-| **Pokemon TCG API** | Card metadata, images, set information | 20,000 calls/day | 24-hour TTL      | Local metadata cache |
+### Resilience
 
-#### Error Handling and Resilience
-
-```mermaid
-graph TB
-    subgraph "Resilience Patterns"
-        REQUEST[API Request]
-
-        subgraph "Circuit Breaker"
-            CLOSED[Closed State<br/>Normal Operation]
-            OPEN[Open State<br/>Fast Fail]
-            HALF_OPEN[Half-Open State<br/>Testing Recovery]
-        end
-
-        subgraph "Retry Strategy"
-            IMMEDIATE[Immediate Retry<br/>Transient Failures]
-            EXPONENTIAL[Exponential Backoff<br/>Rate Limit Errors]
-            CIRCUIT_RETRY[Circuit Breaker Retry<br/>Service Recovery]
-        end
-
-        subgraph "Fallback Strategy"
-            CACHE_FALLBACK[Cache Fallback<br/>Stale Data Acceptable]
-            DEFAULT_FALLBACK[Default Values<br/>Minimal Functionality]
-            ERROR_RESPONSE[Error Response<br/>Graceful Failure]
-        end
-    end
-
-    REQUEST --> CLOSED
-    CLOSED --> OPEN
-    OPEN --> HALF_OPEN
-    HALF_OPEN --> CLOSED
-
-    REQUEST --> IMMEDIATE
-    IMMEDIATE --> EXPONENTIAL
-    EXPONENTIAL --> CIRCUIT_RETRY
-
-    REQUEST --> CACHE_FALLBACK
-    CACHE_FALLBACK --> DEFAULT_FALLBACK
-    DEFAULT_FALLBACK --> ERROR_RESPONSE
-```
+- **Timeouts**: health probes abort at 2000 ms (`HEALTH_TIMEOUT_MS`);
+  unhealthy paths degrade out of the toggle.
+- **Cache fallthrough**: Redis → Cosmos → upstream means any single layer
+  outage degrades rather than fails.
+- **Auto-fallback**: the frontend reverts to the default backend when the
+  active one is unhealthy.
 
 ## Security Architecture
 
-### Security Layers
-
 ```mermaid
 graph TB
-    subgraph "Network Security"
-        VNET[Virtual Network<br/>Network Isolation]
-        NSG[Network Security Groups<br/>Traffic Filtering]
-        FIREWALL[Azure Firewall<br/>Advanced Protection]
+    subgraph Identity["Identity & Access"]
+        MI[Managed Identity<br/>SystemAssigned on Functions,<br/>UAMI for ACR pull on ACA]
+        KV[Azure Key Vault<br/>secrets]
     end
 
-    subgraph "Identity & Access"
-        AAD[Azure Active Directory<br/>Identity Provider]
-        MANAGED_ID[Managed Identity<br/>Service Authentication]
-        RBAC[Role-Based Access Control<br/>Least Privilege]
+    subgraph Gateway["Gateway-layer Concerns"]
+        APIM_CORS[APIM CORS regex policy<br/>ADR-013]
+        ACA_CORS[ACA ingress CORS<br/>same allowlist]
+        RATE[Rate limiting<br/>available, not configured]
     end
 
-    subgraph "API Security"
-        APIM_AUTH[APIM Authentication<br/>Subscription Keys]
-        OAUTH[OAuth 2.0<br/>Future Implementation]
-        RATE_LIMIT[Rate Limiting<br/>DDoS Protection]
+    subgraph Data["Data Security"]
+        TLS[Encryption in transit<br/>TLS]
+        REST[Encryption at rest<br/>Cosmos DB]
     end
 
-    subgraph "Data Security"
-        ENCRYPTION_REST[Encryption at Rest<br/>Cosmos DB, Storage]
-        ENCRYPTION_TRANSIT[Encryption in Transit<br/>TLS 1.2+]
-        KEY_VAULT[Azure Key Vault<br/>Secrets Management]
-    end
-
-    subgraph "Application Security"
-        INPUT_VALIDATION[Input Validation<br/>XSS Prevention]
-        OUTPUT_ENCODING[Output Encoding<br/>Injection Prevention]
-        SECURITY_HEADERS[Security Headers<br/>OWASP Compliance]
-    end
-
-    VNET --> NSG
-    NSG --> FIREWALL
-
-    AAD --> MANAGED_ID
-    MANAGED_ID --> RBAC
-
-    APIM_AUTH --> OAUTH
-    OAUTH --> RATE_LIMIT
-
-    ENCRYPTION_REST --> ENCRYPTION_TRANSIT
-    ENCRYPTION_TRANSIT --> KEY_VAULT
-
-    INPUT_VALIDATION --> OUTPUT_ENCODING
-    OUTPUT_ENCODING --> SECURITY_HEADERS
+    KV --> MI
+    APIM_CORS --> RATE
+    ACA_CORS --> RATE
 ```
 
-### Authentication and Authorization
+- **Authn/authz**: read endpoints are anonymous; the Functions host emits
+  no CORS headers — the gateway is the single allowlist gate (APIM on
+  Path B, ACA ingress on Path C). Path A is same-origin within SvelteKit.
+- **Secrets**: Key Vault references resolved into Function App app-settings
+  (Path B) / ACA `secret` blocks via managed identity (Path C); Vercel env
+  vars (Path A).
+- **Identity**: SystemAssigned managed identity on the Function App;
+  user-assigned managed identity (UAMI) for ACR pull on ACA (no registry
+  admin user).
+- **Supply chain (Path C)**: digest-pinned image, Trivy HIGH+ CVE scan in
+  CI, Debian patch layer in the Dockerfile.
 
-**Current Implementation**:
-
-- **API Management**: Subscription key authentication
-- **Function Apps**: Function-level authorization keys
-- **Cosmos DB**: Connection string authentication (development)
-
-**Planned Enhancements**:
-
-- **Azure AD Integration**: Managed identity for service-to-service authentication
-- **OAuth 2.0**: User authentication for premium features
-- **Certificate-Based**: Client certificate authentication for high-security scenarios
+See [architecture-comparison.md](./architecture-comparison.md#security-posture)
+for the full per-path security comparison.
 
 ## Performance Architecture
 
-### Performance Optimization Strategy
-
 ```mermaid
 graph TB
-    subgraph "Frontend Performance"
-        CODE_SPLITTING[Code Splitting<br/>Route-based Loading]
-        LAZY_LOADING[Lazy Loading<br/>Component Loading]
-        ASSET_OPTIMIZATION[Asset Optimization<br/>Minification, Compression]
-        SERVICE_WORKER[Service Worker<br/>Offline Capability]
+    subgraph Frontend["Frontend"]
+        VITE[Vite build + code splitting]
+        RUNES[Svelte 5 runes reactivity]
     end
 
-    subgraph "API Performance"
-        RESPONSE_CACHING[Response Caching<br/>Multi-tier Strategy]
-        COMPRESSION[Response Compression<br/>Gzip, Brotli]
-        CDN_ACCELERATION[CDN Acceleration<br/>Global Distribution]
-        CONNECTION_POOLING[Connection Pooling<br/>Database Efficiency]
+    subgraph API["API"]
+        CACHE[Redis → Cosmos cache hierarchy]
+        SCALE[Per-request / scale-to-zero compute]
     end
 
-    subgraph "Database Performance"
-        PARTITION_STRATEGY[Partition Strategy<br/>Optimal Data Distribution]
-        INDEX_OPTIMIZATION[Index Optimization<br/>Query Performance]
-        QUERY_OPTIMIZATION[Query Optimization<br/>Single-partition Queries]
-        RU_OPTIMIZATION[RU Optimization<br/>Cost Efficiency]
+    subgraph DB["Database"]
+        SERVERLESS[Cosmos serverless RU model]
+        PART[Partitioned containers]
     end
 
-    subgraph "Monitoring & Optimization"
-        PERFORMANCE_MONITORING[Performance Monitoring<br/>Real-time Metrics]
-        BOTTLENECK_ANALYSIS[Bottleneck Analysis<br/>Performance Profiling]
-        CAPACITY_PLANNING[Capacity Planning<br/>Scaling Strategy]
-        COST_OPTIMIZATION[Cost Optimization<br/>Resource Efficiency]
-    end
-
-    CODE_SPLITTING --> LAZY_LOADING
-    LAZY_LOADING --> ASSET_OPTIMIZATION
-    ASSET_OPTIMIZATION --> SERVICE_WORKER
-
-    RESPONSE_CACHING --> COMPRESSION
-    COMPRESSION --> CDN_ACCELERATION
-    CDN_ACCELERATION --> CONNECTION_POOLING
-
-    PARTITION_STRATEGY --> INDEX_OPTIMIZATION
-    INDEX_OPTIMIZATION --> QUERY_OPTIMIZATION
-    QUERY_OPTIMIZATION --> RU_OPTIMIZATION
-
-    PERFORMANCE_MONITORING --> BOTTLENECK_ANALYSIS
-    BOTTLENECK_ANALYSIS --> CAPACITY_PLANNING
-    CAPACITY_PLANNING --> COST_OPTIMIZATION
+    VITE --> RUNES
+    CACHE --> SCALE
+    SERVERLESS --> PART
 ```
 
-### Performance Metrics
+**Notes**:
 
-**Target Performance Metrics**:
-
-- **Frontend Load Time**: < 2 seconds (first contentful paint)
-- **API Response Time**: < 500ms (95th percentile)
-- **Database Query Time**: < 100ms (single-partition queries)
-- **Cache Hit Ratio**: > 80% (application-level caching)
-
-**Achieved Performance**:
-
-- **DevContainer Startup**: 30-60 seconds (95% improvement)
-- **Frontend Build Time**: 2.4 seconds (production build)
-- **Test Execution**: ~40 seconds (26 comprehensive tests)
-- **Development Environment**: $0/month cost optimization
+- Cold-start and cost profiles differ by path; the quantified comparison
+  (Vercel ~50–150 ms, APIM+Functions cold ~500–1500 ms, ACA at
+  `min_replicas=1` ~0 ms cold) is in
+  [architecture-comparison.md](./architecture-comparison.md#scaling-and-cost).
+- Caching at the Redis/Cosmos layers minimizes Scrydex upstream calls.
+- Cosmos serverless keeps cost proportional to usage.
 
 ## Deployment Architecture
 
 ### Infrastructure as Code
 
+Terraform composes the Azure footprint from modules under `infra/modules/`.
+There are **9 base modules plus the `container-app` module** added for
+Path C. There is no Static Web App module (the frontend deploys to Vercel,
+not Azure).
+
 ```mermaid
 graph TB
-    subgraph "Terraform Infrastructure"
-        MODULES[Terraform Modules<br/>Reusable Components]
-
-        subgraph "Core Modules"
-            RG[Resource Group<br/>Resource Organization]
-            SWA[Static Web App<br/>Frontend Hosting]
-            FUNC[Function App<br/>Backend Services]
-            COSMOS[Cosmos DB<br/>Database Services]
-            APIM[API Management<br/>Gateway Services]
-            STORAGE[Storage Account<br/>Asset Storage]
-            INSIGHTS[Application Insights<br/>Monitoring Services]
-        end
-
-        subgraph "Environment Configs"
-            DEV[Development<br/>Cost-optimized]
-            STAGING[Staging<br/>Production-like]
-            PROD[Production<br/>High-availability]
-        end
-
-        subgraph "Deployment Pipeline"
-            VALIDATE[Terraform Validate<br/>Syntax Checking]
-            PLAN[Terraform Plan<br/>Change Preview]
-            APPLY[Terraform Apply<br/>Infrastructure Deployment]
-            DESTROY[Terraform Destroy<br/>Cleanup Operations]
-        end
+    subgraph Base["9 Base Modules"]
+        RG[resource-group]
+        KV[key-vault]
+        COSMOS[cosmos-db]
+        FUNC[function-app]
+        STORAGE[storage-account]
+        AI[application-insights]
+        LA[log-analytics]
+        APIM[api-management]
+        ACR[container-registry]
     end
 
-    MODULES --> RG
-    MODULES --> SWA
-    MODULES --> FUNC
-    MODULES --> COSMOS
-    MODULES --> APIM
-    MODULES --> STORAGE
-    MODULES --> INSIGHTS
+    subgraph PathC["Path C addition"]
+        CA[container-app<br/>reuses log-analytics, cosmos,<br/>app-insights, storage, ACR outputs]
+    end
 
-    MODULES --> DEV
-    MODULES --> STAGING
-    MODULES --> PROD
-
-    MODULES --> VALIDATE
-    VALIDATE --> PLAN
-    PLAN --> APPLY
-    APPLY --> DESTROY
+    Base --> CA
 ```
 
-### Environment Strategy
+| Module | Role |
+| --- | --- |
+| `resource-group` | Resource container |
+| `key-vault` | Secrets |
+| `cosmos-db` | PokemonCards DB + Cards/Sets/set_mappings containers |
+| `function-app` | Path B Functions host (Consumption) |
+| `storage-account` | Functions storage / assets |
+| `application-insights` | Telemetry sink |
+| `log-analytics` | Centralized logs (shared by Path B and Path C) |
+| `api-management` | Path B gateway (Consumption) |
+| `container-registry` | ACR for the Path C image |
+| `container-app` | Path C runtime (ACA + ingress + scale rules) |
 
-**Environment Specifications**:
+The frontend (Path A) has no Terraform footprint — it is managed entirely
+through Vercel project settings. APIM is additionally configured as code
+under `apim/`.
 
-| Environment     | Purpose                       | Configuration                          | Cost Target    |
-| --------------- | ----------------------------- | -------------------------------------- | -------------- |
-| **Development** | Local development and testing | Serverless/consumption tiers           | $0/month       |
-| **Staging**     | Pre-production validation     | Production-like with reduced scale     | $50-100/month  |
-| **Production**  | Live application              | High-availability, global distribution | $200-500/month |
+### Environment & CI/CD (by path)
+
+| | Path A | Path B | Path C |
+| --- | --- | --- | --- |
+| Deploy | Vercel auto-deploy on push, PR previews | Azure DevOps multi-stage; Functions ZIP deploy | Azure DevOps; Docker build → Trivy → ACR push → `az containerapp update` |
+| Custom domain | `pcpc.maber.io` | deferred (`*.azure-api.net`) per [ADR-012](./adr/ADR-012-apim-managed-cert-suspension.md) | deferred (`*.azurecontainerapps.io`) |
 
 ## Development Architecture
 
-### DevContainer Architecture
+### DevContainer
 
-```mermaid
-graph TB
-    subgraph "DevContainer Ecosystem"
-        ACR[Azure Container Registry<br/>Pre-built Images]
+Development uses a pre-built DevContainer image hosted in Azure Container
+Registry, with Node.js 22, Azure CLI, Terraform, Functions Core Tools, and
+supporting tooling, plus local emulators (Azurite, Cosmos DB Emulator) for
+offline backend development. Pre-building in ACR keeps environment setup to
+seconds rather than minutes.
 
-        subgraph "Container Image (1.28GB)"
-            BASE[Ubuntu 22.04 LTS<br/>Base Operating System]
-            NODE[Node.js 22.19.0 LTS<br/>Runtime Environment]
-            TOOLS[Development Tools<br/>9 Pre-installed Tools]
-            EXTENSIONS[VS Code Extensions<br/>35 Pre-configured Extensions]
-        end
+### Testing
 
-        subgraph "Development Tools"
-            AZURE_CLI[Azure CLI 2.77.0<br/>Cloud Management]
-            TERRAFORM[Terraform 1.9.8<br/>Infrastructure as Code]
-            FUNCTIONS_TOOLS[Functions Core Tools<br/>Local Development]
-            GO[Go 1.23.12<br/>Additional Language Support]
-            POWERSHELL[PowerShell 7.5.3<br/>Scripting Environment]
-            GIT[Git 2.51.0<br/>Version Control]
-            GITHUB_CLI[GitHub CLI 2.80.0<br/>GitHub Integration]
-            PYTHON[Python 3.12.11<br/>Scripting Support]
-        end
-
-        subgraph "Container Orchestration"
-            DEVCONTAINER[DevContainer<br/>Main Development Environment]
-            AZURITE[Azurite Emulator<br/>Storage Services]
-            COSMOS_EMU[Cosmos DB Emulator<br/>Database Services]
-            HEALTH_CHECKS[Health Checks<br/>Service Dependencies]
-        end
-
-        subgraph "Performance Optimization"
-            LAYER_CACHING[Docker Layer Caching<br/>Efficient Updates]
-            IMAGE_OPTIMIZATION[Image Optimization<br/>Size Reduction]
-            STARTUP_OPTIMIZATION[Startup Optimization<br/>95% Time Reduction]
-        end
-    end
-
-    ACR --> BASE
-    BASE --> NODE
-    NODE --> TOOLS
-    TOOLS --> EXTENSIONS
-
-    TOOLS --> AZURE_CLI
-    TOOLS --> TERRAFORM
-    TOOLS --> FUNCTIONS_TOOLS
-    TOOLS --> GO
-    TOOLS --> POWERSHELL
-    TOOLS --> GIT
-    TOOLS --> GITHUB_CLI
-    TOOLS --> PYTHON
-
-    ACR --> DEVCONTAINER
-    DEVCONTAINER --> AZURITE
-    DEVCONTAINER --> COSMOS_EMU
-    DEVCONTAINER --> HEALTH_CHECKS
-
-    ACR --> LAYER_CACHING
-    LAYER_CACHING --> IMAGE_OPTIMIZATION
-    IMAGE_OPTIMIZATION --> STARTUP_OPTIMIZATION
-```
-
-**DevContainer Performance Achievements**:
-
-- **95% Time Reduction**: Environment setup from 5-10 minutes to 30-60 seconds
-- **Pre-built Optimization**: All tools and extensions ready immediately
-- **Layer Caching**: Efficient Docker layer management for updates
-- **Container Orchestration**: Health checks ensure reliable service startup
-
-### Testing Architecture
-
-```mermaid
-graph TB
-    subgraph "Test Pyramid Implementation"
-        E2E[End-to-End Tests<br/>Playwright Cross-browser]
-        INTEGRATION[Integration Tests<br/>API & Database]
-        UNIT[Unit Tests<br/>Frontend & Backend]
-    end
-
-    subgraph "Frontend Testing"
-        COMPONENT[Component Tests<br/>Svelte Testing Library]
-        RENDER[Rendering Tests<br/>DOM Validation]
-        INTERACTION[Interaction Tests<br/>User Events]
-        ACCESSIBILITY[Accessibility Tests<br/>A11y Compliance]
-    end
-
-    subgraph "Backend Testing"
-        FUNCTION[Function Tests<br/>Azure Functions]
-        SERVICE[Service Tests<br/>Business Logic]
-        API_TEST[API Tests<br/>Endpoint Validation]
-        DATABASE[Database Tests<br/>Cosmos DB Integration]
-    end
-
-    subgraph "Test Infrastructure"
-        JEST[Jest Framework<br/>Projects Configuration]
-        PLAYWRIGHT[Playwright<br/>Cross-browser Testing]
-        MOCKS[Test Mocks<br/>External Dependencies]
-        COVERAGE[Coverage Reports<br/>HTML, LCOV, JSON]
-    end
-
-    E2E --> INTEGRATION
-    INTEGRATION --> UNIT
-
-    UNIT --> COMPONENT
-    COMPONENT --> RENDER
-    RENDER --> INTERACTION
-    INTERACTION --> ACCESSIBILITY
-
-    UNIT --> FUNCTION
-    FUNCTION --> SERVICE
-    SERVICE --> API_TEST
-    API_TEST --> DATABASE
-
-    JEST --> PLAYWRIGHT
-    PLAYWRIGHT --> MOCKS
-    MOCKS --> COVERAGE
-```
+- **Frontend**: Vitest (`npm run test` in `frontend/`), including the
+  backend abstraction (`lib/backends/health.test.ts`,
+  `path-*.ts` test helpers) and server utils.
+- **Backend**: Jest for Functions services and utilities.
+- **E2E**: Playwright for cross-browser flows.
 
 ## Monitoring Architecture
 
-### Observability Strategy
-
 ```mermaid
 graph TB
-    subgraph "Three Pillars of Observability"
-        METRICS[Metrics<br/>Performance Counters]
-        LOGS[Logs<br/>Structured Logging]
-        TRACES[Traces<br/>Distributed Tracing]
+    subgraph Sources["Telemetry Sources"]
+        FUNC[Functions — MonitoringService<br/>@azure/monitor-opentelemetry]
+        ACA_LOGS[ACA revision/replica logs]
+        VERCEL[Vercel logs]
     end
 
-    subgraph "Azure Monitor Stack"
-        APPINSIGHTS[Application Insights<br/>APM & Analytics]
-        LOG_ANALYTICS[Log Analytics<br/>Centralized Logging]
-        AZURE_MONITOR[Azure Monitor<br/>Infrastructure Metrics]
-        WORKBOOKS[Azure Workbooks<br/>Custom Dashboards]
+    subgraph Azure["Azure Monitor Stack"]
+        AI[Application Insights]
+        LA[Log Analytics<br/>shared by Path B & Path C]
     end
 
-    subgraph "Custom Monitoring"
-        BUSINESS_METRICS[Business Metrics<br/>API Usage, Errors]
-        PERFORMANCE_METRICS[Performance Metrics<br/>Response Times, Throughput]
-        COST_METRICS[Cost Metrics<br/>Resource Usage, Optimization]
-        SECURITY_METRICS[Security Metrics<br/>Authentication, Authorization]
-    end
-
-    subgraph "Alerting & Response"
-        ALERTS[Alert Rules<br/>Threshold-based]
-        NOTIFICATIONS[Notifications<br/>Email, Teams, SMS]
-        RUNBOOKS[Automated Runbooks<br/>Response Automation]
-        ESCALATION[Escalation Policies<br/>On-call Management]
-    end
-
-    METRICS --> APPINSIGHTS
-    LOGS --> LOG_ANALYTICS
-    TRACES --> APPINSIGHTS
-
-    APPINSIGHTS --> AZURE_MONITOR
-    LOG_ANALYTICS --> WORKBOOKS
-
-    AZURE_MONITOR --> BUSINESS_METRICS
-    WORKBOOKS --> PERFORMANCE_METRICS
-    BUSINESS_METRICS --> COST_METRICS
-    PERFORMANCE_METRICS --> SECURITY_METRICS
-
-    COST_METRICS --> ALERTS
-    SECURITY_METRICS --> NOTIFICATIONS
-    ALERTS --> RUNBOOKS
-    NOTIFICATIONS --> ESCALATION
+    FUNC --> AI
+    ACA_LOGS --> LA
+    AI --> LA
 ```
+
+- **Application Insights** receives Functions telemetry via
+  `MonitoringService` (`@azure/monitor-opentelemetry`); Path B and Path C
+  share the same App Insights + Log Analytics workspace.
+- **Path C** additionally emits ACA-native revision/replica logs.
+- **Path A** observability is Vercel logs + browser dev tools.
 
 ## Architecture Decisions
 
-### Key Technical Decisions
+The decision narrative is captured in the ADRs; the most load-bearing for
+this architecture:
 
-#### 1. Serverless-First Architecture
+- [ADR-003 — Caching Architecture](./adr/ADR-003-caching-architecture-design.md): Redis → Cosmos → upstream hierarchy
+- [ADR-007 — API Architecture Spectrum](./adr/ADR-007-api-architecture-spectrum.md): why three paths exist
+- [ADR-008 — APIM vs SvelteKit BFF](./adr/ADR-008-apim-vs-bff-gateway.md): Path A vs Path B gateway tradeoff
+- [ADR-009 — Functions Consumption vs Container Apps](./adr/ADR-009-functions-consumption-vs-container-apps.md): Path B vs Path C runtime tradeoff
+- [ADR-012 — APIM Managed-Cert Suspension](./adr/ADR-012-apim-managed-cert-suspension.md): why custom domains are deferred
+- [ADR-013 — CORS Regex Policy](./adr/ADR-013-cors-regex-policy.md): gateway-owned CORS allowlist
 
-**Decision**: Use Azure Functions and Cosmos DB serverless for backend services
-**Rationale**:
+### Key technical decisions (summary)
 
-- Cost optimization for variable workloads
-- Automatic scaling without infrastructure management
-- Pay-per-use pricing model aligns with usage patterns
-
-**Alternatives Considered**:
-
-- Container-based services (Azure Container Apps)
-- Traditional VM-based hosting
-- Kubernetes orchestration
-
-**Trade-offs**:
-
-- ✅ Lower operational overhead
-- ✅ Automatic scaling
-- ✅ Cost efficiency for variable loads
-- ❌ Cold start latency
-- ❌ Vendor lock-in considerations
-
-#### 2. Multi-Tier Caching Strategy
-
-**Decision**: Implement caching at browser, CDN, API gateway, and application levels
-**Rationale**:
-
-- Optimize performance across all system layers
-- Reduce external API calls and costs
-- Improve user experience with faster response times
-
-**Implementation**:
-
-- **Browser**: IndexedDB with TTL management
-- **CDN**: Azure CDN for static assets and API responses
-- **API Gateway**: APIM response caching
-- **Application**: Optional Redis for computed results
-
-#### 3. Hybrid API Integration
-
-**Decision**: Combine PokeData API (pricing) with Pokemon TCG API (metadata)
-**Rationale**:
-
-- PokeData provides enhanced pricing data not available elsewhere
-- Pokemon TCG API offers comprehensive metadata and images
-- Hybrid approach provides best of both data sources
-
-**Resilience Patterns**:
-
-- Circuit breaker for fault tolerance
-- Exponential backoff for rate limiting
-- Graceful fallback to cached data
-
-#### 4. DevContainer ACR Optimization
-
-**Decision**: Pre-build development environment in Azure Container Registry
-**Rationale**:
-
-- 95% reduction in environment setup time
-- Consistent development environment across team
-- Eliminates dependency on external package repositories
-
-**Implementation**:
-
-- 1.28GB optimized container image
-- 35 VS Code extensions pre-installed
-- 9 development tools ready to use
-- Health checks for service dependencies
-
-#### 5. Infrastructure as Code with Terraform
-
-**Decision**: Use Terraform for all infrastructure management
-**Rationale**:
-
-- Declarative infrastructure definition
-- Version control for infrastructure changes
-- Multi-environment deployment consistency
-- Azure provider maturity and feature coverage
-
-**Module Strategy**:
-
-- Reusable modules for common patterns
-- Environment-specific configurations
-- Remote state management for team collaboration
-
-### Architecture Evolution
-
-#### Phase 1: Foundation (Completed)
-
-- Basic infrastructure setup
-- Development environment optimization
-- Core service architecture
-
-#### Phase 2: Application Migration (Completed)
-
-- Frontend and backend application migration
-- Database schema implementation
-- API integration patterns
-
-#### Phase 3: Advanced Features (Completed)
-
-- API Management as Code
-- Comprehensive testing framework
-- Database schema management
-
-#### Phase 4: Enterprise Documentation (In Progress)
-
-- Comprehensive documentation suite
-- Monitoring and observability setup
-- Production readiness validation
-
-### Future Architecture Considerations
-
-#### Planned Enhancements
-
-1. **Enhanced Security**
-
-   - Azure AD integration for authentication
-   - Certificate-based authentication
-   - Advanced threat protection
-
-2. **Global Distribution**
-
-   - Multi-region deployment
-   - Global database replication
-   - Edge computing optimization
-
-3. **Advanced Analytics**
-
-   - Real-time analytics pipeline
-   - Machine learning integration
-   - Predictive pricing models
-
-4. **Microservices Evolution**
-   - Service mesh implementation
-   - Event-driven architecture
-   - CQRS pattern adoption
-
-#### Scalability Roadmap
-
-- **Current**: Single-region serverless architecture
-- **Phase 1**: Multi-region deployment with global distribution
-- **Phase 2**: Event-driven microservices with service mesh
-- **Phase 3**: AI/ML integration for predictive analytics
+1. **Three interchangeable backends from one frontend** — make the
+   architectural comparison operational, not theoretical.
+2. **Gateway-owned cross-cutting concerns** — CORS/rate-limiting/telemetry
+   live at APIM (Path B) or ACA ingress (Path C) so the Functions code is
+   byte-identical across runtimes.
+3. **Single Scrydex upstream + Cosmos cache** — one data source, one cache
+   hierarchy, one set of shared types (`@pcpc/shared`).
+4. **Scale-to-zero everywhere, container portability on Path C** — Path C's
+   OCI image is the portable artifact (runs on AKS/ECS/GKE/local Docker)
+   without paying AKS cost today.
 
 ---
 
 ## Summary
 
-The PCPC system architecture is built around the following design principles:
+PCPC's architecture is defined by **one product served three ways**:
 
-- **Cloud-Native**: Serverless-first approach with Azure managed services
-- **Performance-Optimized**: Multi-tier caching and optimized data access patterns
-- **Security-First**: Defense in depth with comprehensive security layers
-- **Developer-Friendly**: DevContainer with 95% setup time reduction
-- **Scalable**: Designed for growth with clear evolution path
+- **One SvelteKit frontend** (Svelte 5 runes, Tailwind v4) on **Vercel**,
+  with a runtime backend toggle (`?backend=vercel|azure|aca`) and
+  health-probe graceful degradation.
+- **Three backend paths** — Vercel BFF (`+server.ts`), APIM + Azure
+  Functions v4 (Consumption), and the same Functions image on Azure
+  Container Apps with KEDA-ready scaling.
+- **Shared data** — one Cosmos DB account (`PokemonCards`), optional Redis,
+  and the **Scrydex** upstream — with App Insights / Log Analytics
+  observability and Key Vault / managed-identity security.
 
-This architecture serves as both a functional Pokemon card price checking application and a comprehensive demonstration of advanced software engineering capabilities suitable for senior-level technical roles.
+The companion document,
+[architecture-comparison.md](./architecture-comparison.md), carries the
+full operational, cost, and security tradeoff analysis between the three
+paths.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -80,7 +80,7 @@ graph TB
 
 ### Azure Resources
 
-The PCPC infrastructure consists of 7 core Azure resources managed through Terraform modules:
+The PCPC infrastructure is managed through 10 Terraform modules (`infra/modules/`): `api-management`, `application-insights`, `container-app`, `container-registry`, `cosmos-db`, `function-app`, `key-vault`, `log-analytics`, `resource-group`, and `storage-account`. The core resources are described below. (The frontend is no longer provisioned by Terraform; see the Static Web App note.)
 
 #### 1. Resource Group (`infra/modules/resource-group/`)
 
@@ -103,33 +103,11 @@ module "resource_group" {
 }
 ```
 
-#### 2. Static Web App (`infra/modules/static-web-app/`)
+#### 2. Frontend (Vercel — not managed by Terraform)
 
-**Purpose**: Hosts the Svelte frontend application
-**Features (current)**:
+**Purpose**: Hosts the SvelteKit frontend application
 
-- Managed Azure Static Web Apps resource
-- Configuration via Terraform variables (no repo-binding in TF)
-- Deployed via Azure DevOps template (`.ado/templates/deploy-swa.yml`)
-
-> Note: Custom domains are provisioned by Terraform when enabled and when Porkbun API credentials are provided. Azure CDN/Front Door is not provisioned at this time and remains a future enhancement.
-
-**Minimal Module Configuration (current)**:
-
-```hcl
-module "static_web_app" {
-  source = "../../modules/static-web-app"
-
-  name                = "pcpc-swa-dev"
-  resource_group_name = module.resource_group.name
-  location            = module.resource_group.location
-
-  # Build/deploy is handled by Azure DevOps
-  # Optional app_settings or flags can be set here
-
-  tags = local.common_tags
-}
-```
+> **Note:** As of 2026-05-14, the frontend is deployed to [Vercel](https://vercel.com/) using `@sveltejs/adapter-vercel` (see `frontend/svelte.config.js`). It is **not** provisioned by this Terraform configuration — there is no `infra/modules/static-web-app/` module. The prior Azure Static Web Apps + Porkbun DNS provisioning was removed. Frontend deployment is handled by Vercel's own build/deploy pipeline (Git integration), so there are no Terraform resources to apply for the frontend.
 
 #### 3. Function App (`infra/modules/function-app/`)
 
@@ -159,7 +137,7 @@ module "function_app" {
     WEBSITE_NODE_DEFAULT_VERSION = "~22"
 
     COSMOS_DB_CONNECTION_STRING = module.cosmos_db.connection_string
-    COSMOS_DB_DATABASE_NAME     = "PokeData"
+    COSMOS_DB_DATABASE_NAME     = "PokemonCards"
 
     POKEDATA_API_KEY     = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.pokedata_api_key.id})"
     POKEMON_TCG_API_KEY  = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.pokemon_tcg_api_key.id})"
@@ -189,7 +167,7 @@ module "cosmos_db" {
   resource_group_name = module.resource_group.name
   location           = module.resource_group.location
 
-  database_name = "PokeData"
+  database_name = "PokemonCards"
 
   containers = [
     {
@@ -607,23 +585,31 @@ curl -X GET "https://pokedata-apim-dev.azure-api.net/api/sets" \
 
 #### Remote State Configuration
 
+Terraform state is stored in Azure Blob Storage. The backend is declared inline in each environment's `main.tf` (there is no separate `backend.tf` or `state-storage/` directory). For example, `infra/envs/dev/main.tf`:
+
 ```hcl
-# backend.tf
 terraform {
+  # Remote backend for state management
   backend "azurerm" {
-    resource_group_name  = "terraform-state-rg"
-    storage_account_name = "terraformstatestorage"
+    resource_group_name  = "pcpc-terraform-state-rg"
+    storage_account_name = "pcpctfstatedacc29c2"
     container_name       = "tfstate"
-    key                  = "pcpc/dev/terraform.tfstate"
+    key                  = "dev.terraform.tfstate"
+    # tenant_id and subscription_id are supplied at init time via the
+    # ARM_TENANT_ID / ARM_SUBSCRIPTION_ID environment variables, Azure CLI
+    # authentication, or -backend-config arguments.
   }
 }
 ```
 
+The `staging` and `prod` environments use the same storage account and container with their own state keys (`staging.terraform.tfstate`, `prod.terraform.tfstate`).
+
 #### State Management Commands
 
 ```bash
-# Initialize remote state
-terraform init -backend-config="backend.hcl"
+# Initialize remote state (auth values come from ARM_* env vars / az login,
+# or pass them with -backend-config="key=value" arguments)
+terraform init
 
 # Import existing resources
 terraform import azurerm_resource_group.main /subscriptions/sub-id/resourceGroups/rg-name
@@ -666,30 +652,22 @@ terraform workspace list
 
 ## Application Deployment
 
-### Frontend Deployment (Static Web App)
+### Frontend Deployment (Vercel)
 
-The frontend deployment is automated through Azure DevOps using the Static Web Apps template.
+The frontend (`frontend/`) is a SvelteKit app deployed to Vercel via `@sveltejs/adapter-vercel` (see `frontend/svelte.config.js`). Deployment is driven by Vercel's Git integration: pushes to the connected branch trigger a Vercel build and deploy. There is no Azure or Terraform step for the frontend.
 
-#### Deployment Configuration
-
-**Azure DevOps Template** (`.ado/templates/deploy-swa.yml`)
-
-This template builds the frontend and deploys to the SWA resource. Configure variables (e.g., API base URL, subscription key) via variable groups or pipeline variables.
-
-#### Manual Deployment
+#### Local Build
 
 ```bash
 # Build frontend locally
-cd app/frontend
+cd frontend
 npm install
 npm run build
-
-# Deploy using Azure CLI
-az staticwebapp deploy \
-  --name "pokedata-dev" \
-  --resource-group "pokedata-dev-rg" \
-  --source-location "public"
 ```
+
+#### Configuration
+
+Frontend environment variables (e.g., API base URL, subscription key) are configured in the Vercel project settings rather than in Azure DevOps. See the [Environment Variables](#environment-variables) section for the relevant `VITE_*` values.
 
 ### Backend Deployment (Azure Functions)
 
@@ -706,7 +684,7 @@ trigger:
       - main
   paths:
     include:
-      - app/backend/*
+      - backend/functions/*
 
 pool:
   vmImage: "ubuntu-latest"
@@ -729,14 +707,14 @@ stages:
             displayName: "Install Node.js"
 
           - script: |
-              cd app/backend
+              cd backend/functions
               npm install
               npm run build
             displayName: "Install dependencies and build"
 
           - task: ArchiveFiles@2
             inputs:
-              rootFolderOrFile: "app/backend"
+              rootFolderOrFile: "backend/functions"
               includeRootFolder: false
               archiveType: "zip"
               archiveFile: "$(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip"
@@ -777,7 +755,7 @@ stages:
 
 ```bash
 # Build backend locally
-cd app/backend
+cd backend/functions
 npm install
 npm run build
 
@@ -804,11 +782,11 @@ az functionapp function list \
 # Deploy database schema using Cosmos DB Data Migration Tool
 dt.exe /s:JsonFile /s.Files:db/schemas/containers/sets.json \
   /t:CosmosDB /t.ConnectionString:"AccountEndpoint=https://pokedata-cosmos-dev.documents.azure.com:443/;AccountKey=your-key;" \
-  /t.Database:PokeData /t.Collection:sets
+  /t.Database:PokemonCards /t.Collection:sets
 
 dt.exe /s:JsonFile /s.Files:db/schemas/containers/cards.json \
   /t:CosmosDB /t.ConnectionString:"AccountEndpoint=https://pokedata-cosmos-dev.documents.azure.com:443/;AccountKey=your-key;" \
-  /t.Database:PokeData /t.Collection:cards
+  /t.Database:PokemonCards /t.Collection:cards
 ```
 
 #### Index Management
@@ -818,14 +796,14 @@ dt.exe /s:JsonFile /s.Files:db/schemas/containers/cards.json \
 az cosmosdb sql container update \
   --resource-group "pokedata-dev-rg" \
   --account-name "pokedata-cosmos-dev" \
-  --database-name "PokeData" \
+  --database-name "PokemonCards" \
   --name "sets" \
   --idx @db/schemas/indexes/sets-indexes.json
 
 az cosmosdb sql container update \
   --resource-group "pokedata-dev-rg" \
   --account-name "pokedata-cosmos-dev" \
-  --database-name "PokeData" \
+  --database-name "PokemonCards" \
   --name "cards" \
   --idx @db/schemas/indexes/cards-indexes.json
 ```
@@ -1027,7 +1005,7 @@ VITE_CACHE_TTL=3600
     "WEBSITE_NODE_DEFAULT_VERSION": "~22",
 
     "COSMOS_DB_CONNECTION_STRING": "AccountEndpoint=https://pokedata-cosmos-dev.documents.azure.com:443/;AccountKey=...",
-    "COSMOS_DB_DATABASE_NAME": "PokeData",
+    "COSMOS_DB_DATABASE_NAME": "PokemonCards",
 
     "POKEDATA_API_KEY": "@Microsoft.KeyVault(SecretUri=https://pokedata-kv-dev.vault.azure.net/secrets/pokedata-api-key/)",
     "POKEMON_TCG_API_KEY": "@Microsoft.KeyVault(SecretUri=https://pokedata-kv-dev.vault.azure.net/secrets/pokemon-tcg-api-key/)",
@@ -1090,7 +1068,7 @@ resource "azurerm_key_vault_secret" "pokemon_tcg_api_key" {
 
 #### Environment Variable Templates
 
-**Development Template** (`app/frontend/.env.example`):
+**Development Template** (`frontend/.env.example`):
 
 ```bash
 # API Configuration
@@ -1113,7 +1091,7 @@ VITE_CACHE_TTL=300
 VITE_API_TIMEOUT=10000
 ```
 
-**Backend Template** (`app/backend/.env.example`):
+**Backend Template** (`backend/functions/.env.example`):
 
 ```bash
 # Azure Functions Configuration
@@ -1124,7 +1102,7 @@ WEBSITE_NODE_DEFAULT_VERSION=~22
 
 # Database Configuration
 COSMOS_DB_CONNECTION_STRING=AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==
-COSMOS_DB_DATABASE_NAME=PokeData
+COSMOS_DB_DATABASE_NAME=PokemonCards
 
 # External API Keys (use Key Vault references in production)
 POKEDATA_API_KEY=your-pokedata-api-key
@@ -1354,7 +1332,7 @@ async function checkDatabaseHealth(): Promise<"healthy" | "unhealthy"> {
     // Simple database connectivity check
     const cosmosClient = getCosmosClient();
     await cosmosClient
-      .database("PokeData")
+      .database("PokemonCards")
       .container("sets")
       .items.query("SELECT TOP 1 * FROM c")
       .fetchNext();
@@ -1712,7 +1690,7 @@ az staticwebapp appsettings set \
 az cosmosdb sql database restore \
   --resource-group "pokedata-prod-rg" \
   --account-name "pokedata-cosmos-prod" \
-  --database-name "PokeData" \
+  --database-name "PokemonCards" \
   --restore-timestamp "2025-09-28T20:00:00Z"
 ```
 
@@ -1722,7 +1700,7 @@ az cosmosdb sql database restore \
 
 This deployment guide provides comprehensive coverage of the PCPC deployment process, from infrastructure setup to production monitoring. Key highlights include:
 
-- **Complete Infrastructure as Code**: 7 Terraform modules with multi-environment support
+- **Complete Infrastructure as Code**: 10 Terraform modules with multi-environment support
 - **Automated CI/CD Pipelines**: Azure DevOps validation and deployment pipelines
 - **Comprehensive Monitoring**: Application Insights with custom dashboards and alerts
 - **Rollout**: Direct deploy with validations (blue-green/canary planned)

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -59,11 +59,11 @@ Before you begin, ensure you have the following installed:
 4. **Install Dependencies**
 
    ```bash
-   # Frontend dependencies (154 packages)
-   cd app/frontend && npm install
+   # Frontend dependencies
+   cd frontend && npm install
 
-   # Backend dependencies (94 packages)
-   cd ../backend && npm install
+   # Backend dependencies
+   cd ../backend/functions && npm install
 
    # Return to root
    cd ../..
@@ -73,10 +73,10 @@ Before you begin, ensure you have the following installed:
 
    ```bash
    # Start frontend development server
-   cd app/frontend && npm run dev
+   cd frontend && npm run dev
 
    # In another terminal, start backend
-   cd app/backend && npm run start
+   cd backend/functions && npm run start
    ```
 
 ### Repository Structure
@@ -85,24 +85,25 @@ Understanding the PCPC repository structure is crucial for effective development
 
 ```
 PCPC/
-├── app/                          # Application code
-│   ├── frontend/                 # Svelte frontend application
-│   │   ├── src/                  # Source code (components, services, stores)
-│   │   ├── public/               # Static assets and build output
-│   │   └── package.json          # Frontend dependencies and scripts
-│   └── backend/                  # Azure Functions backend
-│       ├── src/                  # TypeScript source code
-│       │   ├── functions/        # Azure Functions (5 functions)
-│       │   ├── services/         # Business logic services (11 services)
-│       │   ├── models/           # TypeScript interfaces and types
-│       │   └── utils/            # Utility functions and helpers
-│       └── package.json          # Backend dependencies and scripts
+├── frontend/                     # SvelteKit frontend application
+│   ├── src/                      # Source code (components, services, stores)
+│   ├── static/                   # Static assets
+│   └── package.json              # Frontend dependencies and scripts
+├── backend/                      # Backend code
+│   ├── functions/                # Azure Functions app
+│   │   ├── src/                  # TypeScript source code
+│   │   │   ├── functions/        # Azure Functions (6 functions)
+│   │   │   ├── services/         # Business logic services
+│   │   │   ├── models/           # TypeScript interfaces and types
+│   │   │   └── utils/            # Utility functions and helpers
+│   │   └── package.json          # Backend dependencies and scripts
+│   └── shared/                   # Shared types (@pcpc/shared)
 ├── infra/                        # Infrastructure as Code
 │   ├── modules/                  # Terraform modules (7 modules)
 │   └── envs/                     # Environment-specific configurations
 ├── tests/                        # Comprehensive testing framework
-│   ├── frontend/                 # Frontend component tests
 │   ├── backend/                  # Backend function tests
+│   ├── e2e/                      # End-to-end (Playwright) tests
 │   └── config/                   # Testing configuration and utilities
 ├── docs/                         # Documentation suite
 ├── apim/                         # API Management as Code
@@ -184,50 +185,63 @@ The DevContainer includes a comprehensive extension pack:
 
 #### Frontend Environment Variables
 
-Create `app/frontend/.env` based on `.env.example`:
+Create `frontend/.env` based on `frontend/.env.example`:
 
 ```bash
-# API Configuration
-VITE_API_BASE_URL=http://localhost:7071/api
-VITE_APIM_SUBSCRIPTION_KEY=your-subscription-key-here
+# Azure Cosmos DB
+COSMOS_DB_CONNECTION_STRING=
+COSMOS_DB_DATABASE_NAME=PokemonCards
+COSMOS_DB_CARDS_CONTAINER_NAME=Cards
+COSMOS_DB_SETS_CONTAINER_NAME=Sets
 
-# Feature Flags
-VITE_ENABLE_DEBUG_PANEL=true
-VITE_ENABLE_PERFORMANCE_MONITORING=true
-VITE_ENABLE_CACHE_DEBUGGING=true
+# Redis Cache (optional)
+REDIS_CONNECTION_STRING=
+ENABLE_REDIS_CACHE=false
 
-# External APIs
-VITE_POKEDATA_API_BASE_URL=https://www.pokedata.io/v0
-VITE_POKEMON_TCG_API_BASE_URL=https://api.pokemontcg.io/v2
+# Scrydex API
+SCRYDEX_API_KEY=
+SCRYDEX_TEAM_ID=
+SCRYDEX_API_BASE_URL=https://api.scrydex.com/pokemon/v1
 
-# Development Settings
-VITE_ENVIRONMENT=development
-VITE_LOG_LEVEL=debug
+# Cache TTLs (seconds)
+CACHE_TTL_SETS=604800
+CACHE_TTL_CARDS=3600
+
+# Frontend (Vite - prefixed with VITE_)
+VITE_API_URL=/api
 ```
 
 #### Backend Environment Variables
 
-Create `app/backend/local.settings.json` based on the template:
+Create `backend/functions/local.settings.json` based on the `local.settings.json.example` template:
 
 ```json
 {
   "IsEncrypted": false,
   "Values": {
-    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "node",
     "FUNCTIONS_EXTENSION_VERSION": "~4",
+    "NODE_ENV": "development",
 
     "COSMOS_DB_CONNECTION_STRING": "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-    "COSMOS_DB_DATABASE_NAME": "PokeData",
+    "COSMOS_DB_DATABASE_NAME": "PokemonCards",
+    "COSMOS_DB_CARDS_CONTAINER_NAME": "Cards",
+    "COSMOS_DB_SETS_CONTAINER_NAME": "Sets",
 
-    "POKEDATA_API_KEY": "your-pokedata-api-key",
-    "POKEMON_TCG_API_KEY": "your-pokemon-tcg-api-key",
+    "SCRYDEX_API_KEY": "your_scrydex_api_key_here",
+    "SCRYDEX_TEAM_ID": "your_scrydex_team_id_here",
+    "SCRYDEX_API_BASE_URL": "https://api.scrydex.com/pokemon/v1",
 
-    "REDIS_CACHE_ENABLED": "false",
-    "REDIS_CONNECTION_STRING": "",
+    "REDIS_CONNECTION_STRING": "localhost:6379",
+    "ENABLE_REDIS_CACHE": "false",
 
-    "BLOB_STORAGE_CONNECTION_STRING": "UseDevelopmentStorage=true",
-    "BLOB_CONTAINER_NAME": "images"
+    "DEBUG_MODE": "true",
+    "CACHE_TTL_SETS": "604800",
+    "CACHE_TTL_CARDS": "86400"
+  },
+  "Host": {
+    "LocalHttpPort": 7071,
+    "CORS": "*"
   }
 }
 ```
@@ -236,7 +250,7 @@ Create `app/backend/local.settings.json` based on the template:
 
 The DevContainer automatically forwards the following ports:
 
-- **3000**: Frontend development server (Svelte)
+- **5173**: Frontend development server (Vite/SvelteKit)
 - **7071**: Azure Functions local runtime
 - **8081**: Cosmos DB Emulator
 - **10000-10002**: Azurite Storage Emulator
@@ -253,9 +267,9 @@ The DevContainer automatically forwards the following ports:
 # VS Code will automatically start the container
 
 # Start development services (examples)
-cd app/frontend && npm run dev
+cd frontend && npm run dev
 # In another terminal
-cd app/backend && npm run start
+cd backend/functions && npm run start
  
 # Run unit tests from repo root
 npm test
@@ -265,7 +279,7 @@ npm test
 
 ```bash
 # Navigate to frontend directory
-cd app/frontend
+cd frontend
 
 # Start development server with hot reload
 npm run dev
@@ -289,7 +303,7 @@ npm run preview
 
 ```bash
 # Navigate to backend directory
-cd app/backend
+cd backend/functions
 
 # Start Azure Functions runtime
 npm run start
@@ -312,11 +326,8 @@ npm run watch
 #### 4. Testing Workflow
 
 ```bash
-# Run all tests (26 tests across frontend and backend)
+# Run all backend tests (Jest, from repo root)
 npm test
-
-# Run frontend tests only
-npm run test:frontend
 
 # Run backend tests only
 npm run test:backend
@@ -326,6 +337,9 @@ npm run test:watch
 
 # Generate coverage report
 npm run test:coverage
+
+# Run frontend tests (from the frontend package)
+cd frontend && npm test
 ```
 
 ### Git Workflow
@@ -379,73 +393,38 @@ git commit -m "infra: update Terraform modules"
 #### Frontend Code Structure
 
 ```
-app/frontend/src/
-├── components/           # Reusable Svelte components
-│   ├── SearchableSelect.svelte
-│   ├── CardSearchSelect.svelte
-│   ├── CardVariantSelector.svelte
-│   ├── FeatureFlagDebugPanel.svelte
-│   └── SearchableInput.svelte
-├── services/            # Business logic and API services
-│   ├── cloudDataService.js
-│   ├── hybridDataService.js
-│   ├── featureFlagService.js
-│   ├── cacheService.js
-│   ├── debugService.js
-│   ├── performanceService.js
-│   └── corsProxy.js
-├── stores/              # Svelte stores for state management
-│   ├── themeStore.js
-│   ├── setStore.js
-│   ├── cardStore.js
-│   ├── cacheStore.js
-│   └── debugStore.js
-├── utils/               # Utility functions and helpers
-│   ├── cacheUtils.js
-│   ├── dateUtils.js
-│   ├── formatUtils.js
-│   └── validationUtils.js
-├── config/              # Configuration and constants
-│   ├── apiConfig.js
-│   ├── cacheConfig.js
-│   └── debugConfig.js
-└── data/                # Static data and mappings
-    └── setMappings.js
+frontend/src/
+├── lib/                  # Shared library code ($lib alias)
+│   ├── components/       # Reusable Svelte components
+│   ├── services/         # Business logic and API services
+│   ├── stores/           # Svelte stores for state management
+│   ├── backends/         # Data-source backend adapters
+│   ├── server/           # Server-only modules
+│   └── utils/            # Utility functions and helpers
+└── routes/               # SvelteKit routes (pages + API endpoints)
+    ├── api/              # Server API route handlers
+    ├── cards/            # Card pages
+    └── sets/             # Set pages
 ```
 
 #### Backend Code Structure
 
 ```
-app/backend/src/
+backend/functions/src/
 ├── functions/           # Azure Functions (HTTP and Timer)
 │   ├── GetSetList/
 │   ├── GetCardsBySet/
 │   ├── GetCardInfo/
+│   ├── HealthCheck/
 │   ├── RefreshData/
-│   └── MonitorCredits/
+│   └── MonitorScrydexUsage/
 ├── services/            # Business logic services
 │   ├── CosmosDbService.ts
 │   ├── RedisCacheService.ts
-│   ├── BlobStorageService.ts
-│   ├── PokeDataApiService.ts
-│   ├── PokemonTcgApiService.ts
-│   ├── CreditMonitoringService.ts
-│   ├── ImageEnhancementService.ts
-│   ├── ImageUrlUpdateService.ts
-│   ├── PokeDataToTcgMappingService.ts
-│   ├── SetMappingService.ts
-│   └── BlobStorageService_old.ts
+│   ├── ScrydexApiService.ts
+│   └── MonitoringService.ts
 ├── models/              # TypeScript interfaces and types
-│   ├── Card.ts
-│   ├── Set.ts
-│   ├── ApiResponse.ts
-│   └── Config.ts
 └── utils/               # Utility functions
-    ├── cacheUtils.ts
-    ├── errorUtils.ts
-    ├── logUtils.ts
-    ├── validationUtils.ts
-    └── performanceUtils.ts
 ```
 
 ## Code Standards
@@ -724,7 +703,7 @@ PCPC follows the Test Pyramid pattern with comprehensive coverage:
 // tests/frontend/components/SearchableSelect.test.js
 import { render, fireEvent, waitFor } from "@testing-library/svelte";
 import { expect, test, describe, vi } from "vitest";
-import SearchableSelect from "../../../app/frontend/src/components/SearchableSelect.svelte";
+import SearchableSelect from "../../../frontend/src/lib/components/SearchableSelect.svelte";
 
 describe("SearchableSelect Component", () => {
   const mockOptions = [
@@ -773,7 +752,7 @@ describe("SearchableSelect Component", () => {
 ```javascript
 // tests/frontend/services/cacheService.test.js
 import { describe, test, expect, beforeEach, vi } from "vitest";
-import { cacheService } from "../../../app/frontend/src/services/cacheService.js";
+import { cacheService } from "../../../frontend/src/lib/services/cacheService.js";
 
 describe("Cache Service", () => {
   beforeEach(() => {
@@ -809,7 +788,7 @@ describe("Cache Service", () => {
 // tests/backend/functions/GetSetList.test.js
 import { describe, test, expect, beforeEach, vi } from "vitest";
 import { app } from "@azure/functions";
-import { GetSetList } from "../../../app/backend/src/functions/GetSetList/index.js";
+import { GetSetList } from "../../../backend/functions/src/functions/GetSetList/index.js";
 
 describe("GetSetList Function", () => {
   beforeEach(() => {
@@ -862,7 +841,7 @@ describe("GetSetList Function", () => {
 ```typescript
 // tests/backend/services/CosmosDbService.test.ts
 import { describe, test, expect, beforeEach, vi } from "vitest";
-import { CosmosDbService } from "../../../app/backend/src/services/CosmosDbService";
+import { CosmosDbService } from "../../../backend/functions/src/services/CosmosDbService";
 
 describe("CosmosDbService", () => {
   let cosmosDbService: CosmosDbService;
@@ -919,7 +898,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: "http://localhost:5173",
     trace: "on-first-retry",
   },
   projects: [
@@ -946,8 +925,8 @@ export default defineConfig({
   ],
   webServer: {
     command: "npm run dev",
-    port: 3000,
-    cwd: "./app/frontend",
+    port: 5173,
+    cwd: "./frontend",
   },
 });
 ```
@@ -971,7 +950,7 @@ The PCPC frontend includes comprehensive debugging tools:
 
 ```javascript
 // Built-in debug panel (available in development)
-// Access via: http://localhost:3000?debug=true
+// Access via: http://localhost:5173?debug=true
 
 // Debug service provides comprehensive logging
 import { debugService } from "../services/debugService.js";
@@ -999,9 +978,9 @@ Configure VS Code debugging for frontend:
   "name": "Debug Frontend",
   "type": "node",
   "request": "launch",
-  "program": "${workspaceFolder}/app/frontend/node_modules/.bin/rollup",
-  "args": ["-c", "--watch"],
-  "cwd": "${workspaceFolder}/app/frontend",
+  "program": "${workspaceFolder}/frontend/node_modules/.bin/vite",
+  "args": ["dev"],
+  "cwd": "${workspaceFolder}/frontend",
   "console": "integratedTerminal",
   "env": {
     "NODE_ENV": "development"
@@ -1019,9 +998,9 @@ Configure VS Code debugging for frontend:
   "name": "Debug Backend",
   "type": "node",
   "request": "launch",
-  "program": "${workspaceFolder}/app/backend/node_modules/.bin/func",
+  "program": "${workspaceFolder}/backend/functions/node_modules/.bin/func",
   "args": ["start", "--typescript"],
-  "cwd": "${workspaceFolder}/app/backend",
+  "cwd": "${workspaceFolder}/backend/functions",
   "console": "integratedTerminal",
   "env": {
     "NODE_ENV": "development"
@@ -1162,47 +1141,26 @@ class DebugCacheService {
 
 #### Build Optimization
 
-```javascript
-// rollup.config.cjs - Production optimizations
-export default {
-  input: "src/main.js",
-  output: {
-    sourcemap: !production,
-    format: "iife",
-    name: "app",
-    file: "public/build/bundle.js",
+```typescript
+// vite.config.ts - SvelteKit build configuration
+import { sveltekit } from "@sveltejs/kit/vite";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [tailwindcss(), sveltekit()],
+  build: {
+    // Vite/Rollup applies production minification and tree-shaking automatically.
+    // Tune chunking, sourcemaps, and target here as needed.
+    sourcemap: false,
+    target: "esnext",
   },
-  plugins: [
-    svelte({
-      compilerOptions: {
-        dev: !production,
-      },
-    }),
-    css({ output: "bundle.css" }),
-    resolve({
-      browser: true,
-      dedupe: ["svelte"],
-    }),
-    commonjs(),
-
-    // Production optimizations
-    production &&
-      terser({
-        compress: {
-          drop_console: true,
-          drop_debugger: true,
-        },
-      }),
-
-    // Bundle analyzer (optional)
-    production &&
-      analyzer({
-        summaryOnly: true,
-        limit: 10,
-      }),
-  ],
-};
+});
 ```
+
+The frontend is built with Vite (via the SvelteKit plugin); there is no
+hand-written Rollup config. Run `npm run build` for a production build and
+`npm run preview` to serve it locally.
 
 #### Runtime Performance
 
@@ -1266,7 +1224,7 @@ export function getCosmosClient(): CosmosClient {
 // Batch operations for efficiency
 export async function batchUpdateCards(cards: Card[]): Promise<void> {
   const client = getCosmosClient();
-  const container = client.database("PokeData").container("cards");
+  const container = client.database("PokemonCards").container("Cards");
 
   // Process in batches of 100
   const batchSize = 100;

--- a/docs/frontend-theming-style-guide.md
+++ b/docs/frontend-theming-style-guide.md
@@ -2,10 +2,12 @@
 
 ## Overview
 
-This style guide documents the CSS theming system for the PCPC frontend application. It provides a comprehensive reference for the design token hierarchy, usage patterns, and best practices for maintaining consistent, theme-aware component styling.
+This style guide documents the CSS theming system for the PCPC frontend application. It is the reference for the design token catalog, usage patterns, and best practices for consistent component styling.
 
-**Last Updated:** October 1, 2025  
-**Version:** 1.0.0
+The current theme is the **"Elevated Dark" v7** token system. It is **dark-mode-first**; a light mode is deferred (not yet implemented). The design intent and approved token values come from `frontend/PCPC_v7_Design_Spec.md` (Issue #12C, "Visual personality pass").
+
+**Last Updated:** June 16, 2026
+**Version:** 2.0.0 (v7 "Elevated Dark")
 
 ---
 
@@ -13,12 +15,12 @@ This style guide documents the CSS theming system for the PCPC frontend applicat
 
 1. [Design Token System](#design-token-system)
 2. [Token Categories](#token-categories)
-3. [Component Styling Patterns](#component-styling-patterns)
-4. [Do's and Don'ts](#dos-and-donts)
-5. [Reference Implementation](#reference-implementation)
-6. [Common Patterns](#common-patterns)
-7. [Accessibility Guidelines](#accessibility-guidelines)
-8. [Migration Guide](#migration-guide)
+3. [Theme Switching](#theme-switching)
+4. [Tailwind v4 Setup](#tailwind-v4-setup)
+5. [Component Styling Patterns](#component-styling-patterns)
+6. [Do's and Don'ts](#dos-and-donts)
+7. [Reference Implementation](#reference-implementation)
+8. [Accessibility Guidelines](#accessibility-guidelines)
 
 ---
 
@@ -26,346 +28,311 @@ This style guide documents the CSS theming system for the PCPC frontend applicat
 
 ### Architecture
 
-PCPC uses a **semantic token system** with CSS Custom Properties (CSS Variables) for runtime theme switching. The system is defined in `app/frontend/public/global.css` and follows this hierarchy:
+PCPC uses a **semantic token system** built on CSS Custom Properties (CSS variables). All tokens are defined once, under a single `:root` block, in:
 
 ```
-Semantic Tokens (Purpose-Based)
-└─> Component Usage
-    └─> Runtime Theme Switching
+frontend/src/app.css
 ```
 
-### Theme Switching
+There is no separate global stylesheet — `app.css` is the single source of truth. It is imported once at the app entry (`frontend/src/routes/+layout.svelte` / the root layout) and the tokens cascade to every component.
 
-Themes are controlled via the `data-theme` attribute on the root element:
+The hierarchy is:
 
-```html
-<!-- Light Mode (default) -->
-<html data-theme="light">
-  <!-- Dark Mode -->
-  <html data-theme="dark"></html>
-</html>
+```
+Raw token definitions (:root in app.css)
+└─> Backward-compat aliases (also :root, mapping legacy names → new tokens)
+    └─> Component usage (var(--token) in .svelte <style> blocks)
 ```
 
-All theme transitions are smooth with a 0.3s ease animation applied globally.
+Tokens are organized into groups: **surfaces**, **text hierarchy**, **accents**, **pricing/semantic**, **grading-company colors**, **chart colors**, **rarity colors**, **borders**, **radius/spacing**, **type scale**, **shadows**, and **transitions**.
+
+> Note on legacy names: the old `--bg-*`, `--text-inverse`, `--color-pokemon-*`, `--shadow-light/medium/heavy`, etc. still exist, but **only as backward-compat aliases** at the bottom of `app.css` (they `var()`-reference the real v7 tokens). New code should use the v7 tokens documented below, not the aliases.
 
 ---
 
 ## Token Categories
 
-### 1. Background Colors
+All values below are the literal definitions from `frontend/src/app.css` (`:root`, lines 8–163).
 
-#### Page & Layout Backgrounds
+### 1. Surfaces (three depth levels)
 
-| Token                | Light Mode        | Dark Mode | Usage                                   |
-| -------------------- | ----------------- | --------- | --------------------------------------- |
-| `--bg-primary`       | `#000000`         | `#000000` | Main page background behind all content |
-| `--bg-secondary`     | `rgba(0,0,0,0.9)` | `#41444e` | Card image containers, scrollbar tracks |
-| `--bg-tertiary`      | `rgba(0,0,0,0.9)` | `#41444e` | Results section background              |
-| `--bg-image-opacity` | `1`               | `1`       | Background image opacity                |
+| Token         | Value     | Usage                                          |
+| ------------- | --------- | ---------------------------------------------- |
+| `--surface-0` | `#0d0f14` | Page background (deepest level), `body`        |
+| `--surface-1` | `#12141b` | Containers, headers, group/section backgrounds |
+| `--surface-2` | `#1a1d28` | Inputs, dropdowns, cards, elevated elements    |
 
-#### Container Backgrounds
+### 2. Text Hierarchy
 
-| Token               | Light Mode        | Dark Mode | Usage                                 |
-| ------------------- | ----------------- | --------- | ------------------------------------- |
-| `--bg-container`    | `rgba(0,0,0,0.9)` | `#41444e` | Main form container background        |
-| `--bg-dropdown`     | `#41444e`         | `#22242f` | Input fields, dropdown menus          |
-| `--bg-hover`        | `#000000`         | `#22242f` | Hover states for interactive elements |
-| `--bg-group-header` | `#000000`         | `#41444e` | Group headers in dropdown lists       |
+| Token              | Value     | Usage                                       |
+| ------------------ | --------- | ------------------------------------------- |
+| `--text-primary`   | `#e8eaef` | Primary body text, headings                 |
+| `--text-secondary` | `#d7dee3` | Secondary text                              |
+| `--text-muted`     | `#9ca3af` | Labels, secondary detail, placeholders icon |
+| `--text-dim`       | `#7c8493` | Dimmed text, input placeholders, the title slash |
+| `--text-faint`     | `#374151` | Faintest text / disabled-adjacent           |
 
-**Usage Example:**
+### 3. Accents
 
-```css
-.form-container {
-  background-color: var(--bg-container);
-}
+| Token               | Value     | Usage                                |
+| ------------------- | --------- | ------------------------------------ |
+| `--accent-red`      | `#e8453c` | Primary accent: buttons, focus, selected indicators |
+| `--accent-red-dark` | `#d63a31` | Button hover state                   |
+| `--amber`           | `#c49a6c` | v7 accent: meta chips, detail buttons, expanded borders |
+| `--amber-dim`       | `rgba(196, 154, 108, 0.12)` | Amber tint backgrounds |
+| `--amber-border`    | `rgba(196, 154, 108, 0.25)` | Amber hairline borders |
 
-.dropdown-menu {
-  background-color: var(--bg-dropdown);
-}
+### 4. Pricing (semantic)
 
-.dropdown-item:hover {
-  background-color: var(--bg-hover);
-}
-```
+| Token             | Value     | Usage                  |
+| ----------------- | --------- | ---------------------- |
+| `--price-green`   | `#4ade80` | Price up / positive    |
+| `--price-red`     | `#f87171` | Price down / error     |
+| `--price-neutral` | `#9ca3af` | Neutral / no change    |
 
-### 2. Typography Colors
+### 5. Language Badges
 
-| Token              | Light Mode | Dark Mode | Usage                                  |
-| ------------------ | ---------- | --------- | -------------------------------------- |
-| `--text-primary`   | `#000000`  | `#d7dee3` | Main text (labels, body, card details) |
-| `--text-secondary` | `#000000`  | `#d7dee3` | Secondary text (currency, timestamps)  |
-| `--text-muted`     | `#000000`  | `#e3d7d7` | Disabled inputs, placeholders          |
-| `--text-inverse`   | `#000000`  | `#eeff00` | Text on contrasting backgrounds        |
+| Token            | Value                      | Usage                    |
+| ---------------- | -------------------------- | ------------------------ |
+| `--badge-en-bg`  | `rgba(59, 130, 246, 0.1)`  | English badge background |
+| `--badge-en-text`| `#60a5fa`                  | English badge text; also links / cached indicator |
+| `--badge-jp-bg`  | `rgba(232, 69, 60, 0.1)`   | Japanese badge background |
+| `--badge-jp-text`| `#f09595`                  | Japanese badge text      |
 
-**Usage Example:**
+### 6. Borders
 
-```css
-.label {
-  color: var(--text-primary);
-}
+| Token             | Value                       | Usage                        |
+| ----------------- | --------------------------- | ---------------------------- |
+| `--border-subtle` | `rgba(255, 255, 255, 0.06)` | Standard hairline borders    |
+| `--border-faint`  | `rgba(255, 255, 255, 0.03)` | Faintest separators          |
 
-.timestamp {
-  color: var(--text-secondary);
-}
+Borders in v7 are hairline (0.5px) by convention.
 
-input::placeholder {
-  color: var(--text-muted);
-}
+### 7. Grading-Company Colors
 
-.header-text {
-  color: var(--text-inverse);
-}
-```
+| Token               | Value                       | Usage          |
+| ------------------- | --------------------------- | -------------- |
+| `--grade-psa`       | `rgba(59, 130, 246, 0.15)`  | PSA chip bg    |
+| `--grade-psa-text`  | `#60a5fa`                   | PSA text       |
+| `--grade-cgc`       | `rgba(139, 92, 246, 0.15)`  | CGC chip bg    |
+| `--grade-cgc-text`  | `#a78bfa`                   | CGC text       |
+| `--grade-bgs`       | `rgba(234, 179, 8, 0.15)`   | BGS chip bg    |
+| `--grade-bgs-text`  | `#fbbf24`                   | BGS text       |
+| `--grade-sgc`       | `rgba(52, 211, 153, 0.1)`   | SGC chip bg    |
+| `--grade-sgc-text`  | `#34d399`                   | SGC text       |
 
-### 3. Border Colors
+### 8. Chart Colors
 
-| Token                | Light Mode | Dark Mode | Usage                                     |
-| -------------------- | ---------- | --------- | ----------------------------------------- |
-| `--border-primary`   | `#000000`  | `#22242f` | Primary borders (results, cards, buttons) |
-| `--border-secondary` | `#000000`  | `#000000` | Secondary borders (list separators)       |
-| `--border-input`     | `#000000`  | `#48365b` | Input field borders (normal state)        |
-| `--border-focus`     | `#000000`  | `#48365b` | Input field borders (focused state)       |
+Per-condition (`chart.js` datasets):
 
-**Usage Example:**
+| Token        | Value     | Condition         |
+| ------------ | --------- | ----------------- |
+| `--chart-nm` | `#4ade80` | Near Mint         |
+| `--chart-lp` | `#60a5fa` | Lightly Played    |
+| `--chart-mp` | `#a78bfa` | Moderately Played |
+| `--chart-hp` | `#fbbf24` | Heavily Played    |
+| `--chart-dm` | `#f87171` | Damaged           |
 
-```css
-.card {
-  border: 1px solid var(--border-primary);
-}
+Per-company graded: `--chart-psa` `#60a5fa`, `--chart-cgc` `#a78bfa`, `--chart-bgs` `#fbbf24`, `--chart-sgc` `#34d399`.
 
-.list-item {
-  border-bottom: 1px solid var(--border-secondary);
-}
+Per-company luminance shades (compare chart) are also defined, e.g. `--psa-1..3`, `--cgc-1..6`, `--bgs-1..3`, `--sgc-1..3`. See `app.css` lines 69–73 for the full set.
 
-input {
-  border: 1px solid var(--border-input);
-}
+### 9. Rarity Colors
 
-input:focus {
-  border-color: var(--border-focus);
-}
-```
+| Token               | Value     | Rarity                       |
+| ------------------- | --------- | ---------------------------- |
+| `--rarity-common`   | `#6b7280` | Common                       |
+| `--rarity-uncommon` | `#4ade80` | Uncommon                     |
+| `--rarity-rare`     | `#60a5fa` | Rare                         |
+| `--rarity-holo`     | `#a78bfa` | Holo                         |
+| `--rarity-ultra`    | `#fbbf24` | Ultra Rare                   |
+| `--rarity-full-art` | `#f472b6` | Full Art                     |
+| `--rarity-sar-from` | `#fbbf24` | SAR gradient start (gold)    |
+| `--rarity-sar-to`   | `#f472b6` | SAR gradient end (pink)      |
+| `--rarity-hyper`    | `#f59e0b` | Hyper Rare                   |
 
-### 4. Brand Colors (Pokemon Theme)
+### 10. Radius & Spacing
 
-| Token                      | Light Mode | Dark Mode | Usage                               |
-| -------------------------- | ---------- | --------- | ----------------------------------- |
-| `--color-pokemon-blue`     | `#000000`  | `#d7dee3` | Header, headings, cached indicators |
-| `--color-pokemon-red`      | `#000000`  | `#ff0000` | Primary buttons, prices, errors     |
-| `--color-pokemon-red-dark` | `#000000`  | `#ff0000` | Button hover states                 |
+| Token             | Value     | Usage              |
+| ----------------- | --------- | ------------------ |
+| `--radius-card`   | `10px`    | Cards              |
+| `--radius-input`  | `6px`     | Inputs, dropdowns  |
+| `--radius-badge`  | `4px`     | Badges             |
+| `--radius-pill`   | `6px`     | Pills              |
 
-**Usage Example:**
+Layout tokens: `--content-max-width: 1400px`, `--sidebar-width: 200px`, `--layout-gap: 24px` (these scale up at the `1800px` / `2200px` breakpoints — see lines 237–254).
 
-```css
-.header {
-  background-color: var(--color-pokemon-blue);
-}
+### 11. Type Scale
 
-.price-value {
-  color: var(--color-pokemon-red);
-}
+| Token             | Value  | Usage                     |
+| ----------------- | ------ | ------------------------- |
+| `--fs-micro`      | `10px` | Micro labels              |
+| `--fs-badge`      | `11px` | Badges, uppercase labels  |
+| `--fs-body`       | `12px` | Body text                 |
+| `--fs-secondary`  | `13px` | Secondary text            |
+| `--fs-card-name`  | `20px` | Card name                 |
+| `--fs-hero`       | `28px` | Hero price                |
 
-.primary-button {
-  background-color: var(--color-pokemon-red);
-}
+These scale up at `min-width: 1800px` and `--fs-hero` shrinks to `24px` at `max-width: 768px`. The font family is **Geist** (with a system-font fallback stack).
 
-.primary-button:hover {
-  background-color: var(--color-pokemon-red-dark);
-}
-```
+### 12. Shadows
 
-### 5. Interactive States
+| Token           | Value                                | Usage              |
+| --------------- | ------------------------------------ | ------------------ |
+| `--shadow-sm`   | `0 1px 2px rgba(0, 0, 0, 0.3)`       | Subtle elevation   |
+| `--shadow-md`   | `0 4px 12px rgba(0, 0, 0, 0.4)`      | Dropdowns, popovers |
+| `--shadow-lg`   | `0 8px 24px rgba(0, 0, 0, 0.5)`      | Modals             |
+| `--shadow-glow` | `0 0 40px rgba(232, 69, 60, 0.08)`   | Accent glow        |
 
-| Token            | Light Mode | Dark Mode | Usage                                     |
-| ---------------- | ---------- | --------- | ----------------------------------------- |
-| `--bg-hover`     | `#000000`  | `#22242f` | Hover background for interactive elements |
-| `--border-focus` | `#000000`  | `#48365b` | Focus state borders                       |
+### 13. Transitions & Focus
 
-### 6. Shadows
+| Token                | Value                                                          | Usage                |
+| -------------------- | -------------------------------------------------------------- | -------------------- |
+| `--transition-speed` | `0.2s`                                                         | Hover/focus timing   |
+| `--transition-fn`    | `ease`                                                         | Easing function      |
+| `--focus-ring`       | `0 0 0 2px var(--surface-0), 0 0 0 4px rgba(232, 69, 60, 0.4)` | `box-shadow` focus ring on inputs |
 
-| Token             | Light Mode        | Dark Mode         | Usage                            |
-| ----------------- | ----------------- | ----------------- | -------------------------------- |
-| `--shadow-light`  | `rgba(0,0,0,0.1)` | `rgba(0,0,0,0.3)` | Light shadows                    |
-| `--shadow-medium` | `rgba(0,0,0,0.2)` | `rgba(0,0,0,0.5)` | Medium shadows (results section) |
-| `--shadow-heavy`  | `rgba(0,0,0,0.3)` | `rgba(0,0,0,0.7)` | Heavy shadows (form container)   |
+---
 
-**Usage Example:**
+## Theme Switching
 
-```css
-.card {
-  box-shadow: 0 2px 4px var(--shadow-light);
-}
+**There is no working light/dark CSS switch today.** Document and code reality:
 
-.modal {
-  box-shadow: 0 4px 8px var(--shadow-medium);
-}
+- `app.css` defines all tokens under a single `:root` block. There are **no `[data-theme]` selectors** anywhere in `app.css` (confirmed: 0 occurrences). The system is dark-mode-first; light mode is explicitly deferred (see the header comment in `app.css`).
+- A theme store exists at `frontend/src/lib/stores/theme.svelte.ts` (re-exported from `frontend/src/lib/stores/index.ts` as `themeStore`). It tracks a `'light' | 'dark'` value, persists it to `localStorage`, reads the OS `prefers-color-scheme`, and calls `document.documentElement.setAttribute('data-theme', theme)`.
+- **However, no CSS consumes that `data-theme` attribute.** Because there are no `[data-theme="..."]` rules, setting the attribute has no visual effect — the app renders the dark `:root` tokens regardless of the store's value. The store is effectively dormant theming plumbing.
 
-.elevated-container {
-  box-shadow: 0 8px 16px var(--shadow-heavy);
-}
-```
+Practical implication: do **not** write components that rely on a theme toggle changing colors. If a real light mode is added later, it should introduce a `[data-theme='light']` (or `@media (prefers-color-scheme: light)`) block in `app.css` that overrides the `:root` token values — at which point this section should be updated.
 
-### 7. Transitions
+---
 
-| Token                | Value  | Usage                                                   |
-| -------------------- | ------ | ------------------------------------------------------- |
-| `--transition-speed` | `0.3s` | Animation speed for theme transitions and hover effects |
+## Tailwind v4 Setup
 
-**Usage Example:**
+PCPC uses **Tailwind CSS v4** in CSS-first mode (no `tailwind.config.js`):
 
-```css
-.animated-element {
-  transition: all var(--transition-speed) ease;
-}
-```
+- `frontend/package.json` pins `tailwindcss` and `@tailwindcss/vite` at `^4.1.0`.
+- Tailwind is wired in as a Vite plugin in `frontend/vite.config.ts`:
+
+  ```ts
+  import tailwindcss from '@tailwindcss/vite';
+  import { sveltekit } from '@sveltejs/kit/vite';
+  import { defineConfig } from 'vite';
+
+  export default defineConfig({
+    plugins: [tailwindcss(), sveltekit()]
+  });
+  ```
+
+- Tailwind is activated by a single line at the top of `app.css`:
+
+  ```css
+  @import 'tailwindcss';
+  ```
+
+So `app.css` does double duty: it pulls in Tailwind and defines the design tokens. Components mix Tailwind utility classes with scoped `<style>` blocks that reference the CSS variables above.
 
 ---
 
 ## Component Styling Patterns
 
-### Pattern 1: Basic Component (Recommended)
-
-Use semantic tokens directly in component styles:
+### Pattern 1: Surfaces and text
 
 ```svelte
 <style>
-  .component {
-    background-color: var(--bg-dropdown);
+  .panel {
+    background-color: var(--surface-1);
     color: var(--text-primary);
-    border: 1px solid var(--border-primary);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-card);
   }
-
-  .component:hover {
-    background-color: var(--bg-hover);
+  .panel .meta {
+    color: var(--text-muted);
+    font-size: var(--fs-badge);
   }
 </style>
 ```
 
-### Pattern 2: Interactive Elements
+### Pattern 2: Primary button (accent)
 
-For buttons, links, and clickable items:
+The global `button` element already uses the accent (see `app.css` lines 212–218). To match it in a custom element:
 
 ```svelte
 <style>
   .button {
-    background-color: var(--color-pokemon-red);
-    color: white;
+    background-color: var(--accent-red);
+    color: #ffffff;
     border: none;
-    transition: background-color var(--transition-speed) ease;
+    border-radius: var(--radius-input);
+    transition: background-color var(--transition-speed) var(--transition-fn);
   }
-
-  .button:hover {
-    background-color: var(--color-pokemon-red-dark);
+  .button:hover:not(:disabled) {
+    background-color: var(--accent-red-dark);
   }
-
   .button:disabled {
-    background-color: var(--border-primary);
-    color: var(--text-muted);
+    background-color: var(--surface-2);
+    color: var(--text-dim);
     cursor: not-allowed;
   }
 </style>
 ```
 
-### Pattern 3: Form Inputs
-
-For text inputs, selects, and textareas:
+### Pattern 3: Form input with focus ring
 
 ```svelte
 <style>
   .input {
-    background-color: var(--bg-dropdown);
+    background-color: var(--surface-2);
     color: var(--text-primary);
-    border: 1px solid var(--border-input);
-    padding: 0.5rem;
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-input);
   }
-
   .input:focus {
-    border-color: var(--border-focus);
     outline: none;
+    border-color: var(--accent-red);
+    box-shadow: var(--focus-ring);
   }
-
   .input::placeholder {
-    color: var(--text-muted);
-  }
-
-  .input:disabled {
-    color: var(--text-muted);
-    background-color: var(--bg-hover);
+    color: var(--text-dim);
   }
 </style>
 ```
 
-### Pattern 4: Dropdown Menus
-
-For dropdown lists and select menus:
+### Pattern 4: Dropdown menu
 
 ```svelte
 <style>
   .dropdown {
-    background-color: var(--bg-dropdown);
-    border: 1px solid var(--border-primary);
-    box-shadow: 0 4px 8px var(--shadow-medium);
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-input);
+    box-shadow: var(--shadow-md);
   }
-
-  .dropdown-item {
-    color: var(--text-primary);
-    padding: 0.5rem;
-    border-bottom: 1px solid var(--border-secondary);
+  .group-label {
+    background-color: var(--surface-1);
+    color: var(--text-muted);
+    font-size: var(--fs-badge);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
   }
-
   .dropdown-item:hover {
-    background-color: var(--bg-hover);
-    color: var(--color-pokemon-blue);
+    background-color: var(--bg-hover); /* alias → rgba(255,255,255,0.04) */
   }
-
-  .dropdown-item:last-child {
-    border-bottom: none;
+  .dropdown-item.selected {
+    border-left: 3px solid var(--accent-red);
   }
 </style>
 ```
 
-### Pattern 5: Group Headers
-
-For section headers within lists:
+### Pattern 5: Pricing and rarity semantics
 
 ```svelte
 <style>
-  .group-header {
-    background-color: var(--bg-group-header);
-    color: var(--color-pokemon-blue);
-    padding: 0.5rem;
-    font-weight: bold;
-    border-bottom: 1px solid var(--border-primary);
-    position: sticky;
-    top: 0;
-  }
-</style>
-```
+  .price-up   { color: var(--price-green); }
+  .price-down { color: var(--price-red); }
+  .price-flat { color: var(--price-neutral); }
 
-### Pattern 6: Cards and Containers
-
-For card components and content containers:
-
-```svelte
-<style>
-  .card {
-    background-color: var(--bg-container);
-    border: 1px solid var(--border-primary);
-    border-radius: 4px;
-    padding: 1rem;
-    box-shadow: 0 2px 4px var(--shadow-light);
-  }
-
-  .card-header {
-    color: var(--color-pokemon-blue);
-    border-bottom: 1px solid var(--border-secondary);
-    padding-bottom: 0.5rem;
-    margin-bottom: 1rem;
-  }
-
-  .card-body {
-    color: var(--text-primary);
-  }
+  .rarity-rare { color: var(--rarity-rare); }
+  .rarity-holo { color: var(--rarity-holo); }
 </style>
 ```
 
@@ -373,462 +340,123 @@ For card components and content containers:
 
 ## Do's and Don'ts
 
-### ✅ DO
+### DO
 
-#### Use Semantic Tokens
+- Use v7 tokens (`--surface-*`, `--text-*`, `--accent-*`, `--price-*`, `--grade-*`, `--rarity-*`) directly in component `<style>` blocks.
+- Use `--focus-ring` for input focus states, matching the global `input:focus` rule.
+- Use the type-scale tokens (`--fs-body`, `--fs-badge`, …) instead of hardcoded `px` sizes so components scale at the desktop/mobile breakpoints.
+- Use the radius and shadow tokens for consistent elevation.
 
 ```css
-/* ✅ CORRECT - Uses semantic tokens */
-.dropdown {
-  background-color: var(--bg-dropdown);
+/* CORRECT — v7 tokens */
+.card {
+  background-color: var(--surface-2);
   color: var(--text-primary);
-  border: 1px solid var(--border-primary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-md);
 }
 ```
 
-#### Use Theme-Aware Interactive States
+### DON'T
+
+- Don't hardcode hex/rgba colors that a token already covers.
 
 ```css
-/* ✅ CORRECT - Theme-aware hover state */
-.item:hover {
-  background-color: var(--bg-hover);
-  color: var(--color-pokemon-blue);
-}
+/* WRONG */
+.card { background-color: #1a1d28; color: #e8eaef; }
+/* CORRECT */
+.card { background-color: var(--surface-2); color: var(--text-primary); }
 ```
 
-#### Use Consistent Spacing
-
-```css
-/* ✅ CORRECT - Consistent padding */
-.component {
-  padding: 0.5rem;
-  margin: 0.5rem 0;
-}
-```
-
-#### Use Transitions for Smooth Theme Switching
-
-```css
-/* ✅ CORRECT - Smooth transitions */
-.component {
-  transition: background-color var(--transition-speed) ease, color var(
-        --transition-speed
-      ) ease;
-}
-```
-
-### ❌ DON'T
-
-#### Don't Use Hardcoded Colors
-
-```css
-/* ❌ WRONG - Hardcoded white background */
-.dropdown {
-  background-color: white;
-  color: #333;
-  border: 1px solid #ddd;
-}
-
-/* ✅ CORRECT - Use semantic tokens */
-.dropdown {
-  background-color: var(--bg-dropdown);
-  color: var(--text-primary);
-  border: 1px solid var(--border-primary);
-}
-```
-
-#### Don't Use Magic RGBA Values
-
-```css
-/* ❌ WRONG - Hardcoded rgba */
-.overlay {
-  background-color: rgba(255, 255, 255, 0.2);
-}
-
-/* ✅ CORRECT - Use semantic tokens or define new token */
-.overlay {
-  background-color: var(--bg-secondary);
-}
-```
-
-#### Don't Use Hardcoded Hover States
-
-```css
-/* ❌ WRONG - Hardcoded hover colors */
-.item:hover {
-  background-color: #f0f0f0;
-  color: #3c5aa6;
-}
-
-/* ✅ CORRECT - Theme-aware hover */
-.item:hover {
-  background-color: var(--bg-hover);
-  color: var(--color-pokemon-blue);
-}
-```
-
-#### Don't Mix Hardcoded and Token-Based Styles
-
-```css
-/* ❌ WRONG - Inconsistent approach */
-.component {
-  background-color: var(--bg-dropdown); /* Token */
-  color: #333; /* Hardcoded */
-  border: 1px solid var(--border-primary); /* Token */
-}
-
-/* ✅ CORRECT - Consistent token usage */
-.component {
-  background-color: var(--bg-dropdown);
-  color: var(--text-primary);
-  border: 1px solid var(--border-primary);
-}
-```
+- Don't reach for the backward-compat aliases (`--bg-primary`, `--color-pokemon-red`, `--shadow-light`, `--text-inverse`, …) in new code. They map to v7 tokens but exist only so legacy components keep working — prefer the real token (`--surface-0`, `--accent-red`, etc.).
+- Don't write theme-toggle-dependent styling. As documented above, no CSS responds to `data-theme`, so a "light mode override" you add to a component will never trigger.
 
 ---
 
 ## Reference Implementation
 
-### SearchableSelect.svelte (Correct Pattern)
+### `SearchableSelect.svelte` (correct pattern)
 
-This component demonstrates the correct usage of the theming system:
+`frontend/src/lib/components/SearchableSelect.svelte` is a good real-world example of the v7 system in use. Its scoped `<style>` block uses tokens throughout:
 
 ```svelte
 <style>
-  /* Input field - uses semantic tokens */
-  input {
-    width: 100%;
-    padding: 0.5rem;
-    font-size: 1rem;
-    border: 1px solid var(--border-input);
-    border-radius: 4px;
-    background-color: var(--bg-dropdown);
+  .searchable-input {
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-input, 6px);
+    background-color: var(--surface-2);
     color: var(--text-primary);
+    font-size: var(--fs-body);
+    transition: border-color var(--transition-speed, 0.2s) ease,
+                box-shadow var(--transition-speed, 0.2s) ease;
   }
-
-  /* Dropdown menu - theme-aware */
+  .searchable-input:focus {
+    outline: none;
+    border-color: var(--accent-red);
+    box-shadow: var(--focus-ring);
+  }
   .dropdown {
-    background-color: var(--bg-dropdown);
-    border: 1px solid var(--border-primary);
-    box-shadow: 0 4px 8px var(--shadow-light);
+    background-color: var(--surface-2);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-input, 6px);
+    box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.4));
   }
-
-  /* Group headers - uses brand colors */
-  .group-header {
-    background-color: var(--bg-group-header);
-    color: var(--color-pokemon-blue);
-    border-bottom: 1px solid var(--border-primary);
+  .group-label {
+    background-color: var(--surface-1);
+    color: var(--text-muted);
+    font-size: var(--fs-badge);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
   }
-
-  /* List items - proper hover states */
-  .item {
-    color: var(--text-primary);
-    border-bottom: 1px solid var(--border-secondary);
+  .dropdown-item { color: var(--text-primary); }
+  .dropdown-item:hover,
+  .dropdown-item.highlighted {
+    background-color: var(--bg-hover, rgba(255, 255, 255, 0.04));
   }
-
-  .item:hover, .highlighted {
-    background-color: var(--bg-hover);
-    color: var(--color-pokemon-blue);
-  }
-
-  /* Secondary text - uses muted color */
-  .secondary {
-    color: var(--text-secondary);
-  }
+  .dropdown-item.selected { border-left: 3px solid var(--accent-red); }
+  .item-secondary { color: var(--text-muted); font-size: var(--fs-badge); }
 </style>
 ```
 
-**Key Takeaways:**
+**Key takeaways:**
 
-1. All colors use CSS variables
-2. Hover states use theme-aware tokens
-3. Interactive elements have proper focus states
-4. Consistent spacing and transitions
-
----
-
-## Common Patterns
-
-### Pattern: Modal/Dialog
-
-```svelte
-<style>
-  .modal-overlay {
-    background-color: var(--bg-secondary);
-    /* Note: For semi-transparent overlays, consider adding opacity */
-    opacity: 0.95;
-  }
-
-  .modal-content {
-    background-color: var(--bg-container);
-    border: 1px solid var(--border-primary);
-    box-shadow: 0 8px 16px var(--shadow-heavy);
-    color: var(--text-primary);
-  }
-
-  .modal-header {
-    color: var(--color-pokemon-blue);
-    border-bottom: 1px solid var(--border-secondary);
-  }
-</style>
-```
-
-### Pattern: List with Separators
-
-```svelte
-<style>
-  .list {
-    background-color: var(--bg-dropdown);
-    border: 1px solid var(--border-primary);
-  }
-
-  .list-item {
-    color: var(--text-primary);
-    padding: 0.75rem;
-    border-bottom: 1px solid var(--border-secondary);
-  }
-
-  .list-item:last-child {
-    border-bottom: none;
-  }
-
-  .list-item:hover {
-    background-color: var(--bg-hover);
-  }
-</style>
-```
-
-### Pattern: Status Indicators
-
-```svelte
-<style>
-  .status {
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    font-size: 0.875rem;
-  }
-
-  .status-success {
-    background-color: var(--color-pokemon-blue);
-    color: white;
-  }
-
-  .status-error {
-    background-color: var(--color-pokemon-red);
-    color: white;
-  }
-
-  .status-warning {
-    background-color: var(--bg-hover);
-    color: var(--text-primary);
-    border: 1px solid var(--border-primary);
-  }
-</style>
-```
-
-### Pattern: Loading States
-
-```svelte
-<style>
-  .loading {
-    color: var(--text-secondary);
-    background-color: var(--bg-hover);
-    padding: 1rem;
-    text-align: center;
-  }
-
-  .skeleton {
-    background-color: var(--bg-hover);
-    border-radius: 4px;
-    animation: pulse 1.5s ease-in-out infinite;
-  }
-
-  @keyframes pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.5; }
-  }
-</style>
-```
+1. Surfaces come from `--surface-1` / `--surface-2`; text from `--text-primary` / `--text-muted`.
+2. Focus uses `border-color: var(--accent-red)` plus `box-shadow: var(--focus-ring)`, matching the global input style.
+3. Radius, shadow, type-scale, and transition tokens are used (with literal fallbacks) rather than magic values.
+4. The selected-row affordance is an `--accent-red` left border.
 
 ---
 
 ## Accessibility Guidelines
 
-### Color Contrast
+### Color contrast
 
-Ensure sufficient color contrast ratios for accessibility:
+Target WCAG AA against the dark surfaces:
 
-- **Normal text:** Minimum 4.5:1 contrast ratio
-- **Large text (18pt+):** Minimum 3:1 contrast ratio
-- **Interactive elements:** Minimum 3:1 contrast ratio
+- Normal text: ≥ 4.5:1
+- Large text (≥ 18px / `--fs-card-name` and up): ≥ 3:1
+- Interactive/non-text indicators: ≥ 3:1
 
-### Focus States
+`--text-primary` (`#e8eaef`) and `--text-secondary` (`#d7dee3`) clear AA on all three surface levels; `--text-dim` (`#7c8493`) and `--text-faint` (`#374151`) are intentionally low-contrast — use them only for de-emphasized, non-essential text.
 
-Always provide visible focus indicators:
+### Focus states
+
+Use the shared focus ring so keyboard focus is always visible:
 
 ```css
-.interactive-element:focus {
-  outline: 2px solid var(--border-focus);
-  outline-offset: 2px;
-}
-
-/* Or use box-shadow for custom focus rings */
-.button:focus {
-  box-shadow: 0 0 0 3px rgba(60, 90, 166, 0.3);
+.interactive:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 ```
 
-### Keyboard Navigation
+### Keyboard navigation
 
-Ensure all interactive elements are keyboard accessible:
-
-```svelte
-<div
-  role="button"
-  tabindex="0"
-  on:click={handleClick}
-  on:keydown={e => e.key === 'Enter' && handleClick()}
->
-  Interactive Element
-</div>
-```
+All interactive elements must be reachable and operable by keyboard. `SearchableSelect.svelte` is the reference: it handles `ArrowUp`/`ArrowDown`/`Enter`/`Escape`, manages a highlighted index, and exposes `role="option"` with `aria-selected`.
 
 ---
 
-## Migration Guide
-
-### Step 1: Identify Hardcoded Colors
-
-Search for common hardcoded color patterns:
-
-- `color: white` or `color: #fff`
-- `background-color: white` or `background: #fff`
-- `color: #333` or similar dark grays
-- `border: 1px solid #ddd` or similar light grays
-- `rgba(255, 255, 255, ...)` or similar rgba values
-
-### Step 2: Map to Semantic Tokens
-
-Use this mapping guide:
-
-| Hardcoded Value          | Semantic Token                                       | Context                   |
-| ------------------------ | ---------------------------------------------------- | ------------------------- |
-| `white` (background)     | `var(--bg-dropdown)`                                 | Input fields, dropdowns   |
-| `white` (text)           | `var(--text-inverse)`                                | Text on dark backgrounds  |
-| `#333`, `#666` (text)    | `var(--text-primary)` or `var(--text-secondary)`     | Body text                 |
-| `#ddd`, `#ccc` (borders) | `var(--border-primary)` or `var(--border-secondary)` | Borders                   |
-| `#f0f0f0` (hover)        | `var(--bg-hover)`                                    | Hover states              |
-| `#3c5aa6` (blue)         | `var(--color-pokemon-blue)`                          | Brand blue                |
-| `rgba(255,255,255,0.2)`  | `var(--bg-secondary)` + opacity                      | Semi-transparent overlays |
-
-### Step 3: Replace Systematically
-
-Replace one component at a time:
-
-```css
-/* BEFORE */
-.dropdown {
-  background-color: white;
-  border: 1px solid #ddd;
-  color: #333;
-}
-
-.dropdown-item:hover {
-  background-color: #f0f0f0;
-  color: #3c5aa6;
-}
-
-/* AFTER */
-.dropdown {
-  background-color: var(--bg-dropdown);
-  border: 1px solid var(--border-primary);
-  color: var(--text-primary);
-}
-
-.dropdown-item:hover {
-  background-color: var(--bg-hover);
-  color: var(--color-pokemon-blue);
-}
-```
-
-### Step 4: Test Both Themes
-
-After each component migration:
-
-1. Test in light mode
-2. Test in dark mode
-3. Test theme switching transition
-4. Verify hover/focus states
-5. Check accessibility contrast
-
-### Step 5: Document Component-Specific Patterns
-
-If a component needs unique styling, document it:
-
-```svelte
-<style>
-  /* Special case: This component needs higher contrast */
-  .special-dropdown {
-    /* Override with more specific token if needed */
-    background-color: var(--bg-container);
-    /* Or define component-specific variable */
-    --dropdown-bg: var(--bg-container);
-  }
-</style>
-```
-
----
-
-## Quick Reference Card
-
-### Most Common Tokens
-
-```css
-/* Backgrounds */
---bg-dropdown        /* Input fields, dropdowns */
---bg-container       /* Form containers, cards */
---bg-hover           /* Hover states */
-
-/* Text */
---text-primary       /* Main text */
---text-secondary     /* Secondary text */
---text-muted         /* Disabled, placeholders */
-
-/* Borders */
---border-primary     /* Main borders */
---border-secondary   /* List separators */
---border-input       /* Input borders */
-
-/* Brand */
---color-pokemon-blue /* Headers, links */
---color-pokemon-red  /* Buttons, prices */
-```
-
-### Common Replacements
-
-```css
-white           → var(--bg-dropdown)
-#333, #666      → var(--text-primary)
-#ddd, #ccc      → var(--border-primary)
-#f0f0f0         → var(--bg-hover)
-#3c5aa6         → var(--color-pokemon-blue)
-```
-
----
-
-## Conclusion
-
-This style guide provides a comprehensive reference for maintaining consistent, theme-aware styling across the PCPC frontend application. By following these patterns and guidelines, you ensure:
-
-1. **Consistency:** All components use the same theming system
-2. **Maintainability:** Changes to the theme affect all components automatically
-3. **Accessibility:** Proper contrast and focus states are maintained
-4. **User Experience:** Smooth theme transitions and predictable interactions
-
-For questions or clarifications, refer to the reference implementation in `SearchableSelect.svelte` or consult this guide.
-
----
-
-**Document Version:** 1.0.0  
-**Last Updated:** October 1, 2025  
-**Maintained By:** PCPC Development Team
+**Document Version:** 2.0.0 ("Elevated Dark" v7)
+**Last Updated:** June 16, 2026
+**Source of truth:** `frontend/src/app.css` · **Design intent:** `frontend/PCPC_v7_Design_Spec.md`

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -68,7 +68,15 @@ graph TB
 
 ### Frontend Monitoring
 
-#### Web SDK Configuration
+> **Status: Not yet implemented (planned).** The frontend does not currently
+> ship any Application Insights browser SDK. There is no
+> `@microsoft/applicationinsights-web` or `web-vitals` dependency in
+> `frontend/package.json`, and no telemetry initialization in `frontend/src`.
+> The code samples in this section describe a planned approach and are NOT
+> reflective of the current build. Backend telemetry (see below) is the only
+> Application Insights integration that exists today.
+
+#### Web SDK Configuration (planned)
 
 ```javascript
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
@@ -143,7 +151,10 @@ export class TelemetryService {
 }
 ```
 
-#### Core Web Vitals Tracking
+#### Core Web Vitals Tracking (planned)
+
+> Not implemented. There is no `web-vitals` dependency in the frontend; the
+> sample below is a planned design only.
 
 ```javascript
 // Enhanced performance monitoring
@@ -217,130 +228,89 @@ const webVitalsMonitor = new WebVitalsMonitor();
 
 ### Backend Function Monitoring
 
+The backend uses the `@azure/monitor-opentelemetry` package (a real dependency
+in `backend/functions/package.json`), initialized via `useAzureMonitor()`.
+Telemetry is accessed through a `MonitoringService` singleton
+(`backend/functions/src/services/MonitoringService.ts`), which wraps
+OpenTelemetry spans behind `trackEvent`, `trackMetric`, `trackException`,
+`trackDependency`, and `trackTrace` helpers. There is no `applicationinsights`
+(classic SDK) `TelemetryClient` in this codebase.
+
+#### MonitoringService Initialization
+
+```typescript
+// backend/functions/src/services/MonitoringService.ts
+import { useAzureMonitor } from "@azure/monitor-opentelemetry";
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+
+export class MonitoringService {
+    private static instance: MonitoringService;
+    private tracer: any;
+    private isInitialized = false;
+
+    public static getInstance(): MonitoringService {
+        if (!MonitoringService.instance) {
+            MonitoringService.instance = new MonitoringService();
+        }
+        return MonitoringService.instance;
+    }
+
+    private initialize(): void {
+        const connectionString = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+        if (!connectionString) {
+            // Graceful degradation: log to console only when not configured
+            this.isInitialized = false;
+            return;
+        }
+
+        useAzureMonitor({
+            azureMonitorExporterOptions: { connectionString },
+            samplingRatio: this.getSamplingRatio(),
+        });
+
+        this.tracer = trace.getTracer("pcpc-backend", this.version);
+        this.isInitialized = true;
+    }
+}
+
+// Export singleton for convenience
+export const monitoring = MonitoringService.getInstance();
+```
+
 #### Function Instrumentation
 
 ```typescript
-import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
-import { TelemetryClient, SeverityLevel } from "applicationinsights";
+// backend/functions/src/index.ts wires the singleton at startup
+import { MonitoringService } from "./services/MonitoringService";
+export const monitoringService = MonitoringService.getInstance();
+```
 
-// Initialize Application Insights client
-const telemetryClient = new TelemetryClient();
+```typescript
+// Using the singleton inside a handler
+import { monitoring } from "../services/MonitoringService";
 
-// Monitoring wrapper for Azure Functions
-export function withMonitoring<T extends any[]>(
-    functionName: string,
-    handler: (request: HttpRequest, context: InvocationContext, ...args: T) => Promise<HttpResponseInit>
-) {
-    return async (request: HttpRequest, context: InvocationContext, ...args: T): Promise<HttpResponseInit> => {
-        const startTime = Date.now();
-        const correlationId = context.invocationId;
-        
-        // Start operation tracking
-        const operation = telemetryClient.startOperation(context, request);
-        
-        try {
-            // Log function start
-            context.log(`Function ${functionName} started`, {
-                correlationId: correlationId,
-                requestUrl: request.url,
-                method: request.method
-            });
-            
-            // Execute function
-            const result = await handler(request, context, ...args);
-            
-            // Calculate execution metrics
-            const executionTime = Date.now() - startTime;
-            const statusCode = result.status || 200;
-            
-            // Track success metrics
-            telemetryClient.trackMetric({
-                name: `Function.${functionName}.ExecutionTime`,
-                value: executionTime,
-                properties: {
-                    functionName: functionName,
-                    statusCode: statusCode.toString(),
-                    correlationId: correlationId
-                }
-            });
-            
-            telemetryClient.trackMetric({
-                name: `Function.${functionName}.Success`,
-                value: 1,
-                properties: {
-                    functionName: functionName,
-                    statusCode: statusCode.toString()
-                }
-            });
-            
-            // Log successful completion
-            context.log(`Function ${functionName} completed successfully`, {
-                correlationId: correlationId,
-                executionTime: `${executionTime}ms`,
-                statusCode: statusCode
-            });
-            
-            return result;
-            
-        } catch (error) {
-            const executionTime = Date.now() - startTime;
-            
-            // Track error metrics
-            telemetryClient.trackException({
-                exception: error as Error,
-                properties: {
-                    functionName: functionName,
-                    correlationId: correlationId,
-                    executionTime: executionTime.toString()
-                },
-                severity: SeverityLevel.Error
-            });
-            
-            telemetryClient.trackMetric({
-                name: `Function.${functionName}.Error`,
-                value: 1,
-                properties: {
-                    functionName: functionName,
-                    errorType: error.constructor.name,
-                    correlationId: correlationId
-                }
-            });
-            
-            // Log error
-            context.log.error(`Function ${functionName} failed`, {
-                correlationId: correlationId,
-                error: error.message,
-                stack: error.stack,
-                executionTime: `${executionTime}ms`
-            });
-            
-            throw error;
-            
-        } finally {
-            // Complete operation tracking
-            telemetryClient.completeOperation(operation);
-        }
-    };
-}
-
-// Usage example
-export const getSetList = withMonitoring('GetSetList', async (request, context) => {
-    // Function implementation
-    const sets = await cardService.getAllSets();
-    
-    return {
-        status: 200,
-        jsonBody: { sets }
-    };
-});
+export const getSetList = async (request, context) => {
+    const op = monitoring.startOperation("GetSetList");
+    try {
+        const sets = await cardService.getAllSets();
+        monitoring.trackEvent("CardSetList", { count: sets.length });
+        return { status: 200, jsonBody: { sets } };
+    } catch (error) {
+        monitoring.trackException(error as Error, { functionName: "GetSetList" });
+        throw error;
+    } finally {
+        op.end();
+    }
+};
 ```
 
 #### Database Query Monitoring
 
 ```typescript
-// Cosmos DB monitoring wrapper
+// Cosmos DB monitoring wrapper (uses the MonitoringService singleton)
+import { monitoring } from "../services/MonitoringService";
+
 export class MonitoredCosmosService {
-    private telemetryClient = new TelemetryClient();
     
     async executeQuery<T>(
         containerName: string,
@@ -357,41 +327,37 @@ export class MonitoredCosmosService {
             
             const executionTime = Date.now() - startTime;
             
-            // Track query metrics
-            this.telemetryClient.trackDependency({
-                dependencyTypeName: 'Azure DocumentDB',
-                name: operationName,
-                data: query.query.substring(0, 100) + '...',
-                duration: executionTime,
-                success: true,
-                properties: {
+            // Track query metrics (positional signature on MonitoringService)
+            monitoring.trackDependency(
+                operationName,
+                'Azure DocumentDB',
+                query.query.substring(0, 100) + '...',
+                executionTime,
+                true,
+                {
                     containerName: containerName,
                     requestCharge: response.requestCharge.toString(),
                     itemCount: response.resources.length.toString(),
                     partitionKey: options?.partitionKey?.toString()
                 }
+            );
+            
+            monitoring.trackMetric('CosmosDB.RequestCharge', response.requestCharge, {
+                containerName: containerName,
+                queryType: this.categorizeQuery(query.query)
             });
             
-            this.telemetryClient.trackMetric({
-                name: 'CosmosDB.RequestCharge',
-                value: response.requestCharge,
-                properties: {
-                    containerName: containerName,
-                    queryType: this.categorizeQuery(query.query)
-                }
-            });
-            
-            // Log performance warnings
+            // Log performance warnings (severity 2 = Warning)
             if (response.requestCharge > 50) {
-                this.telemetryClient.trackTrace({
-                    message: `High RU consumption detected: ${response.requestCharge} RUs`,
-                    severityLevel: SeverityLevel.Warning,
-                    properties: {
+                monitoring.trackTrace(
+                    `High RU consumption detected: ${response.requestCharge} RUs`,
+                    2,
+                    {
                         containerName: containerName,
                         query: query.query,
                         requestCharge: response.requestCharge.toString()
                     }
-                });
+                );
             }
             
             return {
@@ -402,17 +368,17 @@ export class MonitoredCosmosService {
         } catch (error) {
             const executionTime = Date.now() - startTime;
             
-            this.telemetryClient.trackDependency({
-                dependencyTypeName: 'Azure DocumentDB',
-                name: operationName,
-                data: query.query.substring(0, 100) + '...',
-                duration: executionTime,
-                success: false,
-                properties: {
+            monitoring.trackDependency(
+                operationName,
+                'Azure DocumentDB',
+                query.query.substring(0, 100) + '...',
+                executionTime,
+                false,
+                {
                     containerName: containerName,
                     error: error.message
                 }
-            });
+            );
             
             throw error;
         }
@@ -685,7 +651,7 @@ async function checkCosmosDbHealth(): Promise<HealthCheckResult> {
 async function checkExternalApiHealth(): Promise<HealthCheckResult> {
     try {
         const startTime = Date.now();
-        const response = await fetch('https://api.pokemontcg.io/v2/sets?pageSize=1');
+        const response = await fetch('https://api.scrydex.com/pokemon/v1/sets?pageSize=1');
         const responseTime = Date.now() - startTime;
         
         if (response.ok) {
@@ -755,12 +721,15 @@ requests
 
 ### Synthetic Monitoring
 
+> Synthetic monitoring is not yet deployed (see Next Steps). The sample below
+> reuses the existing `MonitoringService` singleton for telemetry.
+
 ```typescript
 // Automated endpoint testing
 import { chromium } from 'playwright';
+import { monitoring } from "../services/MonitoringService";
 
 export class SyntheticMonitoring {
-    private telemetryClient = new TelemetryClient();
     
     async runHealthChecks(): Promise<void> {
         const browser = await chromium.launch();
@@ -790,22 +759,15 @@ export class SyntheticMonitoring {
             
             const loadTime = Date.now() - startTime;
             
-            this.telemetryClient.trackMetric({
-                name: 'SyntheticTest.HomepageLoad',
-                value: loadTime,
-                properties: {
-                    testType: 'synthetic',
-                    endpoint: 'homepage'
-                }
+            monitoring.trackMetric('SyntheticTest.HomepageLoad', loadTime, {
+                testType: 'synthetic',
+                endpoint: 'homepage'
             });
             
         } catch (error) {
-            this.telemetryClient.trackException({
-                exception: error,
-                properties: {
-                    testType: 'synthetic',
-                    testName: 'HomepageLoad'
-                }
+            monitoring.trackException(error as Error, {
+                testType: 'synthetic',
+                testName: 'HomepageLoad'
             });
         }
     }
@@ -823,23 +785,16 @@ export class SyntheticMonitoring {
                 const response = await fetch(endpoint);
                 const responseTime = Date.now() - startTime;
                 
-                this.telemetryClient.trackMetric({
-                    name: 'SyntheticTest.APIResponse',
-                    value: responseTime,
-                    properties: {
-                        endpoint: endpoint,
-                        statusCode: response.status.toString(),
-                        success: response.ok.toString()
-                    }
+                monitoring.trackMetric('SyntheticTest.APIResponse', responseTime, {
+                    endpoint: endpoint,
+                    statusCode: response.status.toString(),
+                    success: response.ok.toString()
                 });
                 
             } catch (error) {
-                this.telemetryClient.trackException({
-                    exception: error,
-                    properties: {
-                        testType: 'synthetic',
-                        endpoint: endpoint
-                    }
+                monitoring.trackException(error as Error, {
+                    testType: 'synthetic',
+                    endpoint: endpoint
                 });
             }
         }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -56,89 +56,46 @@ graph TB
 
 ### Bundle Optimization Strategy
 
-#### Rollup Configuration Performance
+#### Vite Build Configuration Performance
 
-**Production Build Optimization**:
-```javascript
-// rollup.config.js - Performance optimized configuration
-export default {
-    input: 'src/main.js',
-    output: {
-        sourcemap: false, // Disable in production for size
-        format: 'iife',
-        name: 'app',
-        file: 'public/build/bundle.js',
-        // Code splitting for performance
-        manualChunks: {
-            vendor: ['svelte', 'axios'],
-            utils: ['src/utils/index.js']
-        }
-    },
-    plugins: [
-        svelte({
-            compilerOptions: {
-                dev: false,
-                // Performance optimizations
-                hydratable: false,
-                legacy: false
-            },
-            // CSS extraction for parallel loading
-            emitCss: true
-        }),
-        resolve({
-            browser: true,
-            dedupe: ['svelte']
-        }),
-        commonjs(),
-        // Minification with performance focus
-        terser({
-            compress: {
-                drop_console: true,
-                drop_debugger: true,
-                pure_funcs: ['console.log']
-            },
-            mangle: {
-                reserved: ['$', 'exports', 'require']
-            }
-        }),
-        // Asset optimization
-        copy({
-            targets: [{
-                src: 'src/assets/**/*',
-                dest: 'public/build/assets',
-                transform: (contents, filename) => {
-                    // Image compression logic
-                    if (filename.endsWith('.jpg') || filename.endsWith('.png')) {
-                        return compressImage(contents);
-                    }
-                    return contents;
-                }
-            }]
-        })
-    ]
-};
+The frontend is built with Vite and SvelteKit. Production builds run through
+`vite build` (which uses Rollup internally), so most bundling, code splitting,
+and minification optimizations are applied automatically by Vite's defaults.
+
+**Vite Configuration** (`frontend/vite.config.ts`):
+```typescript
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    plugins: [tailwindcss(), sveltekit()]
+    // Vite applies production minification (esbuild), tree shaking, and
+    // automatic code splitting out of the box. Add a `build` block here only
+    // when overriding defaults (e.g. rollupOptions.output.manualChunks).
+});
 ```
 
 #### Bundle Analysis and Optimization
 
-**Current Bundle Performance** (verified):
-- **Production Build Time**: 2.4 seconds
-- **Development Build Time**: 1.3 seconds  
+**Bundle Performance** (illustrative targets):
+- **Production Build Time**: ~2-3 seconds
 - **Bundle Size**: Optimized through tree shaking and minification
-- **Dependencies**: 154 packages efficiently bundled
+- **Dependencies**: Efficiently bundled via Vite's Rollup-based pipeline
 
 **Bundle Size Optimization**:
 ```bash
-# Analyze bundle composition
-npm run build:analyze
+# Build the frontend (output goes to the SvelteKit build directory)
+cd frontend
+npm run build
+
+# Analyze bundle composition with Vite's visualizer
+npx vite-bundle-visualizer
 
 # Bundle size tracking
 echo "Bundle Size Analysis:" > bundle-report.txt
 echo "========================" >> bundle-report.txt
-ls -la public/build/ >> bundle-report.txt
-echo "" >> bundle-report.txt
-echo "Gzipped Sizes:" >> bundle-report.txt
-gzip -c public/build/bundle.js | wc -c >> bundle-report.txt
+ls -la build/ >> bundle-report.txt
 ```
 
 ### Lazy Loading Implementation
@@ -591,12 +548,18 @@ graph TD
     D -->|Miss| F{API Management Cache}
     F -->|Hit| G[Return API Cache]
     F -->|Miss| H[Azure Functions]
-    H --> I{Application Cache}
-    I -->|Hit| J[Return Function Cache]
+    H --> I{Redis Cache}
+    I -->|Hit| J[Return Cached Data]
     I -->|Miss| K[Cosmos DB Query]
     K --> L[Cache Response at All Levels]
     L --> M[Return to User]
 ```
+
+> The server-side Redis tier is implemented by `RedisCacheService`
+> (`backend/functions/src/services/RedisCacheService.ts`) and is only active
+> when the `ENABLE_REDIS_CACHE` app setting is set to `"true"`. The client tier
+> uses IndexedDB and the gateway tier uses the API Management response cache
+> (`cache-lookup`/`cache-store`).
 
 ### Frontend Caching Implementation
 
@@ -1246,7 +1209,7 @@ The PCPC performance architecture establishes a comprehensive foundation for del
 ### Key Performance Achievements
 
 - **Sub-second API Responses**: Optimized caching and database queries
-- **Fast Build Times**: 2.4-second production builds with optimized bundling
+- **Fast Build Times**: Quick production builds via Vite's optimized bundling
 - **Efficient Resource Utilization**: Multi-tier caching reducing server load
 - **Comprehensive Monitoring**: Real-time performance tracking and alerting
 - **Scalable Architecture**: Designed for growth without performance degradation

--- a/docs/security.md
+++ b/docs/security.md
@@ -106,26 +106,21 @@ sequenceDiagram
 
 #### Azure Functions Authorization
 
-**Function-Level Security**:
-```typescript
-import { AuthorizationLevel } from '@azure/functions';
+**Current model: anonymous host auth, gateway-enforced access**
 
-export const httpTrigger: AzureFunction = async function (context, req) {
-    // Function configured with authLevel: 'function'
-    // Requires x-functions-key header or code query parameter
-    
-    // Additional custom authorization logic
-    if (!validateRequestOrigin(req)) {
-        context.res = {
-            status: 403,
-            body: { error: "Forbidden: Invalid request origin" }
-        };
-        return;
-    }
-    
-    // Process authorized request
-};
+All HTTP triggers are registered with `authLevel: "anonymous"` on the Functions host. Authentication and access control are enforced at the gateway layer (APIM subscription key on the APIM path, ACA ingress/CORS on the Container Apps path), not by Azure Functions host keys. There is no `x-functions-key` requirement in the current deployment.
+
+```typescript
+// backend/functions/src/index.ts
+app.http("getSetList", {
+    methods: ["GET"],
+    authLevel: "anonymous", // auth enforced at the gateway, not the host
+    route: "sets",
+    handler: getSetList,
+});
 ```
+
+Function-key auth (`authLevel: "function"`, requiring an `x-functions-key` header or `code` query parameter) is available in the Azure Functions runtime, but is intentionally not used: with the Container Apps gateway bypassing APIM, host-key auth would 401 every browser request. Moving auth to the gateway lets the same code path serve both gateways. APIM still provides subscription-key validation, rate limiting, the developer portal, and observability.
 
 ### Planned Enhancements
 
@@ -243,7 +238,8 @@ const getSecret = (secretName: string): string => {
 };
 
 // Usage example
-const pokeDataApiKey = getSecret('POKEDATA_API_KEY');
+const scrydexApiKey = getSecret('SCRYDEX_API_KEY');
+const scrydexTeamId = getSecret('SCRYDEX_TEAM_ID');
 const cosmosDbConnectionString = getSecret('COSMOS_DB_CONNECTION_STRING');
 ```
 
@@ -429,7 +425,7 @@ graph LR
 ```
 
 **Examples**:
-- `dev-functions-apikey-pokedata`
+- `dev-functions-apikey-scrydex`
 - `prod-cosmos-connectionstring-primary`
 - `dev-storage-key-images`
 
@@ -484,23 +480,23 @@ resource "azurerm_key_vault_access_policy" "functions" {
 
 #### Automated Rotation
 
-**PokeData API Key Rotation**:
+**Scrydex API Key Rotation**:
 ```typescript
 // Azure Function for API key rotation
 export const rotateApiKeys: AzureFunction = async function (context, myTimer) {
     try {
         // Get current key from Key Vault
-        const currentKey = await getSecret('POKEDATA_API_KEY');
+        const currentKey = await getSecret('SCRYDEX_API_KEY');
         
-        // Generate new key via PokeData API
+        // Generate new key via Scrydex API
         const newKey = await generateNewApiKey();
         
         // Update Key Vault with new key
-        await updateSecret('POKEDATA_API_KEY', newKey);
+        await updateSecret('SCRYDEX_API_KEY', newKey);
         
         // Update Application Settings
         await updateFunctionAppSettings({
-            'POKEDATA_API_KEY': `@Microsoft.KeyVault(SecretUri=${keyVaultUri})`
+            'SCRYDEX_API_KEY': `@Microsoft.KeyVault(SecretUri=${keyVaultUri})`
         });
         
         // Test new key

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,11 +49,11 @@ graph TD
 | Issue                         | Symptoms                 | Quick Fix                            |
 | ----------------------------- | ------------------------ | ------------------------------------ |
 | DevContainer won't start      | Container fails to build | `docker system prune -a`             |
-| Frontend build fails          | Rollup errors            | `rm -rf node_modules && npm install` |
+| Frontend build fails          | Vite/SvelteKit errors    | `rm -rf node_modules && npm install` |
 | Backend functions not working | 500 errors               | Check `local.settings.json`          |
 | API calls failing             | CORS errors              | Verify APIM CORS policy              |
 | Database connection issues    | Cosmos DB errors         | Check connection string              |
-| Tests failing                 | Jest/Playwright errors   | `npm run test:clean && npm test`     |
+| Tests failing                 | Jest/Playwright errors   | `npm test`                           |
 
 ### Most Frequent Issues
 
@@ -75,7 +75,7 @@ docker ps -a
 docker logs pcpc-devcontainer
 
 # Check port conflicts
-netstat -tulpn | grep -E "(3000|7071|8081|10000)"
+netstat -tulpn | grep -E "(5173|7071|8081|10000)"
 ```
 
 **Solutions**:
@@ -132,7 +132,7 @@ npm install -g npm@latest
 
 **Symptoms**:
 
-- Frontend build fails with Rollup errors
+- Frontend build fails with Vite/SvelteKit errors
 - Backend TypeScript compilation errors
 - Missing dependencies
 
@@ -140,11 +140,11 @@ npm install -g npm@latest
 
 ```bash
 # Frontend build diagnosis
-cd app/frontend
+cd frontend
 npm run build 2>&1 | tee build.log
 
 # Backend build diagnosis
-cd app/backend
+cd backend/functions
 npm run build 2>&1 | tee build.log
 
 # Check for missing files
@@ -155,13 +155,13 @@ find . -name "*.js" -o -name "*.ts" | head -10
 
 ```bash
 # Frontend build fix
-cd app/frontend
-rm -rf node_modules public/build
+cd frontend
+rm -rf node_modules .svelte-kit build
 npm install
 npm run build
 
 # Backend build fix
-cd app/backend
+cd backend/functions
 rm -rf node_modules dist
 npm install
 npm run build
@@ -246,14 +246,14 @@ docker pull maberdevcontainerregistry-ccedhvhwfndwetdp.azurecr.io/pcpc-devcontai
 
 ```bash
 # Check port usage
-netstat -tulpn | grep -E "(3000|7071|8081|10000|10001|10002)"
+netstat -tulpn | grep -E "(5173|7071|8081|10000|10001|10002)"
 
 # Windows specific
-netstat -ano | findstr -E "(3000|7071|8081|10000)"
+netstat -ano | findstr -E "(5173|7071|8081|10000)"
 
 # Find process using port
-lsof -i :3000  # Linux/Mac
-netstat -ano | findstr :3000  # Windows
+lsof -i :5173  # Linux/Mac
+netstat -ano | findstr :5173  # Windows
 ```
 
 **Solutions**:
@@ -261,7 +261,7 @@ netstat -ano | findstr :3000  # Windows
 ```bash
 # Kill processes using ports
 # Linux/Mac
-sudo kill -9 $(lsof -t -i:3000)
+sudo kill -9 $(lsof -t -i:5173)
 
 # Windows
 taskkill /PID <PID> /F
@@ -308,38 +308,38 @@ code --list-extensions --show-versions
 
 #### Frontend Development Problems
 
-**Issue**: Svelte development server issues
+**Issue**: SvelteKit development server issues
 
 **Symptoms**:
 
-- Hot reload not working
-- Build errors with Rollup
+- Hot reload (HMR) not working
+- Build errors with Vite/SvelteKit
 - Component rendering issues
 
 **Diagnostic Steps**:
 
 ```bash
-cd app/frontend
+cd frontend
 
-# Check development server
+# Check development server (Vite, defaults to port 5173)
 npm run dev
 
 # Check build process
 npm run build
 
 # Check component syntax
-npx svelte-check
+npm run check
 ```
 
 **Solutions**:
 
 ```bash
 # Fix hot reload
-# Check rollup.config.cjs livereload configuration
-# Ensure port 35729 is available
+# Restart the Vite dev server (npm run dev)
+# Ensure the Vite dev port (5173) is available
 
 # Fix build errors
-rm -rf public/build
+rm -rf .svelte-kit build
 npm run build
 
 # Fix component issues
@@ -360,7 +360,7 @@ npm run build
 **Diagnostic Steps**:
 
 ```bash
-cd app/backend
+cd backend/functions
 
 # Check Functions runtime
 func --version  # Should be 4.x
@@ -681,8 +681,8 @@ az functionapp function show \
   --name "pokedata-func-dev" \
   --function-name "GetSetList"
 
-# Test function locally
-cd app/backend
+# Test function locally (listens on port 7071)
+cd backend/functions
 func start --typescript
 ```
 
@@ -757,7 +757,7 @@ async function testDatabaseConnection() {
     });
 
     const { database } = await client.databases.createIfNotExists({
-      id: "PokeData",
+      id: "PokemonCards",
     });
 
     console.log("Database connection successful");
@@ -835,11 +835,10 @@ performance.measure('app-load-time', 'app-start', 'app-ready');
 
 // Check bundle size
 npm run build
-ls -lh public/build/
+ls -lh build/
 
-// Analyze bundle composition
-npm install -g webpack-bundle-analyzer
-npx webpack-bundle-analyzer public/build/bundle.js
+// Analyze bundle composition (Vite + rollup-plugin-visualizer)
+npx vite-bundle-visualizer
 ```
 
 **Solutions**:
@@ -964,7 +963,7 @@ export async function GetSetList(
   context: InvocationContext
 ): Promise<HttpResponseInit> {
   // Use pre-initialized clients
-  const container = cosmosClient.database("PokeData").container("sets");
+  const container = cosmosClient.database("PokemonCards").container("Sets");
   // ... function logic
 }
 
@@ -1085,7 +1084,7 @@ az apim subscription regenerate-key \
 # Verify Key Vault access
 az keyvault secret show \
   --vault-name "pokedata-kv-dev" \
-  --name "pokedata-api-key"
+  --name "scrydex-api-key"
 ```
 
 ### SSL/TLS Issues
@@ -1156,33 +1155,18 @@ curl -X POST "https://dc.services.visualstudio.com/v2/track" \
 **Solutions**:
 
 ```typescript
-// Fix Application Insights integration
-import { ApplicationInsights } from "@azure/applicationinsights-web";
+// Fix backend telemetry (Azure Functions)
+// The backend uses the @azure/monitor-opentelemetry distro
+import { useAzureMonitor } from "@azure/monitor-opentelemetry";
 
-const appInsights = new ApplicationInsights({
-  config: {
-    instrumentationKey: process.env.APPINSIGHTS_INSTRUMENTATIONKEY,
-    enableAutoRouteTracking: true,
-    enableCorsCorrelation: true,
-    enableRequestHeaderTracking: true,
-    enableResponseHeaderTracking: true,
+useAzureMonitor({
+  azureMonitorExporterOptions: {
+    connectionString: process.env.APPLICATIONINSIGHTS_CONNECTION_STRING,
   },
 });
 
-appInsights.loadAppInsights();
-
-// Add custom telemetry
-appInsights.trackEvent({
-  name: "CardSearch",
-  properties: {
-    searchTerm: searchTerm,
-    resultCount: results.length,
-  },
-});
-
-// Fix backend telemetry
-// Ensure APPINSIGHTS_INSTRUMENTATIONKEY is set
-// Verify Application Insights SDK is installed
+// Ensure APPLICATIONINSIGHTS_CONNECTION_STRING is set in app settings
+// Verify @azure/monitor-opentelemetry is installed in backend/functions
 ```
 
 ### Log Analysis
@@ -1206,7 +1190,7 @@ az functionapp config appsettings list \
   --name "pokedata-func-dev"
 
 # Check log level
-grep -r "LOG_LEVEL" app/backend/
+grep -r "LOG_LEVEL" backend/functions/
 
 # Test logging
 az functionapp log tail --name "pokedata-func-dev" --resource-group "pokedata-dev-rg"
@@ -1324,13 +1308,13 @@ az functionapp function disable \
 az cosmosdb sql database backup show \
   --resource-group "pokedata-prod-rg" \
   --account-name "pokedata-cosmos-prod" \
-  --database-name "PokeData"
+  --database-name "PokemonCards"
 
 # Restore from backup
 az cosmosdb sql database restore \
   --resource-group "pokedata-prod-rg" \
   --account-name "pokedata-cosmos-prod" \
-  --database-name "PokeData" \
+  --database-name "PokemonCards" \
   --restore-timestamp "2025-09-28T19:00:00Z"
 ```
 
@@ -1366,19 +1350,19 @@ az apim subscription regenerate-key \
 # Update Key Vault secrets
 az keyvault secret set \
   --vault-name "pokedata-kv-prod" \
-  --name "pokedata-api-key" \
+  --name "scrydex-api-key" \
   --value "new-secure-api-key"
 
 az keyvault secret set \
   --vault-name "pokedata-kv-prod" \
-  --name "pokemon-tcg-api-key" \
-  --value "new-secure-tcg-key"
+  --name "scrydex-team-id" \
+  --value "new-secure-team-id"
 
 # Update Function App settings
 az functionapp config appsettings set \
   --resource-group "pokedata-prod-rg" \
   --name "pokedata-func-prod" \
-  --settings "POKEDATA_API_KEY=@Microsoft.KeyVault(SecretUri=https://pokedata-kv-prod.vault.azure.net/secrets/pokedata-api-key/)"
+  --settings "SCRYDEX_API_KEY=@Microsoft.KeyVault(SecretUri=https://pokedata-kv-prod.vault.azure.net/secrets/scrydex-api-key/)"
 
 # Update frontend environment variables
 # Deploy new build with updated subscription keys
@@ -1414,7 +1398,7 @@ az monitor app-insights query \
 az cosmosdb sql database throughput show \
   --resource-group "pokedata-prod-rg" \
   --account-name "pokedata-cosmos-prod" \
-  --name "PokeData"
+  --name "PokemonCards"
 ```
 
 ### Performance Degradation
@@ -1442,7 +1426,7 @@ az monitor metrics list \
 az cosmosdb sql database throughput show \
   --resource-group "pokedata-prod-rg" \
   --account-name "pokedata-cosmos-prod" \
-  --name "PokeData"
+  --name "PokemonCards"
 
 # Check API Management throttling
 az apim api list \
@@ -1463,7 +1447,7 @@ az functionapp plan update \
 az cosmosdb sql database throughput update \
   --resource-group "pokedata-prod-rg" \
   --account-name "pokedata-cosmos-prod" \
-  --name "PokeData" \
+  --name "PokemonCards" \
   --throughput 10000
 
 # Clear caches

--- a/frontend/PCPC_Redesign_Spec.md
+++ b/frontend/PCPC_Redesign_Spec.md
@@ -6,6 +6,8 @@
 **Stack:** SvelteKit 2 · Svelte 5 · TailwindCSS 4 · TypeScript 5 · adapter-vercel
 **Theme:** Dark-mode-first (light mode deferred)
 
+> **Historical design snapshot.** This is the original redesign proposal, written before the move into the PCPC repo (paths below reference the old `apps/pcpc/...` layout). Most of it shipped, but the component breakdown diverged in one place: the proposed standalone `PriceTable.svelte` and `GradedPriceGrid.svelte` were ultimately folded into `PricingPanel.svelte` and do not exist as separate components. See `frontend/src/lib/components/` for the current inventory.
+
 ---
 
 ## 1. Design direction — "Elevated dark"

--- a/infra/README.md
+++ b/infra/README.md
@@ -12,15 +12,19 @@ The infrastructure is organized into reusable modules and environment-specific c
 infra/
 ├── modules/                    # Reusable Terraform modules
 │   ├── api-management/        # Azure API Management
+│   ├── application-insights/  # Application Insights + monitor alerts
 │   ├── container-app/         # Azure Container Apps (Path C)
 │   ├── container-registry/    # Azure Container Registry
 │   ├── cosmos-db/             # Cosmos DB (serverless NoSQL)
 │   ├── function-app/          # Azure Functions (Path B)
+│   ├── key-vault/             # Azure Key Vault (secrets, access policies)
+│   ├── log-analytics/         # Log Analytics workspace
+│   ├── resource-group/        # Azure resource group
 │   └── storage-account/       # Azure Blob Storage
 └── envs/                      # Environment-specific configurations
     ├── dev/                   # Development environment
-    ├── staging/               # Staging environment (planned)
-    └── prod/                  # Production environment (planned)
+    ├── staging/               # Staging environment
+    └── prod/                  # Production environment
 ```
 
 ## Azure Resources
@@ -56,4 +60,4 @@ terraform apply -var-file="terraform.tfvars"
 - Terraform >= 1.13.3
 - Azure CLI (authenticated)
 - Azure subscription with required permissions
-- State storage backend configured (see `state-storage/` in the deployment guide)
+- Remote state backend configured: each environment uses an `azurerm` backend (see the `backend "azurerm"` block in `envs/<env>/main.tf`) backed by the `pcpc-terraform-state-rg` resource group and `tfstate` blob container. See the [Deployment Guide](../docs/deployment-guide.md) for setup details.


### PR DESCRIPTION
## Summary

Several docs predated the **Phase 2.1 PokeData→Scrydex cutover** and the **SvelteKit-on-Vercel three-path redesign**, and described a system that no longer exists. This PR resyncs the documentation with the actual code across two commits (critical+high, then medium/low). Every change was grounded in the source.

Docs-only change. No application code touched.

## Critical + high (commit 1)

| Doc | Fix |
|---|---|
| `api-reference.md` | Full rewrite. Removed fictional endpoints (`/search/cards`, `/stats`, single-set `/sets/{id}`); fixed envelope to `{status,data,cached,cacheAge}`; real Scrydex models (`variants[].prices[]`, `images[]`); corrected query params; dropped `/api/v1`. |
| `architecture.md` | Full rewrite to the three-path architecture (Vercel BFF / APIM+Functions / ACA). Scrydex services, real 6 functions incl. `HealthCheck`, SvelteKit-on-Vercel hosting; mermaid revalidated. |
| `frontend-theming-style-guide.md` | Full rewrite to the real `app.css` v7 token system; corrected the `data-theme` behavior. |
| `development-guide.md`, `LOCAL_DEVELOPMENT.md`, `troubleshooting.md`, `performance.md` | `app/*`→real paths, dev port `3000`→`5173`, Rollup→Vite, PokeData→Scrydex env/services, `MonitorCredits`→`MonitorScrydexUsage`, DB `PokeData`→`PokemonCards`, `REDIS_CACHE_ENABLED`→`ENABLE_REDIS_CACHE`, removed non-existent scripts. |
| `security.md` | Function `authLevel` is `anonymous` (gateway-enforced), not `function`/`x-functions-key`; Scrydex secret names. |
| `monitoring.md` | Backend uses `@azure/monitor-opentelemetry` via `MonitoringService`; frontend telemetry marked not-yet-implemented. |

## Medium + low (commit 2)

| Doc | Fix |
|---|---|
| `docs/adr/README.md` | Removed 4 phantom "Accepted" rows (ADR-002/003/005/006 — no files); unlinked not-yet-written ADR-010. |
| `README.md` | ADR blurb references only the earlier ADRs that exist (001, 004); module count 9→10. |
| `architecture-comparison.md` | Path B module list: dropped nonexistent "static web app legacy module", added container registry + container app; 9→10. |
| `deployment-guide.md` | Removed nonexistent `static-web-app` module section (frontend = Vercel, not Terraform); enumerated 10 real modules; Cosmos DB `PokeData`→`PokemonCards`; `app/*`→real paths; corrected remote-state to the real inline `azurerm` backend. |
| `infra/README.md` | Listed all 10 modules; dropped stale "(planned)" on staging/prod (both implemented); fixed `state-storage/` reference. |
| `frontend/PCPC_Redesign_Spec.md` | Added historical-snapshot banner (PriceTable/GradedPriceGrid folded into `PricingPanel.svelte`). |

## Intentionally left as-is

Point-in-time historical records were **not** rewritten (would be revisionist): `docs/set-mapping-fixes-summary.md`, `docs/set-mapping-pipeline-integration.md`, `docs/github-issues/*`, and ADR-001's `app/*` decision context. Historical SWA/Porkbun sections in `deployment-guide.md` are retained under an explicit "historical reference" banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
