### PR TITLE
refactor(pipelines): dedup CD stages, centralize pnpm, drop dead params

### DIFF
--- a/pipelines/ado/azure-pipelines-pr.yml
+++ b/pipelines/ado/azure-pipelines-pr.yml
@@ -21,10 +21,9 @@ pool:
 variables:
   # Include container image digest variables and ACR service connection
   - template: variables/ci-images.yml
-  - name: nodeVersion
-    value: "22.x"
-  - name: terraformVersion
-    value: "1.13.3"
+  # Centralized script tool versions (pnpm). Node/Terraform versions live in the
+  # CI container images, not here — see variables/versions.yml.
+  - template: variables/versions.yml
 
 resources:
   containers:
@@ -41,16 +40,12 @@ stages:
     displayName: "Validate Backend"
     jobs:
       - template: templates/validate-backend.yml
-        parameters:
-          nodeVersion: $(nodeVersion)
 
   # Stage 2: Infrastructure Validation
   - stage: ValidateInfrastructure
     displayName: "Validate Infrastructure"
     jobs:
       - template: templates/validate-infrastructure.yml
-        parameters:
-          terraformVersion: $(terraformVersion)
 
   # Stage 3: APIM Validation
   - stage: ValidateAPIM

--- a/pipelines/ado/azure-pipelines.yml
+++ b/pipelines/ado/azure-pipelines.yml
@@ -27,6 +27,7 @@ variables:
   # Each Deploy_* stage declares only its own env's groups below, so secrets
   # never cross environment boundaries. The Build stage needs no env groups.
   - template: variables/ci-images.yml
+  - template: variables/versions.yml
   - name: buildConfiguration
     value: "Release"
   - name: nodeVersion
@@ -53,14 +54,6 @@ stages:
         parameters:
           buildConfiguration: $(buildConfiguration)
           nodeVersion: $(nodeVersion)
-          azureSubscription: "az-pcpc-dev"
-          apimName: "pcpc-apim-dev"
-          apimResourceGroup: "pcpc-rg-dev"
-          apimBaseUrl: "https://pcpc-apim-dev.azure-api.net/pcpc-api"
-          apimBasePath: "pcpc-api"
-          useApiManagement: "true"
-          functionAppName: $(FUNCTION_APP_NAME)
-          functionResourceGroup: $(APIM_RESOURCE_GROUP)
 
       # Build the Path C (ACA) container image and push to PCPC's shared ACR.
       # Runs in parallel with the unified-artifact build above — they're
@@ -88,361 +81,49 @@ stages:
               acrResourceGroup: "pcpc-rg-shared"
 
   # ============================================================================
-  # STAGE 2: DEPLOY TO DEV
-  # Automatic deployment to development environment
+  # DEPLOY STAGES (dev → staging → prod)
+  # Each environment is one invocation of templates/deploy-stage.yml — the
+  # ~110-line stage body used to be copy-pasted three times (audit D1/D2).
+  # `Build` is in every stage's dependsOn so the Deploy_ACA job can read the
+  # cross-stage Build_Container_Image output variable (image built once, rolled
+  # to all three envs). Execution order is preserved by the staged dependsOn.
   # ============================================================================
-  - stage: Deploy_Dev
-    displayName: "Deploy to Dev"
-    dependsOn: Build
-    condition: succeeded()
-    variables:
-      - group: vg-pcpc-dev-config
-      - group: vg-pcpc-dev-secrets
-    jobs:
-      # Deploy Infrastructure
-      - job: Deploy_Infrastructure
-        displayName: "Deploy Infrastructure"
-        pool:
-          vmImage: "ubuntu-latest"
-        container: terraform
-        steps:
-          - template: templates/deploy-infra.yml
-            parameters:
-              environment: dev
-              azureSubscription: "az-pcpc-dev"
-              terraformVersion: "1.13.3"
 
-      # Deploy Backend Functions
-      - job: Deploy_Functions
-        displayName: "Deploy Azure Functions"
-        dependsOn: Deploy_Infrastructure
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: node-azure
-        steps:
-          - template: templates/deploy-functions.yml
-            parameters:
-              environment: dev
-              azureSubscription: "az-pcpc-dev"
-              functionAppName: $(FUNCTION_APP_NAME)
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
+  # STAGE 2: DEPLOY TO DEV — automatic, no approval gate.
+  - template: templates/deploy-stage.yml
+    parameters:
+      stageName: Deploy_Dev
+      displayName: "Deploy to Dev"
+      environment: dev
+      azureSubscription: "az-pcpc-dev"
+      containerAppName: "pcpc-aca-dev"
+      requiresApproval: false
+      dependsOn:
+        - Build
 
-      # Deploy APIM APIs and Policies
-      - job: Deploy_APIM
-        displayName: "Deploy APIM APIs & Policies"
-        dependsOn:
-          - Deploy_Infrastructure
-          - Deploy_Functions
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: terraform
-        steps:
-          - template: templates/deploy-apim.yml
-            parameters:
-              environment: dev
-              azureSubscription: "az-pcpc-dev"
+  # STAGE 3: DEPLOY TO STAGING — approval-gated via the pcpc-staging Environment.
+  - template: templates/deploy-stage.yml
+    parameters:
+      stageName: Deploy_Staging
+      displayName: "Deploy to Staging"
+      environment: staging
+      azureSubscription: "az-pcpc-staging"
+      containerAppName: "pcpc-aca-staging"
+      requiresApproval: true
+      dependsOn:
+        - Build
+        - Deploy_Dev
 
-      # Phase 2.2 — Deploy Path C (ACA Container).
-      #
-      # Parallel to Deploy_Functions (Path B). Consumes the canonical
-      # SHA-tagged image reference from the Build stage's
-      # `Build_Container_Image` job (cross-stage `stageDependencies` output)
-      # and rolls a new revision on the Container App. The image-build
-      # itself lives in the Build stage so that future Deploy_Staging /
-      # Deploy_Prod ACA jobs can consume the same artifact.
-      #
-      # `dependsOn: Deploy_Infrastructure` so Terraform has provisioned
-      # the Container App before we try to roll it. (Build stage already
-      # completed by the time Deploy_Dev runs — that's the stage-level
-      # dependsOn at the parent.)
-      - job: Deploy_ACA
-        displayName: "Deploy Path C (ACA Container)"
-        dependsOn: Deploy_Infrastructure
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        variables:
-          # Map the Build stage's image-build job output to a job-scoped
-          # variable so we can pass it as a runtime parameter below.
-          containerImageReference: $[ stageDependencies.Build.Build_Container_Image.outputs['discover_image.ContainerImageReference'] ]
-        steps:
-          - template: templates/deploy-aca.yml
-            parameters:
-              environment: dev
-              azureSubscription: "az-pcpc-dev"
-              containerAppName: "pcpc-aca-dev"
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
-              containerImageReference: $(containerImageReference)
-
-      # Run Smoke Tests
-      - job: Smoke_Tests
-        displayName: "Run Smoke Tests"
-        dependsOn:
-          - Deploy_Functions
-          - Deploy_APIM
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: node-azure
-        steps:
-          - template: templates/smoke-tests.yml
-            parameters:
-              environment: dev
-              azureSubscription: "az-pcpc-dev"
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
-              functionAppName: $(FUNCTION_APP_NAME)
-              apimName: $(APIM_NAME)
-
-  # ============================================================================
-  # STAGE 3: DEPLOY TO STAGING
-  # Approval-gated deployment to staging environment
-  # ============================================================================
-  - stage: Deploy_Staging
-    displayName: "Deploy to Staging"
-    # `Build` is listed explicitly (in addition to Deploy_Dev) so this stage
-    # can read `stageDependencies.Build.Build_Container_Image.outputs[...]`
-    # for the Deploy_ACA job below. Per Microsoft Learn: "Output variables
-    # are only available in the next downstream stage. If multiple stages
-    # consume the same output variable, use the `dependsOn` condition."
-    # (learn.microsoft.com/azure/devops/pipelines/process/set-variables-scripts).
-    # Execution order is unchanged — Deploy_Dev already gates this stage
-    # via its own dependsOn on Build, so adding Build here just propagates
-    # the output-variable visibility.
-    dependsOn:
-      - Build
-      - Deploy_Dev
-    condition: succeeded()
-    variables:
-      - group: vg-pcpc-staging-config
-      - group: vg-pcpc-staging-secrets
-    jobs:
-      # Deploy Infrastructure
-      - deployment: Deploy_Infrastructure
-        displayName: "Deploy Infrastructure"
-        environment: pcpc-staging # Approval gate configured in Azure DevOps
-        pool:
-          vmImage: "ubuntu-latest"
-        container: terraform
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - template: templates/deploy-infra.yml
-                  parameters:
-                    environment: staging
-                    azureSubscription: "az-pcpc-staging"
-                    terraformVersion: "1.13.3"
-
-      # Deploy Backend Functions
-      - job: Deploy_Functions
-        displayName: "Deploy Azure Functions"
-        dependsOn: Deploy_Infrastructure
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: node-azure
-        steps:
-          - template: templates/deploy-functions.yml
-            parameters:
-              environment: staging
-              azureSubscription: "az-pcpc-staging"
-              functionAppName: $(FUNCTION_APP_NAME)
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
-
-      # Deploy APIM APIs and Policies
-      - job: Deploy_APIM
-        displayName: "Deploy APIM APIs & Policies"
-        dependsOn:
-          - Deploy_Functions
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: terraform
-        steps:
-          - template: templates/deploy-apim.yml
-            parameters:
-              environment: staging
-              azureSubscription: "az-pcpc-staging"
-
-      # Phase 2.2 — Deploy Path C (ACA Container) to staging.
-      #
-      # Mirror of Deploy_Dev's Deploy_ACA job. Consumes the same canonical
-      # SHA-tagged image reference from the Build stage's Build_Container_Image
-      # job — one image build per pipeline run, all envs roll the same artifact.
-      # The infra stage above runs as `deployment:` against the `pcpc-staging`
-      # environment for the approval gate, which gates this job too via
-      # dependsOn.
-      - job: Deploy_ACA
-        displayName: "Deploy Path C (ACA Container)"
-        dependsOn: Deploy_Infrastructure
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        variables:
-          containerImageReference: $[ stageDependencies.Build.Build_Container_Image.outputs['discover_image.ContainerImageReference'] ]
-        steps:
-          - template: templates/deploy-aca.yml
-            parameters:
-              environment: staging
-              azureSubscription: "az-pcpc-staging"
-              containerAppName: "pcpc-aca-staging"
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
-              containerImageReference: $(containerImageReference)
-
-      # Run Smoke Tests
-      - job: Smoke_Tests
-        displayName: "Run Smoke Tests"
-        dependsOn:
-          - Deploy_Functions
-          - Deploy_APIM
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: node-azure
-        steps:
-          - template: templates/smoke-tests.yml
-            parameters:
-              environment: staging
-              azureSubscription: "az-pcpc-staging"
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
-              functionAppName: $(FUNCTION_APP_NAME)
-              apimName: $(APIM_NAME)
-
-  # ============================================================================
-  # STAGE 4: DEPLOY TO PRODUCTION
-  # Approval-gated deployment to production environment
-  # ============================================================================
-  - stage: Deploy_Prod
-    displayName: "Deploy to Production"
-    # See the matching note on Deploy_Staging — Build is listed alongside
-    # the upstream deploy stage so Deploy_ACA can read the cross-stage
-    # image-reference output variable.
-    dependsOn:
-      - Build
-      - Deploy_Staging
-    condition: succeeded()
-    variables:
-      - group: vg-pcpc-prod-config
-      - group: vg-pcpc-prod-secrets
-    jobs:
-      # Deploy Infrastructure
-      - deployment: Deploy_Infrastructure
-        displayName: "Deploy Infrastructure"
-        environment: pcpc-prod # Approval gate configured in Azure DevOps
-        pool:
-          vmImage: "ubuntu-latest"
-        container: terraform
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - template: templates/deploy-infra.yml
-                  parameters:
-                    environment: prod
-                    azureSubscription: "az-pcpc-prod"
-                    terraformVersion: "1.13.3"
-
-      # Deploy Backend Functions
-      - job: Deploy_Functions
-        displayName: "Deploy Azure Functions"
-        dependsOn: Deploy_Infrastructure
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: node-azure
-        steps:
-          - template: templates/deploy-functions.yml
-            parameters:
-              environment: prod
-              azureSubscription: "az-pcpc-prod"
-              functionAppName: $(FUNCTION_APP_NAME)
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
-
-      # Deploy APIM APIs and Policies
-      - job: Deploy_APIM
-        displayName: "Deploy APIM APIs & Policies"
-        dependsOn:
-          - Deploy_Functions
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: terraform
-        steps:
-          - template: templates/deploy-apim.yml
-            parameters:
-              environment: prod
-              azureSubscription: "az-pcpc-prod"
-
-      # Phase 2.2 — Deploy Path C (ACA Container) to prod.
-      #
-      # Mirror of Deploy_Dev / Deploy_Staging's Deploy_ACA job. Same SHA-tagged
-      # image reference from the Build stage as the other two envs. The infra
-      # stage above runs as `deployment:` against the `pcpc-prod` environment
-      # for the production approval gate, which gates this job too.
-      - job: Deploy_ACA
-        displayName: "Deploy Path C (ACA Container)"
-        dependsOn: Deploy_Infrastructure
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        variables:
-          containerImageReference: $[ stageDependencies.Build.Build_Container_Image.outputs['discover_image.ContainerImageReference'] ]
-        steps:
-          - template: templates/deploy-aca.yml
-            parameters:
-              environment: prod
-              azureSubscription: "az-pcpc-prod"
-              containerAppName: "pcpc-aca-prod"
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
-              containerImageReference: $(containerImageReference)
-
-      # Run Smoke Tests
-      - job: Smoke_Tests
-        displayName: "Run Smoke Tests"
-        dependsOn:
-          - Deploy_Functions
-          - Deploy_APIM
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: node-azure
-        steps:
-          - template: templates/smoke-tests.yml
-            parameters:
-              environment: prod
-              azureSubscription: "az-pcpc-prod"
-              resourceGroupName: $(APIM_RESOURCE_GROUP)
-              functionAppName: $(FUNCTION_APP_NAME)
-              apimName: $(APIM_NAME)
-
-      # Final Deployment Summary
-      - job: Deployment_Summary
-        displayName: "Deployment Summary"
-        dependsOn: Smoke_Tests
-        condition: succeeded()
-        pool:
-          vmImage: "ubuntu-latest"
-        container: node-azure
-        steps:
-          - checkout: none
-          - script: |
-              echo "=========================================="
-              echo "PRODUCTION DEPLOYMENT COMPLETE"
-              echo "=========================================="
-              echo ""
-              echo "Environment: Production"
-              echo "Build ID: $(Build.BuildId)"
-              echo "Build Number: $(Build.BuildNumber)"
-              echo "Source Branch: $(Build.SourceBranch)"
-              echo "Source Version: $(Build.SourceVersion)"
-              echo ""
-              echo "Deployed Components:"
-              echo "  ✓ Infrastructure (Terraform)"
-              echo "  ✓ Path B: Azure Functions Backend + APIM"
-              echo "  ✓ Path C: Container App (ACA)"
-              echo ""
-              echo "All smoke tests passed successfully."
-              echo "=========================================="
-            displayName: "Display Deployment Summary"
+  # STAGE 4: DEPLOY TO PRODUCTION — approval-gated via the pcpc-prod Environment.
+  - template: templates/deploy-stage.yml
+    parameters:
+      stageName: Deploy_Prod
+      displayName: "Deploy to Production"
+      environment: prod
+      azureSubscription: "az-pcpc-prod"
+      containerAppName: "pcpc-aca-prod"
+      requiresApproval: true
+      includeSummary: true
+      dependsOn:
+        - Build
+        - Deploy_Staging

--- a/pipelines/ado/templates/build-and-push-image.yml
+++ b/pipelines/ado/templates/build-and-push-image.yml
@@ -167,31 +167,17 @@ steps:
   # Bundle the Functions app with pnpm, then build the image FROM that folder.
   #
   # This job runs in parallel with (and independent of) the unified-artifact
-  # Build job, so it produces its own deploy folder from its checkout:
-  #   pnpm install → build → `pnpm deploy --prod` (flat/hoisted node_modules).
-  # The Dockerfile then just COPYs that self-contained folder — no npm/pnpm
-  # install or tsc inside Docker, and no `file:../shared` (devDep, type-only,
-  # omitted by --prod). The host has Node/npx (no `container:` on this job).
+  # Build job, so it produces its OWN deploy folder from its checkout. The
+  # Dockerfile then just COPYs that self-contained folder — no npm/pnpm install
+  # or tsc inside Docker, and no `file:../shared` (devDep, type-only, omitted by
+  # --prod). The host has Node/npx (no `container:` on this job). Shared recipe —
+  # see templates/steps/bundle-functions.yml.
   # ---------------------------------------------------------------------------
-  - script: |
-      set -euo pipefail
-
-      DEPLOY_DIR="$(Build.ArtifactStagingDirectory)/fn-image"
-      rm -rf "$DEPLOY_DIR"
-
-      npx --yes pnpm@10.32.1 install --frozen-lockfile
-      npx --yes pnpm@10.32.1 --filter pcpc-backend run build
-      # Lockfile-faithful deploy (copies from the frozen-installed store, no
-      # range re-resolution). See build.yml for the flag rationale.
-      npx --yes pnpm@10.32.1 --filter pcpc-backend deploy \
-        --prod --config.inject-workspace-packages=true --config.node-linker=hoisted "$DEPLOY_DIR"
-
-      test -f "$DEPLOY_DIR/dist/index.js"
-      test -d "$DEPLOY_DIR/node_modules"
-      echo "Deploy folder ready at $DEPLOY_DIR"
-    displayName: "Bundle Functions (pnpm deploy) for image"
-    workingDirectory: $(Build.SourcesDirectory)
-    condition: and(succeeded(), eq(variables['ShouldBuildImage'], 'true'))
+  - template: steps/bundle-functions.yml
+    parameters:
+      deployDir: "$(Build.ArtifactStagingDirectory)/fn-image"
+      workingDirectory: $(Build.SourcesDirectory)
+      condition: and(succeeded(), eq(variables['ShouldBuildImage'], 'true'))
 
   # Build the image locally (no push yet — we scan before push). Context is the
   # pnpm-deploy output. Absolute paths anchor on $(Build.SourcesDirectory) /

--- a/pipelines/ado/templates/build-ci-images.yml
+++ b/pipelines/ado/templates/build-ci-images.yml
@@ -139,9 +139,9 @@ jobs:
               ACR_SERVICE_CONNECTION: ${{ parameters.acrRegistryServiceConnection }}
             VARYAML
 
-      - task: PublishBuildArtifacts@1
+      - task: PublishPipelineArtifact@1
         displayName: "Publish image manifest and variables"
         inputs:
-          PathtoPublish: $(Build.ArtifactStagingDirectory)
-          ArtifactName: ci-image-digests
-          publishLocation: Container
+          targetPath: $(Build.ArtifactStagingDirectory)
+          artifact: ci-image-digests
+          publishLocation: pipeline

--- a/pipelines/ado/templates/build.yml
+++ b/pipelines/ado/templates/build.yml
@@ -151,11 +151,17 @@ jobs:
           echo "=========================================="
         displayName: "Display Artifact Summary"
 
-      # Publish unified artifact
-      - task: PublishBuildArtifacts@1
+      # Publish unified artifact.
+      #
+      # PublishPipelineArtifact (not the legacy PublishBuildArtifacts) — the
+      # latter registers every file with the build container one-by-one over
+      # REST ("Associating files"), which took ~21 min for this artifact's
+      # ~30k bundled node_modules files. Pipeline artifacts use a dedup store +
+      # manifest (no per-file association) and are Microsoft's recommended task.
+      - task: PublishPipelineArtifact@1
         displayName: "Publish Unified Artifact"
         inputs:
-          PathtoPublish: "$(Build.ArtifactStagingDirectory)/drop"
-          ArtifactName: "drop"
-          publishLocation: "Container"
+          targetPath: "$(Build.ArtifactStagingDirectory)/drop"
+          artifact: "drop"
+          publishLocation: "pipeline"
         condition: and(succeeded(), eq('${{ parameters.publishArtifact }}', 'true'))

--- a/pipelines/ado/templates/build.yml
+++ b/pipelines/ado/templates/build.yml
@@ -12,33 +12,6 @@ parameters:
   - name: publishArtifact
     type: boolean
     default: true
-  - name: azureSubscription
-    type: string
-    default: ""
-  - name: apimName
-    type: string
-    default: ""
-  - name: apimResourceGroup
-    type: string
-    default: ""
-  - name: apimSubscriptionName
-    type: string
-    default: "master"
-  - name: apimBaseUrl
-    type: string
-    default: ""
-  - name: apimBasePath
-    type: string
-    default: "pcpc-api"
-  - name: useApiManagement
-    type: string
-    default: "true"
-  - name: functionAppName
-    type: string
-    default: ""
-  - name: functionResourceGroup
-    type: string
-    default: ""
 
 jobs:
   - job: Build
@@ -47,34 +20,15 @@ jobs:
       vmImage: "ubuntu-latest"
     container: node-azure
     steps:
-      # Install root dependencies (for Jest testing framework).
-      # Root is a pnpm workspace (pnpm-lock.yaml); there is no root
-      # package-lock.json, so install via pnpm, matching Vercel and local dev.
-      - script: |
-          npx --yes pnpm@10.32.1 install --frozen-lockfile
-        displayName: "Install Root Dependencies"
-        workingDirectory: $(System.DefaultWorkingDirectory)
-
       # ============================================================================
-      # BACKEND BUILD
+      # BACKEND BUILD + BUNDLE
       # ============================================================================
 
-      # backend/functions is a pnpm-workspace member; its deps were installed by
-      # the root `pnpm install --frozen-lockfile` above. Build via the filter.
-      - script: |
-          npx --yes pnpm@10.32.1 --filter pcpc-backend run build
-        displayName: "Build Backend (TypeScript)"
-        workingDirectory: $(System.DefaultWorkingDirectory)
-
-      - script: |
-          if [ ! -d "dist" ]; then
-            echo "##vso[task.logissue type=error]Backend build failed - dist/ directory not found"
-            exit 1
-          fi
-          echo "Backend build verification passed"
-          ls -lah dist/
-        displayName: "Verify Backend Build"
-        workingDirectory: $(System.DefaultWorkingDirectory)/backend/functions
+      # Install + build + pnpm deploy --prod into drop/functions. Shared recipe
+      # with the ACA image build — see templates/steps/bundle-functions.yml.
+      - template: steps/bundle-functions.yml
+        parameters:
+          deployDir: "$(Build.ArtifactStagingDirectory)/drop/functions"
 
       # ============================================================================
       # CREATE UNIFIED ARTIFACT
@@ -83,37 +37,13 @@ jobs:
       - script: |
           echo "Creating unified artifact structure..."
 
-          # functions/ is produced by `pnpm deploy` below (it creates the dir);
-          # only pre-create the apim/ subtree here.
+          # functions/ was produced by the bundle step above; only pre-create
+          # the apim/ subtree here.
           mkdir -p $(Build.ArtifactStagingDirectory)/drop/apim
 
-          echo "Artifact structure created:"
+          echo "Artifact structure:"
           tree -L 2 $(Build.ArtifactStagingDirectory)/drop || ls -R $(Build.ArtifactStagingDirectory)/drop
         displayName: "Create Artifact Structure"
-
-      # Produce a self-contained, deployable functions/ folder via pnpm deploy:
-      # dist + host.json + package.json + a flat PRODUCTION node_modules.
-      # The SAME folder is consumed by the Function App deploy and the ACA image.
-      #   --prod                                  : omit devDeps (incl. type-only @pcpc/shared)
-      #   --config.inject-workspace-packages=true : pnpm 10's lockfile-FAITHFUL deploy — copies prod
-      #                                             deps from the store populated by the
-      #                                             `pnpm install --frozen-lockfile` above (pinned to
-      #                                             pnpm-lock.yaml). NOT `--legacy`, which re-resolves
-      #                                             version ranges and could drift from the lockfile.
-      #   --config.node-linker=hoisted            : flat node_modules (no .pnpm symlink farm) so the
-      #                                             Function App zip-deploy resolves modules reliably
-      - script: |
-          set -euo pipefail
-          npx --yes pnpm@10.32.1 --filter pcpc-backend deploy \
-            --prod --config.inject-workspace-packages=true --config.node-linker=hoisted \
-            "$(Build.ArtifactStagingDirectory)/drop/functions"
-
-          echo "Deployed functions/ contents:"
-          ls -lah "$(Build.ArtifactStagingDirectory)/drop/functions"
-          test -f "$(Build.ArtifactStagingDirectory)/drop/functions/dist/index.js"
-          test -d "$(Build.ArtifactStagingDirectory)/drop/functions/node_modules"
-        displayName: "Bundle Backend (pnpm deploy --prod)"
-        workingDirectory: $(System.DefaultWorkingDirectory)
 
       # Copy APIM configuration
       - task: CopyFiles@2

--- a/pipelines/ado/templates/deploy-apim.yml
+++ b/pipelines/ado/templates/deploy-apim.yml
@@ -7,9 +7,8 @@ parameters:
       - prod
   - name: azureSubscription
     type: string
-  - name: terraformVersion
-    type: string
-    default: "1.13.3"
+  # Terraform version is provided by the `terraform` CI container image, so no
+  # terraformVersion parameter is needed here.
 
 steps:
   - checkout: self

--- a/pipelines/ado/templates/deploy-functions.yml
+++ b/pipelines/ado/templates/deploy-functions.yml
@@ -18,14 +18,19 @@ parameters:
     default: true
 
 steps:
-  # Download unified artifact
-  - task: DownloadBuildArtifacts@1
+  # Download unified artifact.
+  #
+  # DownloadPipelineArtifact@2 (matches PublishPipelineArtifact in build.yml).
+  # Unlike the legacy DownloadBuildArtifacts (which nested contents under the
+  # artifact name), this task extracts contents directly to `path`, so we target
+  # $(System.ArtifactsDirectory)/<name> to preserve the existing
+  # .../<name>/functions layout every downstream step relies on.
+  - task: DownloadPipelineArtifact@2
     displayName: "Download Unified Artifact"
     inputs:
       buildType: "current"
-      downloadType: "single"
-      artifactName: "${{ parameters.artifactName }}"
-      downloadPath: "$(System.ArtifactsDirectory)"
+      artifact: "${{ parameters.artifactName }}"
+      path: "$(System.ArtifactsDirectory)/${{ parameters.artifactName }}"
 
   # Display artifact contents for verification
   - script: |

--- a/pipelines/ado/templates/deploy-infra.yml
+++ b/pipelines/ado/templates/deploy-infra.yml
@@ -10,9 +10,8 @@ parameters:
   - name: workingDirectory
     type: string
     default: "infra/envs"
-  - name: terraformVersion
-    type: string
-    default: "1.13.3"
+  # Terraform version is provided by the `terraform` CI container image, so no
+  # terraformVersion parameter is needed here.
 
 steps:
   - checkout: self

--- a/pipelines/ado/templates/deploy-stage.yml
+++ b/pipelines/ado/templates/deploy-stage.yml
@@ -1,0 +1,183 @@
+# Parameterized CD stage: deploys one environment
+# (Infra → Functions → APIM/ACA → Smoke). Used three times by
+# azure-pipelines.yml (dev/staging/prod) so the ~110-line stage body lives here
+# once instead of being copy-pasted per environment (audit findings D1/D2).
+#
+# Dev runs the infrastructure step as a plain job (auto-deploy, no gate);
+# staging/prod run it as a `deployment:` job against the pcpc-<env> Environment
+# so the approval check configured in Azure DevOps gates the whole stage. All
+# other jobs are identical across environments and differ only by parameter.
+
+parameters:
+  - name: stageName
+    type: string
+    # Stage id, e.g. Deploy_Dev. Kept explicit so existing stage ids/links are
+    # unchanged and downstream stages can reference them in dependsOn.
+  - name: displayName
+    type: string
+  - name: environment
+    type: string
+    values:
+      - dev
+      - staging
+      - prod
+  - name: azureSubscription
+    type: string
+  - name: containerAppName
+    type: string
+  - name: dependsOn
+    type: object
+    # Stage-level dependsOn list. Always include Build so the Deploy_ACA job can
+    # read the cross-stage Build_Container_Image output variable.
+  - name: requiresApproval
+    type: boolean
+    default: false
+    # true → run infra as a `deployment:` against pcpc-<env> (approval gate).
+  - name: includeSummary
+    type: boolean
+    default: false
+
+stages:
+  - stage: ${{ parameters.stageName }}
+    displayName: ${{ parameters.displayName }}
+    dependsOn: ${{ parameters.dependsOn }}
+    condition: succeeded()
+    variables:
+      - group: vg-pcpc-${{ parameters.environment }}-config
+      - group: vg-pcpc-${{ parameters.environment }}-secrets
+    jobs:
+      # --- Deploy Infrastructure -------------------------------------------
+      # Approval-gated envs run this as a `deployment:` against the pcpc-<env>
+      # Environment; dev runs it as a plain auto-deploy job.
+      - ${{ if eq(parameters.requiresApproval, true) }}:
+        - deployment: Deploy_Infrastructure
+          displayName: "Deploy Infrastructure"
+          environment: pcpc-${{ parameters.environment }} # Approval gate configured in Azure DevOps
+          pool:
+            vmImage: "ubuntu-latest"
+          container: terraform
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - template: deploy-infra.yml
+                    parameters:
+                      environment: ${{ parameters.environment }}
+                      azureSubscription: ${{ parameters.azureSubscription }}
+      - ${{ else }}:
+        - job: Deploy_Infrastructure
+          displayName: "Deploy Infrastructure"
+          pool:
+            vmImage: "ubuntu-latest"
+          container: terraform
+          steps:
+            - template: deploy-infra.yml
+              parameters:
+                environment: ${{ parameters.environment }}
+                azureSubscription: ${{ parameters.azureSubscription }}
+
+      # --- Deploy Backend Functions (Path B) -------------------------------
+      - job: Deploy_Functions
+        displayName: "Deploy Azure Functions"
+        dependsOn: Deploy_Infrastructure
+        condition: succeeded()
+        pool:
+          vmImage: "ubuntu-latest"
+        container: node-azure
+        steps:
+          - template: deploy-functions.yml
+            parameters:
+              environment: ${{ parameters.environment }}
+              azureSubscription: ${{ parameters.azureSubscription }}
+              functionAppName: $(FUNCTION_APP_NAME)
+              resourceGroupName: $(APIM_RESOURCE_GROUP)
+
+      # --- Deploy APIM APIs and Policies -----------------------------------
+      # dependsOn Deploy_Functions only; Functions already gates on
+      # Deploy_Infrastructure, so APIM still runs after infra. This normalizes
+      # the per-env dependsOn drift the copy-pasted stages had (D2).
+      - job: Deploy_APIM
+        displayName: "Deploy APIM APIs & Policies"
+        dependsOn:
+          - Deploy_Functions
+        condition: succeeded()
+        pool:
+          vmImage: "ubuntu-latest"
+        container: terraform
+        steps:
+          - template: deploy-apim.yml
+            parameters:
+              environment: ${{ parameters.environment }}
+              azureSubscription: ${{ parameters.azureSubscription }}
+
+      # --- Deploy Path C (ACA Container) -----------------------------------
+      # Consumes the canonical SHA-tagged image reference from the Build stage's
+      # Build_Container_Image job (cross-stage stageDependencies output) and
+      # rolls a new revision. dependsOn Deploy_Infrastructure so Terraform has
+      # provisioned the Container App first.
+      - job: Deploy_ACA
+        displayName: "Deploy Path C (ACA Container)"
+        dependsOn: Deploy_Infrastructure
+        condition: succeeded()
+        pool:
+          vmImage: "ubuntu-latest"
+        variables:
+          containerImageReference: $[ stageDependencies.Build.Build_Container_Image.outputs['discover_image.ContainerImageReference'] ]
+        steps:
+          - template: deploy-aca.yml
+            parameters:
+              environment: ${{ parameters.environment }}
+              azureSubscription: ${{ parameters.azureSubscription }}
+              containerAppName: ${{ parameters.containerAppName }}
+              resourceGroupName: $(APIM_RESOURCE_GROUP)
+              containerImageReference: $(containerImageReference)
+
+      # --- Smoke Tests -----------------------------------------------------
+      - job: Smoke_Tests
+        displayName: "Run Smoke Tests"
+        dependsOn:
+          - Deploy_Functions
+          - Deploy_APIM
+        condition: succeeded()
+        pool:
+          vmImage: "ubuntu-latest"
+        container: node-azure
+        steps:
+          - template: smoke-tests.yml
+            parameters:
+              environment: ${{ parameters.environment }}
+              azureSubscription: ${{ parameters.azureSubscription }}
+              resourceGroupName: $(APIM_RESOURCE_GROUP)
+              functionAppName: $(FUNCTION_APP_NAME)
+              apimName: $(APIM_NAME)
+
+      # --- Final Deployment Summary (opt-in; used by prod) -----------------
+      - ${{ if eq(parameters.includeSummary, true) }}:
+        - job: Deployment_Summary
+          displayName: "Deployment Summary"
+          dependsOn: Smoke_Tests
+          condition: succeeded()
+          pool:
+            vmImage: "ubuntu-latest"
+          container: node-azure
+          steps:
+            - checkout: none
+            - script: |
+                echo "=========================================="
+                echo "${{ upper(parameters.environment) }} DEPLOYMENT COMPLETE"
+                echo "=========================================="
+                echo ""
+                echo "Environment: ${{ parameters.displayName }}"
+                echo "Build ID: $(Build.BuildId)"
+                echo "Build Number: $(Build.BuildNumber)"
+                echo "Source Branch: $(Build.SourceBranch)"
+                echo "Source Version: $(Build.SourceVersion)"
+                echo ""
+                echo "Deployed Components:"
+                echo "  ✓ Infrastructure (Terraform)"
+                echo "  ✓ Path B: Azure Functions Backend + APIM"
+                echo "  ✓ Path C: Container App (ACA)"
+                echo ""
+                echo "All smoke tests passed successfully."
+                echo "=========================================="
+              displayName: "Display Deployment Summary"

--- a/pipelines/ado/templates/steps/bundle-functions.yml
+++ b/pipelines/ado/templates/steps/bundle-functions.yml
@@ -1,0 +1,55 @@
+# Shared step-template: produce a self-contained, deployable functions/ folder.
+#
+# Runs the lockfile-faithful pnpm pipeline used by BOTH the unified-artifact
+# build (build.yml) and the ACA container image build (build-and-push-image.yml),
+# so the recipe lives here once instead of being duplicated (audit finding D5):
+#   pnpm install --frozen-lockfile
+#   → pnpm --filter pcpc-backend run build
+#   → pnpm --filter pcpc-backend deploy --prod  (flat/hoisted node_modules)
+# The output folder is self-contained — dist/ + host.json + package.json + a flat
+# PRODUCTION node_modules — and feeds both the Function App zip-deploy and the
+# container image.
+#
+# Flag rationale:
+#   --prod                                  : omit devDeps (incl. type-only @pcpc/shared)
+#   --config.inject-workspace-packages=true : pnpm 10 lockfile-FAITHFUL deploy — copies prod
+#                                             deps from the frozen-installed store (pinned to
+#                                             pnpm-lock.yaml). NOT --legacy, which re-resolves
+#                                             version ranges and could drift from the lockfile.
+#   --config.node-linker=hoisted            : flat node_modules (no .pnpm symlink farm) so the
+#                                             zip-deploy and container both resolve modules reliably
+
+parameters:
+  - name: deployDir
+    type: string
+    # Absolute path the self-contained functions/ folder is written to.
+  - name: workingDirectory
+    type: string
+    default: "$(System.DefaultWorkingDirectory)"
+    # Repo root (where pnpm-workspace.yaml + pnpm-lock.yaml live).
+  - name: condition
+    type: string
+    default: "succeeded()"
+    # Allows callers to gate the bundle (e.g. the image build skips it when the
+    # target tag already exists in ACR).
+
+steps:
+  - script: |
+      set -euo pipefail
+
+      DEPLOY_DIR='${{ parameters.deployDir }}'
+      rm -rf "$DEPLOY_DIR"
+
+      npx --yes pnpm@$(pnpmVersion) install --frozen-lockfile
+      npx --yes pnpm@$(pnpmVersion) --filter pcpc-backend run build
+      npx --yes pnpm@$(pnpmVersion) --filter pcpc-backend deploy \
+        --prod --config.inject-workspace-packages=true --config.node-linker=hoisted "$DEPLOY_DIR"
+
+      echo "Deployed functions/ contents:"
+      ls -lah "$DEPLOY_DIR"
+      test -f "$DEPLOY_DIR/dist/index.js"
+      test -d "$DEPLOY_DIR/node_modules"
+      echo "✓ Bundled functions deploy folder ready at $DEPLOY_DIR"
+    displayName: "Bundle Functions (pnpm deploy --prod)"
+    workingDirectory: ${{ parameters.workingDirectory }}
+    condition: ${{ parameters.condition }}

--- a/pipelines/ado/templates/validate-backend.yml
+++ b/pipelines/ado/templates/validate-backend.yml
@@ -1,10 +1,6 @@
 # Backend Validation Template
 # Validates backend code quality, tests, and TypeScript compilation
-
-parameters:
-  - name: nodeVersion
-    type: string
-    default: "22.x"
+# Node.js version is governed by the node22 CI container image, not a parameter.
 
 jobs:
   - job: ValidateBackend
@@ -21,7 +17,7 @@ jobs:
       # Root is a pnpm workspace (pnpm-lock.yaml); there is no root
       # package-lock.json, so install via pnpm, matching Vercel and local dev.
       - script: |
-          npx --yes pnpm@10.32.1 install --frozen-lockfile
+          npx --yes pnpm@$(pnpmVersion) install --frozen-lockfile
         displayName: "Install Root Dependencies"
         workingDirectory: $(System.DefaultWorkingDirectory)
 
@@ -30,21 +26,21 @@ jobs:
 
       # Run ESLint (no-op until a lint script is added; non-blocking)
       - script: |
-          npx --yes pnpm@10.32.1 --filter pcpc-backend run lint || echo "⚠️  Lint skipped/with warnings (non-blocking)"
+          npx --yes pnpm@$(pnpmVersion) --filter pcpc-backend run lint || echo "⚠️  Lint skipped/with warnings (non-blocking)"
         displayName: "Lint Backend Code"
         workingDirectory: $(System.DefaultWorkingDirectory)
         continueOnError: true
 
       # TypeScript compilation check
       - script: |
-          npx --yes pnpm@10.32.1 --filter pcpc-backend exec tsc --noEmit
+          npx --yes pnpm@$(pnpmVersion) --filter pcpc-backend exec tsc --noEmit
         displayName: "TypeScript Compilation Check"
         workingDirectory: $(System.DefaultWorkingDirectory)
 
       # Run tests with coverage (invoke jest via pnpm exec; `pnpm test -- …`
       # would forward the `--` and jest would treat the flags as path patterns).
       - script: |
-          npx --yes pnpm@10.32.1 exec jest --config=jest.config.cjs --coverage --coverageDirectory=$(System.DefaultWorkingDirectory)/coverage/backend
+          npx --yes pnpm@$(pnpmVersion) exec jest --config=jest.config.cjs --coverage --coverageDirectory=$(System.DefaultWorkingDirectory)/coverage/backend
         displayName: "Run Backend Tests"
         workingDirectory: $(System.DefaultWorkingDirectory)
         env:
@@ -52,7 +48,7 @@ jobs:
 
       # Build backend
       - script: |
-          npx --yes pnpm@10.32.1 --filter pcpc-backend run build
+          npx --yes pnpm@$(pnpmVersion) --filter pcpc-backend run build
         displayName: "Build Backend"
         workingDirectory: $(System.DefaultWorkingDirectory)
 
@@ -73,7 +69,7 @@ jobs:
       # Security audit (non-blocking). One unified pnpm audit over the whole
       # workspace (production deps) now that backend/functions is a member.
       - script: |
-          npx --yes pnpm@10.32.1 audit --prod || echo "⚠️  Security vulnerabilities found (non-blocking)"
+          npx --yes pnpm@$(pnpmVersion) audit --prod || echo "⚠️  Security vulnerabilities found (non-blocking)"
         displayName: "Security Audit (pnpm audit)"
         workingDirectory: $(System.DefaultWorkingDirectory)
         continueOnError: true

--- a/pipelines/ado/templates/validate-infrastructure.yml
+++ b/pipelines/ado/templates/validate-infrastructure.yml
@@ -1,10 +1,6 @@
 # Infrastructure Validation Template
 # Validates Terraform configuration and infrastructure as code
-
-parameters:
-  - name: terraformVersion
-    type: string
-    default: "1.13.3"
+# Terraform/TFLint/Checkov versions are governed by the terraform CI image.
 
 jobs:
   - job: ValidateInfrastructure

--- a/pipelines/ado/variables/versions.yml
+++ b/pipelines/ado/variables/versions.yml
@@ -1,0 +1,16 @@
+# Centralized tool versions for CI/CD pipeline *scripts*.
+#
+# Scope: this file holds versions that pipeline scripts invoke directly (e.g.
+# `npx pnpm@$(pnpmVersion)`). Runtime/toolchain versions that are baked into the
+# CI container images are NOT defined here — their single source of truth is the
+# image Dockerfiles:
+#   - Terraform, TFLint, Checkov : .ci/images/terraform/Dockerfile
+#   - Node.js                    : .ci/images/node22 + node-azure Dockerfiles
+#   - Spectral CLI               : .ci/images/node22/Dockerfile
+# and the Function App runtime is governed by AzureFunctionApp@2 runtimeStack
+# (NODE|22) plus the function-app Terraform module (node_version = "~22").
+#
+# pnpmVersion mirrors the authoritative `packageManager` field in the root
+# package.json — keep the two in sync when bumping pnpm.
+variables:
+  pnpmVersion: "10.32.1"


### PR DESCRIPTION
Phase 3 (dedup/refactor) of the ADO pipeline audit. **Stacked on #237** — review/merge that first.

Structure-only; no behavioral change intended.

## Changes
- **D1/D2** — extract `templates/deploy-stage.yml`: one parameterized CD stage (Infra → Functions → APIM/ACA → Smoke) invoked 3× for dev/staging/prod. Dev stays a plain auto-deploy job; staging/prod run infra as a gated `deployment:` via a `requiresApproval` conditional; prod's summary is opt-in. APIM `dependsOn` normalized to `[Deploy_Functions]` across envs (removes per-env drift). **`azure-pipelines.yml`: 448 → 129 lines.**
- **D3** — remove the 9 dead params passed to `build.yml`.
- **D4** — centralize the pnpm version in `variables/versions.yml` (mirrors `package.json`); remove dead `terraformVersion`/`nodeVersion` params (real versions come from the CI images).
- **D5** — extract `templates/steps/bundle-functions.yml`: the shared pnpm install/build/`deploy --prod` recipe used by both the unified-artifact build and the ACA image build.

## ⚠️ Verification
YAML structure + template wiring validated locally for all 18 files, but **ADO templates can't be rendered here**. Please run an **Azure DevOps pipeline preview/dry-run** before merge to confirm the rendered stages match the originals — the `requiresApproval` deployment-vs-job conditional and `${{ if }}` insertions are the parts worth eyeballing. Stage IDs (`Deploy_Dev/Staging/Prod`) and approval gates are preserved, so no Environment/branch-policy reconfig should be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)