### PR TITLE
ci(image): waive CVE-2026-48506 (second base-image MessagePack CVE)

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -19,6 +19,8 @@ vulnerabilities:
       ExtensionBundle 4.36.0) still ships MessagePack 2.5.192. There is no
       actionable upstream fix to consume. Revisit when Microsoft updates
       MessagePack in the base image / ExtensionBundle.
+    paths:
+      - "FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/**/function.deps.json"
     expired_at: 2026-09-17
 
   - id: CVE-2026-48506
@@ -37,4 +39,6 @@ vulnerabilities:
       it yet: the current 4-node22 image still bundles ExtensionBundle 4.36.0
       with MessagePack 2.5.192. Remove this entry (and the one above) once a
       base image with ExtensionBundle >= 4.37.0 is published.
+    paths:
+      - "FuncExtensionBundles/Microsoft.Azure.Functions.ExtensionBundle/**/function.deps.json"
     expired_at: 2026-09-17

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -20,3 +20,21 @@ vulnerabilities:
       actionable upstream fix to consume. Revisit when Microsoft updates
       MessagePack in the base image / ExtensionBundle.
     expired_at: 2026-09-17
+
+  - id: CVE-2026-48506
+    statement: >-
+      Second CVE (published Jun 2026) against the SAME component as
+      CVE-2026-48109 above: MessagePack 2.5.192 (HIGH, fixed in 2.5.301 /
+      3.1.7) inside Microsoft's Azure Functions ExtensionBundle (.NET), baked
+      into the official base image mcr.microsoft.com/azure-functions/node:4-node22.
+      It is NOT a dependency of the PCPC Node.js function app or its
+      node_modules (Trivy's node-pkg scan is clean); the vulnerable path
+      (MessagePackReader.TrySkip unbounded recursion → stack-overflow DoS) is
+      only reachable via .NET extension deserialization of untrusted
+      MessagePack payloads, which our bindings don't do. Upstream fix exists —
+      ExtensionBundle 4.37.0 (released 2026-06-24) bumps MessagePack to
+      2.5.301 — but verified on 2026-07-09 that no published base image ships
+      it yet: the current 4-node22 image still bundles ExtensionBundle 4.36.0
+      with MessagePack 2.5.192. Remove this entry (and the one above) once a
+      base image with ExtensionBundle >= 4.37.0 is published.
+    expired_at: 2026-09-17


### PR DESCRIPTION
## What changed

Adds a second scoped, time-boxed entry to `.trivyignore.yaml` for **CVE-2026-48506**, which is blocking the CD pipeline's Trivy gate on the ACA image build.

## Why

NVD published a second MessagePack CVE in June 2026 — [CVE-2026-48506](https://avd.aquasec.com/nvd/cve-2026-48506), an uncatchable `StackOverflowException` via `MessagePackReader.TrySkip()` recursion. It affects the **same MessagePack 2.5.192** that's already waived for CVE-2026-48109 (#235): it ships inside Microsoft's Azure Functions ExtensionBundle (.NET), baked into the official `mcr.microsoft.com/azure-functions/node:4-node22` base image.

Same analysis as #235 holds:

- **Not our dependency** — Trivy's `node-pkg` scan of the app is clean (0 HIGH/CRITICAL); both findings are under `FuncExtensionBundles/.../function.deps.json` (dotnet-core)
- **Not reachable** — the vulnerable path requires .NET extension deserialization of untrusted MessagePack payloads, which our bindings don't do
- **No consumable upstream fix yet** — ExtensionBundle **4.37.0** (released 2026-06-24) does bump MessagePack to 2.5.301, but no published base image ships it. Verified 2026-07-09 by pulling and inspecting `4-node22`: still bundles ExtensionBundle 4.36.0 with MessagePack 2.5.192. (The `4.37.x-node22` tags on MCR are old *host*-4.37 images with bundle 4.21.0 — image tags track host version, not bundle version.)

## Time-box

`expired_at: 2026-09-17`, aligned with the existing CVE-2026-48109 entry so both get re-reviewed together. Since ExtensionBundle 4.37.0 already contains the fixed MessagePack, both entries should become removable as soon as Microsoft rolls it into the published base image — likely before the expiry.

## Reviewer notes

- After merge, re-run the failed CD run (or let the next main merge trigger it); the gate should pass with both CVEs suppressed
- Validated the YAML parses and both entries load

🤖 Generated with [Claude Code](https://claude.com/claude-code)