### PR TITLE
docs: remove stray git conflict marker in redesign spec

### DIFF
--- a/frontend/PCPC_Redesign_Spec.md
+++ b/frontend/PCPC_Redesign_Spec.md
@@ -519,4 +519,3 @@ These remain separate tasks:
 - **Issue #3**: Duplicate API calls — still open
 - **Issue #4**: Excessive IndexedDB writes (100 individual ops per card load) — still open
 - **Issue #5**: "No cards found" text persists — still open
->>>>>>> origin/main


### PR DESCRIPTION
## Summary

`frontend/PCPC_Redesign_Spec.md` had a leftover `>>>>>>> origin/main` git conflict marker committed as the last line of the file (~line 522), left behind by an earlier botched merge resolution. It's harmless (a markdown doc) but shouldn't be there.

This PR deletes that final line.

## Verification

`git grep -n '^<<<<<<<\|^>>>>>>>\|^=======$'` returns nothing across the repo (exit 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)