### PR TITLE
ci(image): scoped, time-boxed Trivy waiver for base-image MessagePack CVE

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,22 @@
+# Trivy vulnerability ignore list (scoped, time-boxed).
+#
+# Each entry MUST have: a justification (statement) and an expired_at date so the
+# gate re-blocks and forces a re-review once the fix should be available — these
+# are NOT permanent waivers.
+#
+# Consumed by pipelines/ado/templates/build-and-push-image.yml via `--ignorefile`.
+
+vulnerabilities:
+  - id: CVE-2026-48109
+    statement: >-
+      MessagePack 2.5.192 (HIGH, fixed in 2.5.301) ships inside Microsoft's
+      Azure Functions ExtensionBundle (.NET), which is baked into the official
+      base image mcr.microsoft.com/azure-functions/node:4-node22. It is NOT a
+      dependency of the PCPC Node.js function app or its node_modules, and the
+      affected code path (MessagePack LZ4 decompression) is not reachable from
+      our code. Verified on 2026-06-17 that NO published Azure Functions base
+      image fixes it yet — even the newest build (4.1051.300-1-node22,
+      ExtensionBundle 4.36.0) still ships MessagePack 2.5.192. There is no
+      actionable upstream fix to consume. Revisit when Microsoft updates
+      MessagePack in the base image / ExtensionBundle.
+    expired_at: 2026-09-17

--- a/pipelines/ado/templates/build-and-push-image.yml
+++ b/pipelines/ado/templates/build-and-push-image.yml
@@ -240,15 +240,20 @@ steps:
       echo "Trivy:    aquasec/trivy:${{ parameters.trivyVersion }}"
       echo ""
 
+      # --ignorefile: scoped, time-boxed waivers for un-actionable upstream CVEs
+      # (see .trivyignore.yaml — each entry has a justification + expiry so the
+      # gate re-blocks for re-review). Mounted read-only into the scanner.
       docker run --rm \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v "$(Pipeline.Workspace)/.trivy-cache:/root/.cache/trivy" \
+        -v "$(Build.SourcesDirectory)/.trivyignore.yaml:/.trivyignore.yaml:ro" \
         aquasec/trivy:${{ parameters.trivyVersion }} \
         image \
           --severity '${{ parameters.trivySeverity }}' \
           --exit-code 1 \
           --no-progress \
           --ignore-unfixed \
+          --ignorefile /.trivyignore.yaml \
           --scanners vuln \
           "$(ContainerImageReference)"
 


### PR DESCRIPTION
## Summary

Unblocks the ACA image's Trivy gate, which is failing on **CVE-2026-48109** (MessagePack 2.5.192, HIGH) — a vulnerability inside **Microsoft's Azure Functions ExtensionBundle (.NET), baked into the base image** (`mcr.microsoft.com/azure-functions/node:4-node22`). It is not a dependency of the PCPC Node app or its `node_modules`, and the affected path (MessagePack LZ4 decompression) is not reachable from our code.

## Why a waiver (not a base bump)

I verified exhaustively (2026-06-17) that **no published Azure Functions base image fixes this yet**:
- Our `:4-node22` (2026-06-10) → ExtensionBundle 4.35.0 → MessagePack 2.5.192.
- The **newest** published build `4.1051.300-1-node22` (2026-06-17) → ExtensionBundle **4.36.0** → **still MessagePack 2.5.192**.

The fix is 2.5.301; Microsoft hasn't shipped it in any base/bundle. So there's no upstream fix to consume and bumping the base wouldn't help. `--ignore-unfixed` doesn't skip it (it's "fixed" upstream, just not in the bundle).

## Change

- Add `.trivyignore.yaml` with a **single scoped** entry for CVE-2026-48109, including a justification and **`expired_at: 2026-09-17`** so the gate **re-blocks for re-review** once Microsoft should have patched — this is a time-boxed waiver, not a permanent suppression.
- Wire it into the scan via `--ignorefile` (mounted read-only). Every other CVE stays blocking.

## Verification

Locally ran the exact CI scan command with the ignorefile against the built image: **`Total: 0 (HIGH: 0, CRITICAL: 0)`, exit 0**, CVE shown as suppressed. (The CD image build runs on `main` push, so the gate itself confirms on the next CD run after merge.)

## Revisit

When Microsoft ships a base image / ExtensionBundle with MessagePack ≥ 2.5.301, remove the entry (or let it expire 2026-09-17) and the gate validates the fix is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
